### PR TITLE
Update email-assist label map and remove cleanup mode

### DIFF
--- a/.claude/skills/email-assist/SKILL.md
+++ b/.claude/skills/email-assist/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: email-assist
-description: Triage Gmail inbox by labeling, starring, and archiving emails. Also consolidates legacy labels and creates filters. Use this skill whenever the user mentions email triage, inbox cleanup, email labels, email filters, or wants to process their inbox. Default subcommand is triage.
-argument-hint: "[triage | cleanup | filters]"
+description: Triage Gmail inbox by labeling, starring, and archiving emails. Also creates filters for recurring senders. Use this skill whenever the user mentions email triage, inbox cleanup, email labels, email filters, or wants to process their inbox. Default subcommand is triage.
+argument-hint: "[triage | filters]"
 allowed-tools:
   - mcp__gmail__search_emails
   - mcp__gmail__read_email
@@ -9,8 +9,6 @@ allowed-tools:
   - mcp__gmail__batch_modify_emails
   - mcp__gmail__list_email_labels
   - mcp__gmail__get_or_create_label
-  - mcp__gmail__create_label
-  - mcp__gmail__delete_label
   - mcp__gmail__create_filter
   - mcp__gmail__create_filter_from_template
   - mcp__gmail__list_filters
@@ -28,7 +26,7 @@ allowed-tools:
 
 # Email Assist
 
-Triage the Gmail inbox, clean up legacy labels, and create filters for recurring senders.
+Triage the Gmail inbox and create filters for recurring senders.
 
 ## Before Every Invocation
 
@@ -66,19 +64,6 @@ After processing:
 4. Identify senders appearing 3+ times, suggest creating filters
 5. **Urgent digest**: List all RED_STAR emails remaining in inbox with subject, sender, age, and what action is needed. This is the "respond to these" list.
 6. Print summary: counts by action, new learned rules, filter suggestions
-
-## Mode: cleanup
-
-Merge legacy labels into proper pillar sublabels. Follow [label-map.md](reference/label-map.md) for known merge targets.
-
-For each label:
-1. Search the label to show contents
-2. Propose merge target (specific sublabel, not parent)
-3. User confirms or overrides
-4. `mcp__gmail__batch_modify_emails` to add new label, remove old
-5. `mcp__gmail__delete_label` to remove old label
-
-Never delete a label without user confirmation. Present all proposed merges as a table first.
 
 ## Mode: filters
 

