### PR TITLE
Make install script idempotent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,10 +6,11 @@ read INSTALL
 if [[ "$INSTALL" == "y" || "$INSTALL" == "Y" ]]; then
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
     echo "Installing dotfiles from $DIR ..."
-    cp -r $DIR/. $HOME
-    for ITEM in ${EXCLUDED[@]}; do
-        rm -rf $HOME/$ITEM
-    done
+    rsync -a --exclude='.git' "$DIR/" "$HOME/" \
+        --exclude='install.sh' \
+        --exclude='README.md' \
+        --exclude='.gitignore' \
+        --exclude='brew'
     source $HOME/.bashrc
     echo "dotfiles installed!"
 
@@ -18,19 +19,23 @@ if [[ "$INSTALL" == "y" || "$INSTALL" == "Y" ]]; then
     if [ -f "$EXTENSIONS_FILE" ]; then
         for CLI in code cursor; do
             if command -v $CLI &> /dev/null; then
-                INSTALLED=$($CLI --list-extensions 2>/dev/null)
-                SKIPPED=0
-                ADDED=0
+                INSTALLED=$($CLI --list-extensions 2>/dev/null | tr '[:upper:]' '[:lower:]')
+                MISSING=()
                 while IFS= read -r ext || [ -n "$ext" ]; do
                     [ -z "$ext" ] && continue
-                    if echo "$INSTALLED" | grep -qi "^${ext}$"; then
-                        SKIPPED=$((SKIPPED + 1))
-                    else
-                        $CLI --install-extension "$ext" --force 2>/dev/null
-                        ADDED=$((ADDED + 1))
+                    if ! echo "$INSTALLED" | grep -q "^$(echo "$ext" | tr '[:upper:]' '[:lower:]')$"; then
+                        MISSING+=("$ext")
                     fi
                 done < "$EXTENSIONS_FILE"
