### PR TITLE
Add email-assist skill for Gmail inbox triage

### DIFF
--- a/.claude/plugins/blocklist.json
+++ b/.claude/plugins/blocklist.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-03-27T00:32:53.135Z",
+  "fetchedAt": "2026-03-27T01:57:39.522Z",
   "plugins": [
     {
       "plugin": "code-review@claude-plugins-official",

--- a/.claude/plugins/blocklist.json
+++ b/.claude/plugins/blocklist.json
@@ -1,5 +1,5 @@
 {
-  "fetchedAt": "2026-03-26T17:41:40.198Z",
+  "fetchedAt": "2026-03-27T00:32:53.135Z",
   "plugins": [
     {
       "plugin": "code-review@claude-plugins-official",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -151,6 +151,12 @@
         "source": "github",
         "repo": "anthropics/skills"
       }
+    },
+    "superpowers-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "obra/superpowers-marketplace"
+      }
     }
   },
   "outputStyle": "Concise",

--- a/.claude/skills/email-assist/SKILL.md
+++ b/.claude/skills/email-assist/SKILL.md
@@ -19,8 +19,10 @@ allowed-tools:
   - Write
   - AskUserQuestion
   - mcp__claude_ai_Google_Calendar__gcal_list_events
-  - mcp__gmail__send_email
   - mcp__gmail__draft_email
+  - mcp__gmail__download_attachment
+  - mcp__claude_ai_Linear__save_issue
+  - mcp__claude_ai_Linear__list_teams
   - WebFetch
 ---
 
@@ -53,7 +55,7 @@ For each email, classify using triage-rules.md. Key behaviors:
 
 **When in doubt, ask**: If there is any ambiguity about classification, or an email could take multiple labels, ask the user. Do not guess. Defaulting to asking is always correct.
 
-**Drafting replies**: Never send emails directly. Always create a draft, present it for review, and wait for explicit approval. Never reference people or sources the user does not know. Always read full email content (including attachments) before making assumptions about dates, expiration, or validity.
+**Drafting replies**: Never send emails directly. Always create a draft, present it for review, and wait for explicit approval to send. Never reference people or sources the user does not know. Always read full email content and download attachments when relevant (e.g. to check expiration dates, document details) before making assumptions.
 
 **Calendar awareness**: When someone proposes a date/time, check the calendar to see if it works. If it does, help draft an acceptance and offer to send an invite. If not, propose an alternative (prefer Fridays for in person meetings).
 

--- a/.claude/skills/email-assist/SKILL.md
+++ b/.claude/skills/email-assist/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: email-assist
+description: Triage Gmail inbox by labeling, starring, and archiving emails. Also consolidates legacy labels and creates filters. Use this skill whenever the user mentions email triage, inbox cleanup, email labels, email filters, or wants to process their inbox. Default subcommand is triage.
+argument-hint: "[triage | cleanup | filters]"
+allowed-tools:
+  - mcp__gmail__search_emails
+  - mcp__gmail__read_email
+  - mcp__gmail__modify_email
+  - mcp__gmail__batch_modify_emails
+  - mcp__gmail__list_email_labels
+  - mcp__gmail__get_or_create_label
+  - mcp__gmail__create_label
+  - mcp__gmail__delete_label
+  - mcp__gmail__create_filter
+  - mcp__gmail__create_filter_from_template
+  - mcp__gmail__list_filters
+  - Read
+  - Edit
+  - Write
+  - AskUserQuestion
+---
+
+# Email Assist
+
+Triage the Gmail inbox, clean up legacy labels, and create filters for recurring senders.
+
+## Before Every Invocation
+
+1. Read [learned-rules.md](learned-rules.md) for prior corrections
+2. Read [triage-rules.md](reference/triage-rules.md) and [label-map.md](reference/label-map.md) for classification rules
+3. Call `mcp__gmail__list_email_labels` once to resolve label name -> ID mapping
+
+## Mode: triage (default)
+
+Process inbox emails in batches of 50 via `mcp__gmail__search_emails` with query `in:inbox`.
+
+For each email, classify using triage-rules.md. Key behaviors:
+
+**Auto-process purchases**: Order confirmations, shipping notifications, receipts, delivery updates. Apply `📑 Admin/🛒 Purchases` label, remove `INBOX` and `UNREAD`. No confirmation needed. Use `mcp__gmail__batch_modify_emails` for efficiency.
+
+**Multi-label routing**: Emails can take multiple labels. An Anthropic receipt is both `📑 Admin/🛒 Purchases` and `🛠️ Craft/💻 Development`. Always route to the most specific sublabel, never a parent pillar alone.
+
+**Star assignment**: Apply colored stars via system label IDs.
+- `GREEN_STAR`: FYI, no response needed (newsletters, statements, notifications)
+- `YELLOW_STAR`: Needs action from me (direct emails, meeting requests, account alerts)
+- `RED_STAR`: Urgent or overdue (friends/business waiting on response, deadline language)
+
+**Family emails come first**: Always surface family emails for response. Read the full email content, provide an overview (dad likes to send articles), and offer to draft a warm reply. Label `🤝 Community/👨‍👩‍👦‍👦 Family`. Yellow or red star.
+
+**When in doubt, ask**: If there is any ambiguity about classification, or an email could take multiple labels, ask the user. Do not guess. Defaulting to asking is always correct.
+
+After processing:
+1. Present family emails first with content overview and reply offer
+2. Present remaining emails grouped by proposed action for confirmation
+3. When user corrects a classification, append the rule to `learned-rules.md`
+4. Identify senders appearing 3+ times, suggest creating filters
+5. Print summary: counts by action, new learned rules, filter suggestions
+
+## Mode: cleanup
+
+Merge legacy labels into proper pillar sublabels. Follow [label-map.md](reference/label-map.md) for known merge targets.
+
+For each label:
+1. Search the label to show contents
+2. Propose merge target (specific sublabel, not parent)
+3. User confirms or overrides
+4. `mcp__gmail__batch_modify_emails` to add new label, remove old
+5. `mcp__gmail__delete_label` to remove old label
+
+Never delete a label without user confirmation. Present all proposed merges as a table first.
+
+## Mode: filters
+
+Create Gmail server-side filters for high-frequency senders.
+
+Note: existing filters in the Gmail web UI are not readable via the MCP (scope limitation). The MCP can only create new filters.
+
+1. Analyze learned rules and recent triage to identify candidates
+2. Propose filters via `mcp__gmail__create_filter_from_template` (fromSender template)
+3. Default action: apply appropriate label, mark read, skip inbox
+4. User approves each filter before creation