--- a/.claude/skills/email-assist/reference/label-map.md
+++ b/.claude/skills/email-assist/reference/label-map.md
@@ -4,13 +4,16 @@ Full label taxonomy for routing emails. Label IDs are resolved at runtime via `l
 
 Always route to the most specific sublabel. Never label with just a parent pillar when a sublabel fits.
 
-## Active Label Hierarchy
+## Label Hierarchy
 
 ### Admin (📑)
 - `📑 Admin` (parent)
 - `📑 Admin/🛒 Purchases` -- order confirmations, receipts, shipping, delivery
 - `📑 Admin/🏷 Offers` -- deals, coupons, promotional offers
 - `📑 Admin/🏛️ Government` -- government correspondence, DMV, city forms
+- `📑 Admin/🧾 Bills` -- utility statements, recurring bills
+- `📑 Admin/🪪 Insurance` -- auto insurance, home insurance, renters insurance (NOT health insurance)
+- `📑 Admin/⚖️ Legal` -- legal correspondence
 
 ### Constitution (🍏)
 - `🍏 Constitution` (parent)
@@ -19,7 +22,6 @@ Always route to the most specific sublabel. Never label with just a parent pilla
 - `🍏 Constitution/💰 Financial/📜 Trust` -- trust, estate planning
 - `🍏 Constitution/💪 Athlete` -- gym, fitness, running, climbing, training
 - `🍏 Constitution/🏥 Healthcare` -- medical, dental, vision, health insurance
-- `🍏 Constitution/🪪 Insurance` -- auto insurance, home insurance, renters insurance (NOT health insurance)
 - `🍏 Constitution/🥕 Nutrition` -- supplements, diet, meal planning
 - `🍏 Constitution/🧖 Personal Care` -- grooming, skincare
 - `🍏 Constitution/🍾 Sobriety` -- sobriety related
@@ -38,15 +40,17 @@ Always route to the most specific sublabel. Never label with just a parent pilla
 - `🤝 Community/🤗 Friends` -- personal friends
 - `🤝 Community/👨‍👩‍👦‍👦 Family` -- family members (always surface for response)
 - `🤝 Community/🏛 Brown` -- Brown University
+- `🤝 Community/🏛 Brown/👬 Phi Psi` -- Phi Psi fraternity
 - `🤝 Community/🏛 Brown/Interviews` -- Brown alumni interviews
 - `🤝 Community/📚 Book Club` -- book club
 - `🤝 Community/🌱 SCF` -- SCF
-- `🤝 Community/🌇 Denver` -- Denver community, local events
 - `🤝 Community/🇮🇹 Italiano` -- Italian language learning
 - `🤝 Community/🤲 Giving` -- charity, volunteering, donations
-- `🤝 Community/⚓ Seattle` -- Seattle contacts and community
-- `🤝 Community/🌇 Los Angeles` -- LA contacts and community
-- `🤝 Community/🌉 San Francisco` -- SF contacts and community
+- `🤝 Community/🏙️ Cities` -- city based contacts (parent)
+- `🤝 Community/🏙️ Cities/🌇 Denver` -- Denver community, local events
+- `🤝 Community/🏙️ Cities/⚓ Seattle` -- Seattle contacts and community
+- `🤝 Community/🏙️ Cities/🌆 Los Angeles` -- LA contacts and community
+- `🤝 Community/🏙️ Cities/🌉 San Francisco` -- SF contacts and community
 
 ### Craft (🛠️)
 - `🛠️ Craft` (parent)
@@ -57,54 +61,15 @@ Always route to the most specific sublabel. Never label with just a parent pilla
 - `🛠️ Craft/💼 Vocation/🚯 QuitCarbon` -- QuitCarbon
 - `🛠️ Craft/💼 Vocation/👨‍🏫 Mentorship` -- mentorship
 - `🛠️ Craft/💼 Vocation/🕸 Networking` -- networking, intros, conferences
+- `🛠️ Craft/💼 Vocation/💻 RYLLC` -- Reliably Yours LLC consulting
+- `🛠️ Craft/💼 Vocation/💻 RYLLC/🎯 Atelic` -- Atelic project
+- `🛠️ Craft/💼 Vocation/💻 TPF` -- The Product Forge, Titus
 - `🛠️ Craft/💻 Development` -- software, dev tools, GitHub, tech subscriptions
-- `🛠️ Craft/💻 RYLLC` -- Reliably Yours LLC consulting
-- `🛠️ Craft/💻 RYLLC/🎯 Atelic` -- Atelic project
-- `🛠️ Craft/💻 TPF` -- The Product Forge, Titus
 - `🛠️ Craft/🌏 Adventure` -- travel, trips, flights, hotels
 - `🛠️ Craft/🌏 Adventure/🇦🇺 Australia` -- Australia
 - `🛠️ Craft/🌏 Adventure/🇦🇺 Australia/🦘 Tassie` -- Tasmania
 - `🛠️ Craft/🌏 Adventure/🚙 Vehicles` -- vehicles, auto
 - `🛠️ Craft/🌦️ Climate` -- climate tech
-- `🛠️ Craft/🎨 Leisure` -- leisure, hobbies
+- `🛠️ Craft/🎨 Leisure` -- leisure, hobbies, art, gaming
 - `🛠️ Craft/🎨 Leisure/📸 Photography` -- photography
 - `🛠️ Craft/🌲 Outdoorsman` -- outdoor gear, REI, backcountry
-
-## Legacy Labels (cleanup targets)
-
-These labels predate the pillar system. Use `cleanup` mode to merge them.
-
-| Legacy Label | Merge Target | Notes |
-|---|---|---|
-| People/Connor Foody | 🤝 Community/⚓ Seattle | User confirmed |
-| People/Clare Vivarelli | Review and route | Australia era contact |
-| People/Brad Phillipi | 🤝 Community/🤗 Friends | |
-| Animation | 🛠️ Craft/🎨 Leisure | 2011-2012 content |
-| Courses | 🧠 Contemplation/👨‍🎓 Education | Brown 2010 courses |
-| Jobs | 🛠️ Craft/💼 Vocation | 2016 job search |
-| Registration | 📑 Admin | Old signups |
-| Art | 🛠️ Craft/🎨 Leisure | 2019 art events |
-| Design | 🛠️ Craft/💻 Development | 2014-2019 design work |
-| Tahoe | 🛠️ Craft/🌏 Adventure | 2020 trip planning |
-| Boxing | 🍏 Constitution/💪 Athlete | 2020 gym |
-| Kickstarter | 📑 Admin/🛒 Purchases | Various projects |
-| Craigslist | 📑 Admin/🛒 Purchases | Marketplace transactions |
-| Amazon | 📑 Admin/🛒 Purchases | Prime, orders |
-| Paypal | 📑 Admin/🛒 Purchases | Payment receipts |
-| Inspiration | 🧠 Contemplation | General inspiration |
-| The Great Migration | Review | 2021 relocation docs |
-| Conferences | 🛠️ Craft/💼 Vocation/🕸 Networking | 2019 conference |
-| Burning Man | 🛠️ Craft/🌏 Adventure | 2017 event |
-| Los Angeles | 🤝 Community/🌇 Los Angeles | 2023 LA events (create new sublabel) |
-| Press | 🛠️ Craft/💼 Vocation | 2023 interviews |
-| San Francisco | 🤝 Community/🌉 San Francisco | SF events (merge into same sublabel as 🌉 San Francisco) |
-| Documents | 📑 Admin | Library scans |
-| Phi Psi | 🤝 Community/🤗 Friends | Fraternity |
-| 🎮 GameFlo | 🛠️ Craft/🎨 Leisure | Gaming newsletters |
-| 🎒 Gear | 🛠️ Craft/🌲 Outdoorsman | Outdoor gear |
-| ⚖️ Legal | 📑 Admin | Legal correspondence |
-| 🪪 Insurance | 🍏 Constitution/🪪 Insurance | GEICO, auto insurance |
-| 🧾 Bills | 🍏 Constitution/💰 Financial | Utility statements |
-| 🚌 Transportation | 📑 Admin | Parking, transit |
-| 🌉 San Francisco | 🤝 Community/🌉 San Francisco | SF events (create new sublabel, distinct from plain "San Francisco") |
-| [Imap]/Trash | Delete label only | Truly empty, no emails to move. Delete the label itself with user confirmation. |


### PR DESCRIPTION
## Summary
- Updated label-map.md to reflect current Gmail taxonomy after full label consolidation
- Added Cities parent under Community (Denver, Seattle, LA, SF)
- Moved Phi Psi under Brown, Bills/Legal/Insurance under Admin, RYLLC/TPF under Vocation
- Removed legacy labels section (all 32 labels have been merged)
- Removed cleanup subcommand and related tools (label deletion/creation) since consolidation is complete

## Test plan
- [x] Verified label hierarchy matches current `list_email_labels` output (58 user labels)
- [ ] Run triage on next inbox batch to confirm routing still works with updated map

🤖 Generated with [Claude Code](https://claude.com/claude-code)