-                echo "$CLI extensions: $ADDED installed, $SKIPPED already present."
+
+                if [ ${#MISSING[@]} -eq 0 ]; then
+                    echo "$CLI extensions: all $(wc -l < "$EXTENSIONS_FILE" | tr -d ' ') already installed."
+                else
+                    for ext in "${MISSING[@]}"; do
+                        $CLI --install-extension "$ext" --force 2>/dev/null
+                    done
+                    echo "$CLI extensions: ${#MISSING[@]} installed."
+                fi
             else
                 echo "$CLI not found, skipping extension install."
             fi
@@ -53,7 +58,8 @@ if [[ "$INSTALL" == "y" || "$INSTALL" == "Y" ]]; then
             claude plugin marketplace add "$source" 2>/dev/null
         done < "$SOURCES_FILE"
 
-        # Install enabled plugins
+        # Install enabled plugins (skip already installed)
+        INSTALLED_PLUGINS=$(claude plugin list 2>/dev/null)
         python3 -c "
 import json
 with open('$SETTINGS_FILE') as f:
@@ -62,8 +68,13 @@ for k, v in d.get('enabledPlugins', {}).items():
     if v:
         print(k)
 " | while read -r plugin; do
-            echo "  Installing plugin: $plugin"
-            claude plugin install "$plugin" 2>/dev/null
+            PLUGIN_NAME=$(echo "$plugin" | cut -d'@' -f1)
+            if echo "$INSTALLED_PLUGINS" | grep -q "$PLUGIN_NAME"; then
+                echo "  Already installed: $plugin"
+            else
+                echo "  Installing plugin: $plugin"
+                claude plugin install "$plugin" 2>/dev/null
+            fi
         done
 
         echo "Claude Code plugins installed!"

--- a/install.sh
+++ b/install.sh
@@ -20,13 +20,17 @@ if [[ "$INSTALL" == "y" || "$INSTALL" == "Y" ]]; then
         for CLI in code cursor; do
             if command -v $CLI &> /dev/null; then
                 INSTALLED=$($CLI --list-extensions 2>/dev/null | tr '[:upper:]' '[:lower:]')
-                MISSING=()
+                declare -A exts_to_install
                 while IFS= read -r ext || [ -n "$ext" ]; do
                     [ -z "$ext" ] && continue
-                    if ! echo "$INSTALLED" | grep -q "^$(echo "$ext" | tr '[:upper:]' '[:lower:]')$"; then
-                        MISSING+=("$ext")
-                    fi
+                    exts_to_install["$(echo "$ext" | tr '[:upper:]' '[:lower:]')"]="$ext"
                 done < "$EXTENSIONS_FILE"
+
+                while IFS= read -r installed_ext; do
+                    unset 'exts_to_install[$installed_ext]'
+                done <<< "$INSTALLED"
+
+                MISSING=("${exts_to_install[@]}")
 
                 if [ ${#MISSING[@]} -eq 0 ]; then
                     echo "$CLI extensions: all $(wc -l < "$EXTENSIONS_FILE" | tr -d ' ') already installed."
@@ -69,7 +73,7 @@ for k, v in d.get('enabledPlugins', {}).items():
         print(k)
 " | while read -r plugin; do
             PLUGIN_NAME=$(echo "$plugin" | cut -d'@' -f1)
-            if echo "$INSTALLED_PLUGINS" | grep -q "$PLUGIN_NAME"; then
+            if echo "$INSTALLED_PLUGINS" | grep -xq "$PLUGIN_NAME"; then
                 echo "  Already installed: $plugin"
             else
                 echo "  Installing plugin: $plugin"

--- a/install.sh
+++ b/install.sh
@@ -6,11 +6,11 @@ read INSTALL
 if [[ "$INSTALL" == "y" || "$INSTALL" == "Y" ]]; then
     DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
     echo "Installing dotfiles from $DIR ..."
-    rsync -a --exclude='.git' "$DIR/" "$HOME/" \
-        --exclude='install.sh' \
-        --exclude='README.md' \
-        --exclude='.gitignore' \
-        --exclude='brew'
+    rsync_opts=('-a')
+    for item in "${EXCLUDED[@]}"; do
+        rsync_opts+=(--exclude="$item")
+    done
+    rsync "${rsync_opts[@]}" "$DIR/" "$HOME/"
     source $HOME/.bashrc
     echo "dotfiles installed!"
 
@@ -23,8 +23,9 @@ if [[ "$INSTALL" == "y" || "$INSTALL" == "Y" ]]; then
                 declare -A exts_to_install
                 while IFS= read -r ext || [ -n "$ext" ]; do
                     [ -z "$ext" ] && continue
-                    exts_to_install["$(echo "$ext" | tr '[:upper:]' '[:lower:]')"]="$ext"
+                    exts_to_install["${ext,,}"]="$ext"
                 done < "$EXTENSIONS_FILE"
+                total_exts=${#exts_to_install[@]}
 
                 while IFS= read -r installed_ext; do
                     unset 'exts_to_install[$installed_ext]'
@@ -33,7 +34,7 @@ if [[ "$INSTALL" == "y" || "$INSTALL" == "Y" ]]; then
                 MISSING=("${exts_to_install[@]}")
 
                 if [ ${#MISSING[@]} -eq 0 ]; then
-                    echo "$CLI extensions: all $(wc -l < "$EXTENSIONS_FILE" | tr -d ' ') already installed."
+                    echo "$CLI extensions: all $total_exts already installed."
                 else
                     for ext in "${MISSING[@]}"; do
                         $CLI --install-extension "$ext" --force 2>/dev/null
@@ -64,6 +65,9 @@ if [[ "$INSTALL" == "y" || "$INSTALL" == "Y" ]]; then
 
         # Install enabled plugins (skip already installed)
         INSTALLED_PLUGINS=$(claude plugin list 2>/dev/null)
+        declare -A installed_plugin_set
+        while IFS= read -r p; do [ -n "$p" ] && installed_plugin_set["$p"]=1; done <<< "$INSTALLED_PLUGINS"
+
         python3 -c "
 import json
 with open('$SETTINGS_FILE') as f:
@@ -72,8 +76,8 @@ for k, v in d.get('enabledPlugins', {}).items():
     if v:
         print(k)
 " | while read -r plugin; do
-            PLUGIN_NAME=$(echo "$plugin" | cut -d'@' -f1)
-            if echo "$INSTALLED_PLUGINS" | grep -xq "$PLUGIN_NAME"; then
+            PLUGIN_NAME=${plugin%@*}
+            if [[ -v installed_plugin_set["$PLUGIN_NAME"] ]]; then
                 echo "  Already installed: $plugin"
             else
                 echo "  Installing plugin: $plugin"
@@ -88,4 +92,3 @@ for k, v in d.get('enabledPlugins', {}).items():
 else
     echo "Unable to install dotfiles."
 fi
-


### PR DESCRIPTION
## Summary
- Replace `cp -r` with `rsync -a --exclude` to avoid permission errors on read only marketplace `.git` pack files
- Skip IDE extension install loop entirely when all extensions are already present
- Check `claude plugin list` before installing plugins, skip already installed ones

## Test plan
- [ ] Run `./install.sh` on a clean machine to verify full install works
- [ ] Run `./install.sh` a second time to verify idempotent behavior (no errors, skips existing)
- [ ] Verify marketplace `.git` pack file permission errors are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)