--- a/.claude/skills/email-assist/SKILL.md
+++ b/.claude/skills/email-assist/SKILL.md
@@ -40,7 +40,7 @@ Process inbox emails in batches of 50 via `mcp__gmail__search_emails` with query
 
 For each email, classify using triage-rules.md. Key behaviors:
 
-**Auto-process purchases**: Order confirmations, shipping notifications, receipts, delivery updates. Apply `📑 Admin/🛒 Purchases` label, remove `INBOX` and `UNREAD`. No confirmation needed. Use `mcp__gmail__batch_modify_emails` for efficiency.
+**Auto-process purchases**: Order confirmations, shipping notifications, receipts, delivery updates. Apply `📑 Admin/🛒 Purchases` label, remove `INBOX` and `UNREAD`. Use `mcp__gmail__batch_modify_emails` for efficiency. Only auto-process when classification confidence is high (exact sender match in triage-rules.md or unambiguous subject pattern). If uncertain, include in the confirmation batch.
 
 **Multi-label routing**: Emails can take multiple labels. An Anthropic receipt is both `📑 Admin/🛒 Purchases` and `🛠️ Craft/💻 Development`. Always route to the most specific sublabel, never a parent pillar alone.
 
@@ -84,7 +84,10 @@ Create Gmail server-side filters for high-frequency senders.
 
 Note: existing filters in the Gmail web UI are not readable via the MCP (scope limitation). The MCP can only create new filters.
 
-1. Analyze learned rules and recent triage to identify candidates
-2. Propose filters via `mcp__gmail__create_filter_from_template` (fromSender template)
-3. Default action: apply appropriate label, mark read, skip inbox
-4. User approves each filter before creation
+1. Read `learned-rules.md` for any previously created filters (stored under `## Created Filters`)
+2. Analyze learned rules and recent triage to identify candidates
+3. Skip any sender that already has a filter recorded in learned-rules.md
+4. Propose filters via `mcp__gmail__create_filter_from_template` (fromSender template)
+5. Default action: apply appropriate label, mark read, skip inbox
+6. User approves each filter before creation
+7. After creating a filter, record it in `learned-rules.md` under `## Created Filters` to prevent duplicates

--- a/.claude/skills/email-assist/SKILL.md
+++ b/.claude/skills/email-assist/SKILL.md
@@ -18,6 +18,10 @@ allowed-tools:
   - Edit
   - Write
   - AskUserQuestion
+  - mcp__claude_ai_Google_Calendar__gcal_list_events
+  - mcp__gmail__send_email
+  - mcp__gmail__draft_email
+  - WebFetch
 ---
 
 # Email Assist
@@ -40,21 +44,26 @@ For each email, classify using triage-rules.md. Key behaviors:
 
 **Multi-label routing**: Emails can take multiple labels. An Anthropic receipt is both `📑 Admin/🛒 Purchases` and `🛠️ Craft/💻 Development`. Always route to the most specific sublabel, never a parent pillar alone.
 
-**Star assignment**: Apply colored stars via system label IDs.
-- `GREEN_STAR`: FYI, no response needed (newsletters, statements, notifications)
-- `YELLOW_STAR`: Needs action from me (direct emails, meeting requests, account alerts)
-- `RED_STAR`: Urgent or overdue (friends/business waiting on response, deadline language)
+**Star assignment**: Apply colored stars via system label IDs. Never star emails that get archived.
+- `GREEN_STAR`: Needs action but NOT a response (download a document, review something)
+- `YELLOW_STAR`: Needs a response from me
+- `RED_STAR`: Urgent or overdue response needed
 
-**Family emails come first**: Always surface family emails for response. Read the full email content, provide an overview (dad likes to send articles), and offer to draft a warm reply. Label `🤝 Community/👨‍👩‍👦‍👦 Family`. Yellow or red star.
+**Family emails come first**: Always surface family emails for response. Read the full email content. When they share articles, fetch and summarize the article so the user can review before replying. Offer to draft a reply. Label `🤝 Community/👨‍👩‍👦‍👦 Family`. Yellow or red star. Family emails get no sign off (no "Cheers and chat soon!").
 
 **When in doubt, ask**: If there is any ambiguity about classification, or an email could take multiple labels, ask the user. Do not guess. Defaulting to asking is always correct.
+
+**Drafting replies**: Never send emails directly. Always create a draft, present it for review, and wait for explicit approval. Never reference people or sources the user does not know. Always read full email content (including attachments) before making assumptions about dates, expiration, or validity.
+
+**Calendar awareness**: When someone proposes a date/time, check the calendar to see if it works. If it does, help draft an acceptance and offer to send an invite. If not, propose an alternative (prefer Fridays for in person meetings).
 
 After processing:
 1. Present family emails first with content overview and reply offer
 2. Present remaining emails grouped by proposed action for confirmation
 3. When user corrects a classification, append the rule to `learned-rules.md`
 4. Identify senders appearing 3+ times, suggest creating filters
-5. Print summary: counts by action, new learned rules, filter suggestions
+5. **Urgent digest**: List all RED_STAR emails remaining in inbox with subject, sender, age, and what action is needed. This is the "respond to these" list.
+6. Print summary: counts by action, new learned rules, filter suggestions
 
 ## Mode: cleanup
 

--- a/.claude/skills/email-assist/learned-rules.md
+++ b/.claude/skills/email-assist/learned-rules.md
@@ -9,3 +9,5 @@ Rules added from triage corrections. Read on every invocation. These override de
 ## Behavior Rules
 
 ## Domain Rules
+
+## Created Filters

--- a/.claude/skills/email-assist/learned-rules.md
+++ b/.claude/skills/email-assist/learned-rules.md
@@ -1,0 +1,11 @@
+# Learned Rules
+
+Rules added from triage corrections. Read on every invocation. These override default rules in reference/triage-rules.md.
+
+## Sender Rules
+
+## Subject Rules
+
+## Behavior Rules
+
+## Domain Rules

--- a/.claude/skills/email-assist/reference/label-map.md
+++ b/.claude/skills/email-assist/reference/label-map.md
@@ -19,6 +19,7 @@ Always route to the most specific sublabel. Never label with just a parent pilla
 - `🍏 Constitution/💰 Financial/📜 Trust` -- trust, estate planning
 - `🍏 Constitution/💪 Athlete` -- gym, fitness, running, climbing, training
 - `🍏 Constitution/🏥 Healthcare` -- medical, dental, vision, health insurance
+- `🍏 Constitution/🪪 Insurance` -- auto insurance, home insurance, renters insurance (NOT health insurance)
 - `🍏 Constitution/🥕 Nutrition` -- supplements, diet, meal planning
 - `🍏 Constitution/🧖 Personal Care` -- grooming, skincare
 - `🍏 Constitution/🍾 Sobriety` -- sobriety related
@@ -44,6 +45,7 @@ Always route to the most specific sublabel. Never label with just a parent pilla
 - `🤝 Community/🇮🇹 Italiano` -- Italian language learning
 - `🤝 Community/🤲 Giving` -- charity, volunteering, donations
 - `🤝 Community/⚓ Seattle` -- Seattle contacts and community
+- `🤝 Community/🌇 Los Angeles` -- LA contacts and community
 
 ### Craft (🛠️)
 - `🛠️ Craft` (parent)
@@ -84,7 +86,7 @@ These labels predate the pillar system. Use `cleanup` mode to merge them.
 | Design | 🛠️ Craft/💻 Development | 2014-2019 design work |
 | Tahoe | 🛠️ Craft/🌏 Adventure | 2020 trip planning |
 | Boxing | 🍏 Constitution/💪 Athlete | 2020 gym |
-| Kickstarter | 🛠️ Craft | Various projects |
+| Kickstarter | 📑 Admin/🛒 Purchases | Various projects |
 | Craigslist | 📑 Admin/🛒 Purchases | Marketplace transactions |
 | Amazon | 📑 Admin/🛒 Purchases | Prime, orders |
 | Paypal | 📑 Admin/🛒 Purchases | Payment receipts |
@@ -92,16 +94,16 @@ These labels predate the pillar system. Use `cleanup` mode to merge them.
 | The Great Migration | Review | 2021 relocation docs |
 | Conferences | 🛠️ Craft/💼 Vocation/🕸 Networking | 2019 conference |
 | Burning Man | 🛠️ Craft/🌏 Adventure | 2017 event |
-| Los Angeles | 🤝 Community | 2023 LA events |
+| Los Angeles | 🤝 Community/🌇 Los Angeles | 2023 LA events (create new sublabel) |
 | Press | 🛠️ Craft/💼 Vocation | 2023 interviews |
-| San Francisco | 🤝 Community | 2025 SF events |
+| San Francisco | 🤝 Community | SF events |
 | Documents | 📑 Admin | Library scans |
 | Phi Psi | 🤝 Community/🤗 Friends | Fraternity |
 | 🎮 GameFlo | 🛠️ Craft/🎨 Leisure | Gaming newsletters |
 | 🎒 Gear | 🛠️ Craft/🌲 Outdoorsman | Outdoor gear |
 | ⚖️ Legal | 📑 Admin | Legal correspondence |
-| 🪪 Insurance | 🍏 Constitution/🏥 Healthcare | GEICO, auto |
+| 🪪 Insurance | 🍏 Constitution/🪪 Insurance | GEICO, auto insurance |
 | 🧾 Bills | 🍏 Constitution/💰 Financial | Utility statements |
 | 🚌 Transportation | 📑 Admin | Parking, transit |
 | 🌉 San Francisco | 🤝 Community | SF events |
-| [Imap]/Trash | Delete | Truly empty |
+| [Imap]/Trash | Delete label only | Truly empty, no emails to move. Delete the label itself with user confirmation. |

--- a/.claude/skills/email-assist/reference/label-map.md
+++ b/.claude/skills/email-assist/reference/label-map.md
@@ -46,6 +46,7 @@ Always route to the most specific sublabel. Never label with just a parent pilla
 - `🤝 Community/🤲 Giving` -- charity, volunteering, donations
 - `🤝 Community/⚓ Seattle` -- Seattle contacts and community
 - `🤝 Community/🌇 Los Angeles` -- LA contacts and community
+- `🤝 Community/🌉 San Francisco` -- SF contacts and community
 
 ### Craft (🛠️)
 - `🛠️ Craft` (parent)
@@ -96,7 +97,7 @@ These labels predate the pillar system. Use `cleanup` mode to merge them.
 | Burning Man | 🛠️ Craft/🌏 Adventure | 2017 event |
 | Los Angeles | 🤝 Community/🌇 Los Angeles | 2023 LA events (create new sublabel) |
 | Press | 🛠️ Craft/💼 Vocation | 2023 interviews |
-| San Francisco | 🤝 Community | SF events |
+| San Francisco | 🤝 Community/🌉 San Francisco | SF events (merge into same sublabel as 🌉 San Francisco) |
 | Documents | 📑 Admin | Library scans |
 | Phi Psi | 🤝 Community/🤗 Friends | Fraternity |
 | 🎮 GameFlo | 🛠️ Craft/🎨 Leisure | Gaming newsletters |
@@ -105,5 +106,5 @@ These labels predate the pillar system. Use `cleanup` mode to merge them.
 | 🪪 Insurance | 🍏 Constitution/🪪 Insurance | GEICO, auto insurance |
 | 🧾 Bills | 🍏 Constitution/💰 Financial | Utility statements |
 | 🚌 Transportation | 📑 Admin | Parking, transit |
-| 🌉 San Francisco | 🤝 Community | SF events |
+| 🌉 San Francisco | 🤝 Community/🌉 San Francisco | SF events (create new sublabel, distinct from plain "San Francisco") |
 | [Imap]/Trash | Delete label only | Truly empty, no emails to move. Delete the label itself with user confirmation. |

--- a/.claude/skills/email-assist/reference/label-map.md
+++ b/.claude/skills/email-assist/reference/label-map.md
@@ -1,0 +1,107 @@
+# Label Map
+
+Full label taxonomy for routing emails. Label IDs are resolved at runtime via `list_email_labels`.
+
+Always route to the most specific sublabel. Never label with just a parent pillar when a sublabel fits.
+
+## Active Label Hierarchy
+
+### Admin (📑)
+- `📑 Admin` (parent)
+- `📑 Admin/🛒 Purchases` -- order confirmations, receipts, shipping, delivery
+- `📑 Admin/🏷 Offers` -- deals, coupons, promotional offers
+- `📑 Admin/🏛️ Government` -- government correspondence, DMV, city forms
+
+### Constitution (🍏)
+- `🍏 Constitution` (parent)
+- `🍏 Constitution/💰 Financial` -- banking, investments, financial planning
+- `🍏 Constitution/💰 Financial/💸 Taxes` -- tax documents, W2s, returns
+- `🍏 Constitution/💰 Financial/📜 Trust` -- trust, estate planning
+- `🍏 Constitution/💪 Athlete` -- gym, fitness, running, climbing, training
+- `🍏 Constitution/🏥 Healthcare` -- medical, dental, vision, health insurance
+- `🍏 Constitution/🥕 Nutrition` -- supplements, diet, meal planning
+- `🍏 Constitution/🧖 Personal Care` -- grooming, skincare
+- `🍏 Constitution/🍾 Sobriety` -- sobriety related
+- `🍏 Constitution/🛌 Recovery` -- twelve step, meetings, sponsorship
+
+### Contemplation (🧠)
+- `🧠 Contemplation` (parent)
+- `🧠 Contemplation/📖 Reading` -- books, reading lists, Kindle, Audible
+- `🧠 Contemplation/🍿 Entertainment` -- streaming, TV, movies, music, podcasts
+- `🧠 Contemplation/🛋️ Therapy` -- therapy, counseling
+- `🧠 Contemplation/👨‍🎓 Education` -- courses, MOOCs, certifications, learning
+
+### Community (🤝)
+- `🤝 Community` (parent)
+- `🤝 Community/😘 Jasmine` -- Jasmine
+- `🤝 Community/🤗 Friends` -- personal friends
+- `🤝 Community/👨‍👩‍👦‍👦 Family` -- family members (always surface for response)
+- `🤝 Community/🏛 Brown` -- Brown University
+- `🤝 Community/🏛 Brown/Interviews` -- Brown alumni interviews
+- `🤝 Community/📚 Book Club` -- book club
+- `🤝 Community/🌱 SCF` -- SCF
+- `🤝 Community/🌇 Denver` -- Denver community, local events
+- `🤝 Community/🇮🇹 Italiano` -- Italian language learning
+- `🤝 Community/🤲 Giving` -- charity, volunteering, donations
+- `🤝 Community/⚓ Seattle` -- Seattle contacts and community
+
+### Craft (🛠️)
+- `🛠️ Craft` (parent)
+- `🛠️ Craft/💼 Vocation` -- job search, career
+- `🛠️ Craft/💼 Vocation/0️⃣ Zero` -- Zero Homes
+- `🛠️ Craft/💼 Vocation/😈 Gremlin` -- Gremlin
+- `🛠️ Craft/💼 Vocation/🏬 Salesforce` -- Salesforce
+- `🛠️ Craft/💼 Vocation/🚯 QuitCarbon` -- QuitCarbon
+- `🛠️ Craft/💼 Vocation/👨‍🏫 Mentorship` -- mentorship
+- `🛠️ Craft/💼 Vocation/🕸 Networking` -- networking, intros, conferences
+- `🛠️ Craft/💻 Development` -- software, dev tools, GitHub, tech subscriptions
+- `🛠️ Craft/💻 RYLLC` -- Reliably Yours LLC consulting
+- `🛠️ Craft/💻 RYLLC/🎯 Atelic` -- Atelic project
+- `🛠️ Craft/💻 TPF` -- The Product Forge, Titus
+- `🛠️ Craft/🌏 Adventure` -- travel, trips, flights, hotels
+- `🛠️ Craft/🌏 Adventure/🇦🇺 Australia` -- Australia
+- `🛠️ Craft/🌏 Adventure/🇦🇺 Australia/🦘 Tassie` -- Tasmania
+- `🛠️ Craft/🌏 Adventure/🚙 Vehicles` -- vehicles, auto
+- `🛠️ Craft/🌦️ Climate` -- climate tech
+- `🛠️ Craft/🎨 Leisure` -- leisure, hobbies
+- `🛠️ Craft/🎨 Leisure/📸 Photography` -- photography
+- `🛠️ Craft/🌲 Outdoorsman` -- outdoor gear, REI, backcountry
+
+## Legacy Labels (cleanup targets)
+
+These labels predate the pillar system. Use `cleanup` mode to merge them.
+
+| Legacy Label | Merge Target | Notes |
+|---|---|---|
+| People/Connor Foody | 🤝 Community/⚓ Seattle | User confirmed |
+| People/Clare Vivarelli | Review and route | Australia era contact |
+| People/Brad Phillipi | 🤝 Community/🤗 Friends | |
+| Animation | 🛠️ Craft/🎨 Leisure | 2011-2012 content |
+| Courses | 🧠 Contemplation/👨‍🎓 Education | Brown 2010 courses |
+| Jobs | 🛠️ Craft/💼 Vocation | 2016 job search |
+| Registration | 📑 Admin | Old signups |
+| Art | 🛠️ Craft/🎨 Leisure | 2019 art events |
+| Design | 🛠️ Craft/💻 Development | 2014-2019 design work |
+| Tahoe | 🛠️ Craft/🌏 Adventure | 2020 trip planning |
+| Boxing | 🍏 Constitution/💪 Athlete | 2020 gym |
+| Kickstarter | 🛠️ Craft | Various projects |
+| Craigslist | 📑 Admin/🛒 Purchases | Marketplace transactions |
+| Amazon | 📑 Admin/🛒 Purchases | Prime, orders |
+| Paypal | 📑 Admin/🛒 Purchases | Payment receipts |
+| Inspiration | 🧠 Contemplation | General inspiration |
+| The Great Migration | Review | 2021 relocation docs |
+| Conferences | 🛠️ Craft/💼 Vocation/🕸 Networking | 2019 conference |
+| Burning Man | 🛠️ Craft/🌏 Adventure | 2017 event |
+| Los Angeles | 🤝 Community | 2023 LA events |
+| Press | 🛠️ Craft/💼 Vocation | 2023 interviews |
+| San Francisco | 🤝 Community | 2025 SF events |
+| Documents | 📑 Admin | Library scans |
+| Phi Psi | 🤝 Community/🤗 Friends | Fraternity |
+| 🎮 GameFlo | 🛠️ Craft/🎨 Leisure | Gaming newsletters |
+| 🎒 Gear | 🛠️ Craft/🌲 Outdoorsman | Outdoor gear |
+| ⚖️ Legal | 📑 Admin | Legal correspondence |
+| 🪪 Insurance | 🍏 Constitution/🏥 Healthcare | GEICO, auto |
+| 🧾 Bills | 🍏 Constitution/💰 Financial | Utility statements |
+| 🚌 Transportation | 📑 Admin | Parking, transit |
+| 🌉 San Francisco | 🤝 Community | SF events |
+| [Imap]/Trash | Delete | Truly empty |

--- a/.claude/skills/email-assist/reference/triage-rules.md
+++ b/.claude/skills/email-assist/reference/triage-rules.md
@@ -88,7 +88,7 @@ Use these to determine pillar sublabel assignment. Always prefer the most specif
 
 **Known sender routing** (exact matches, highest priority):
 - `samwieds@gmail.com` -> `🤝 Community/🤗 Friends` (Sam Wiedemeier; adventure/outdoor content may also get `🛠️ Craft/🌏 Adventure`)
-- `mealplanner@richroll.com` -> `🍏 Constitution/🥕 Nutrition`, archive. Also create a Linear ticket in the Atelic workspace with a link to the email.
+- `mealplanner@richroll.com` -> `🍏 Constitution/🥕 Nutrition`, archive + Linear ticket in Atelic
 - `gifts@childhelp.org` -> `🤝 Community/🤲 Giving` (donation receipts, archive)
 - `do_not_reply@geico.com` -> `🍏 Constitution/🪪 Insurance` (NOT Healthcare; GEICO is auto insurance)
 - `kettlesarah@gmail.com` -> `🛠️ Craft/💻 TPF` (Sarah Kettles, TPF associate)

--- a/.claude/skills/email-assist/reference/triage-rules.md
+++ b/.claude/skills/email-assist/reference/triage-rules.md
@@ -88,13 +88,13 @@ Use these to determine pillar sublabel assignment. Always prefer the most specif
 
 **Known sender routing** (exact matches, highest priority):
 - `samwieds@gmail.com` -> `🤝 Community/🤗 Friends` (Sam Wiedemeier; adventure/outdoor content may also get `🛠️ Craft/🌏 Adventure`)
-- `mealplanner@richroll.com` -> `🍏 Constitution/🥕 Nutrition`, archive (TODO: also create Linear ticket in Atelic workspace)
+- `mealplanner@richroll.com` -> `🍏 Constitution/🥕 Nutrition`, archive. Also create a Linear ticket in the Atelic workspace with a link to the email.
 - `gifts@childhelp.org` -> `🤝 Community/🤲 Giving` (donation receipts, archive)
-- `do_not_reply@geico.com` -> `🪪 Insurance` (NOT Healthcare; GEICO is auto insurance)
+- `do_not_reply@geico.com` -> `🍏 Constitution/🪪 Insurance` (NOT Healthcare; GEICO is auto insurance)
 - `kettlesarah@gmail.com` -> `🛠️ Craft/💻 TPF` (Sarah Kettles, TPF associate)
 
 **Constitution signals:**
-- Auto insurance (GEICO) -> `🪪 Insurance`
+- Auto insurance (GEICO) -> `🍏 Constitution/🪪 Insurance`
 - Health insurance, medical -> `🍏 Constitution/🏥 Healthcare`
 - Financial, banking, investment -> `🍏 Constitution/💰 Financial`
 - Tax documents -> `🍏 Constitution/💰 Financial/💸 Taxes`

--- a/.claude/skills/email-assist/reference/triage-rules.md
+++ b/.claude/skills/email-assist/reference/triage-rules.md
@@ -1,0 +1,144 @@
+# Triage Rules
+
+Classification rules for inbox email triage. Read learned-rules.md first; those override anything here.
+
+## Purchase Detection
+
+Auto-process (label, mark read, archive) when ANY of these match:
+
+**Sender patterns** (case insensitive):
+- `*@amazon.com`, `*@amazon.co.*`
+- `*@shopify.com`, `*@myshopify.com`
+- `*@paypal.com`, `*@paypal.co.*`
+- `*@stripe.com`
+- `*@square.com`, `*@squareup.com`
+- `*@apple.com` with receipt/order in subject
+- `noreply@*` with order/shipping/delivery in subject
+- `*@ups.com`, `*@fedex.com`, `*@usps.com`, `*@dhl.com`
+
+**Subject patterns** (case insensitive, any of):
+- "order confirmation", "order shipped", "order delivered"
+- "shipping confirmation", "shipping notification", "tracking number"
+- "your receipt", "payment receipt", "invoice"
+- "out for delivery", "delivery notification"
+- "your order has", "thank you for your order"
+
+**Known purchase senders** (from inbox research):
+- `noreply@olo.com` (Illegal Pete's orders)
+- `care@sijohome.com` (Sijo orders/shipping)
+- `info@info.quince.com` (Quince orders/shipping)
+- `webmaster@groomsgrotto.com` (The Grotto menswear)
+- Cozy Earth
+- Any Shopify-powered store (check headers)
+
+**Multi-label purchases** (get Purchases + a second label):
+- `invoice+statements@mail.anthropic.com` -> also `🛠️ Craft/💻 Development` (Anthropic receipts)
+- `noreply@singenuity.com` -> also `🛠️ Craft/🌏 Adventure` (Cajun Encounters, tour bookings)
+- Tech tools/dev subscriptions -> also `🛠️ Craft/💻 Development`
+
+Target: `📑 Admin/🛒 Purchases`. Always mark read and archive.
+
+## Star Rules
+
+**Core behavior:**
+- Never star emails that get archived. Stars mean action is needed.
+- Always mark emails as read when archiving. Remove both INBOX and UNREAD together.
+
+### GREEN_STAR (needs action, but NOT a response)
+- Download a document, review something, FYI with a to-do
+- Tax documents needing download (W-2s, forms)
+- Financial statements and account summaries
+- Insurance claims needing review
+- Newsletters worth reading (substack.com, mailchimp, convertkit, beehiiv)
+- Subscription renewal confirmations
+
+### YELLOW_STAR (needs a response from me)
+- Direct emails from known contacts (not automated/noreply)
+- Emails with explicit questions requiring response
+- Meeting requests and calendar invitations needing RSVP
+- Account security alerts (password reset, 2FA, suspicious activity)
+- Forms, surveys, or document signing requests
+- Deadlines mentioned in subject or body
+
+### RED_STAR (urgent or overdue response needed)
+- Any email needing a response that is >7 days old, regardless of relationship (only if there is actually something to respond to; photo-only or empty-body emails do not count)
+- Emails from close friends or family (see Family Rules below)
+- Business emails with "urgent", "ASAP", "deadline", "action required"
+- Payment due notices, overdue notices
+- Emails from active business engagements (Zero, RYLLC clients)
+
+## Family Rules
+
+Family emails always get surfaced for response, regardless of content.
+
+**Known family senders:**
+- `mfornaciari2000@yahoo.com` Michael Fornaciari (dad): Likes to send articles and links. Read the full content, summarize the article/topic, offer to draft a warm, appreciative reply.
+- Any sender in `🤝 Community/👨‍👩‍👦‍👦 Family` label history
+
+**Handling:**
+1. Label `🤝 Community/👨‍👩‍👦‍👦 Family`
+2. Yellow or red star (red if >3 days old)
+3. Read full email content
+4. Present overview to user
+5. Offer to draft reply
+
+## Routing Signals
+
+Use these to determine pillar sublabel assignment. Always prefer the most specific sublabel.
+
+**Known sender routing** (exact matches, highest priority):
+- `samwieds@gmail.com` -> `🤝 Community/🤗 Friends` (Sam Wiedemeier; adventure/outdoor content may also get `🛠️ Craft/🌏 Adventure`)
+- `mealplanner@richroll.com` -> `🍏 Constitution/🥕 Nutrition`, archive (TODO: also create Linear ticket in Atelic workspace)
+- `gifts@childhelp.org` -> `🤝 Community/🤲 Giving` (donation receipts, archive)
+- `do_not_reply@geico.com` -> `🪪 Insurance` (NOT Healthcare; GEICO is auto insurance)
+- `kettlesarah@gmail.com` -> `🛠️ Craft/💻 TPF` (Sarah Kettles, TPF associate)
+
+**Constitution signals:**
+- Auto insurance (GEICO) -> `🪪 Insurance`
+- Health insurance, medical -> `🍏 Constitution/🏥 Healthcare`
+- Financial, banking, investment -> `🍏 Constitution/💰 Financial`
+- Tax documents -> `🍏 Constitution/💰 Financial/💸 Taxes`
+- Trust/estate -> `🍏 Constitution/💰 Financial/📜 Trust`
+- Gym, fitness, running, climbing -> `🍏 Constitution/💪 Athlete`
+- Supplements, diet -> `🍏 Constitution/🥕 Nutrition`
+- Grooming, skincare -> `🍏 Constitution/🧖 Personal Care`
+- Recovery, AA, meetings -> `🍏 Constitution/🍾 Sobriety` or `🍏 Constitution/🛌 Recovery`
+
+**Contemplation signals:**
+- Books, reading lists, Kindle -> `🧠 Contemplation/📖 Reading`
+- Streaming, TV, movies, music -> `🧠 Contemplation/🍿 Entertainment`
+- Therapy, counseling -> `🧠 Contemplation/🛋️ Therapy`
+- Courses, education, learning -> `🧠 Contemplation/👨‍🎓 Education`
+
+**Community signals:**
+- Jasmine -> `🤝 Community/😘 Jasmine`
+- Family members -> `🤝 Community/👨‍👩‍👦‍👦 Family`
+- Friends (personal social) -> `🤝 Community/🤗 Friends`
+- Brown University -> `🤝 Community/🏛 Brown`
+- Book club -> `🤝 Community/📚 Book Club`
+- SCF -> `🤝 Community/🌱 SCF`
+- Denver events/community -> `🤝 Community/🌇 Denver`
+- Italian language -> `🤝 Community/🇮🇹 Italiano`
+- Charity, volunteering -> `🤝 Community/🤲 Giving`
+- Seattle contacts -> `🤝 Community/⚓ Seattle`
+
+**Craft signals:**
+- Job search, recruiting, career -> `🛠️ Craft/💼 Vocation`
+- Zero Homes -> `🛠️ Craft/💼 Vocation/0️⃣ Zero`
+- Gremlin -> `🛠️ Craft/💼 Vocation/😈 Gremlin`
+- Networking, intros, conferences -> `🛠️ Craft/💼 Vocation/🕸 Networking`
+- Mentorship -> `🛠️ Craft/💼 Vocation/👨‍🏫 Mentorship`
+- Software, dev tools, GitHub -> `🛠️ Craft/💻 Development`
+- RYLLC, consulting -> `🛠️ Craft/💻 RYLLC`
+- Atelic -> `🛠️ Craft/💻 RYLLC/🎯 Atelic`
+- Product Forge, Titus -> `🛠️ Craft/💻 TPF`
+- Travel, trips, flights, hotels -> `🛠️ Craft/🌏 Adventure`
+- Australia -> `🛠️ Craft/🌏 Adventure/🇦🇺 Australia`
+- Vehicles, auto -> `🛠️ Craft/🌏 Adventure/🚙 Vehicles`
+- Climate tech -> `🛠️ Craft/🌦️ Climate`
+- Photography -> `🛠️ Craft/🎨 Leisure/📸 Photography`
+- Outdoor gear, REI, backcountry -> `🛠️ Craft/🌲 Outdoorsman`
+
+**Admin signals:**
+- Government correspondence -> `📑 Admin/🏛️ Government`
+- Deals, coupons, offers -> `📑 Admin/🏷 Offers`


### PR DESCRIPTION
## Summary
- New local skill at `.claude/skills/email-assist/` with three modes: triage, cleanup, and filters
- Triage auto-labels purchases, applies colored stars (green/yellow/red), routes to pillar sublabels, and surfaces family emails first
- Learned rules system that improves with each user correction
- Calendar awareness for scheduling proposals
- Draft-first email workflow (never sends without approval)
- Includes reference files for triage rules and full label taxonomy

## Test plan
- [x] Triaged 30+ inbox emails across two passes
- [x] Verified purchase auto-processing (label, mark read, archive)
- [x] Verified star assignment and >7 day escalation
- [x] Verified family email handling with article summaries
- [x] Verified calendar checking for meeting proposals
- [x] Hoisted learned rules back into skill after each session

🤖 Generated with [Claude Code](https://claude.com/claude-code)