### PR TITLE
Add assist:meals Skill and Symlink local-skills

### DIFF
--- a/.claude/local-skills/plugins/assist/plugin.json
+++ b/.claude/local-skills/plugins/assist/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "assist",
-  "description": "Personal productivity skills: email triage, schedule planning, knowledge capture, BD outreach, and job applications.",
+  "description": "Personal productivity skills: email triage, schedule planning, knowledge capture, BD outreach, job applications, and meal planning.",
   "version": "1.0.0",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"
   },
   "license": "MIT",
-  "keywords": ["assist", "email", "schedule", "learn", "bd", "job-apply", "productivity"]
+  "keywords": ["assist", "email", "schedule", "codify", "sharpen", "bd", "job-apply", "meals", "productivity"]
 }

--- a/.claude/local-skills/plugins/assist/skills/meals/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/meals/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: assist:meals
+description: Weekly meal planning, shopping list generation, and pantry aware grocery runs. Produces a plant based, seasonal, batch prep friendly meal plan for the week, plus a consolidated shopping list grouped by store. Use this skill whenever the user mentions meal planning, wants to plan the week's food, asks for a shopping list, wants help figuring out what to cook, mentions batch prep, macros, recipes, a grocery run, a Sprouts or Costco trip, or says things like "back on the healthy eating train" or "kick the takeout habit." Also trigger for "/assist:meals", "meals for the week", or "what should I cook". Prefer invoking this skill even when the user's ask is oblique (e.g., "I want to stop eating out" or "I need to hit my macros this week") since meal planning is usually the underlying need.
+argument-hint: "[optional week, e.g. 2026-W17]"
+allowed-tools:
+  - Bash
+  - mcp__claude_ai_Google_Calendar__*
+  - WebFetch
+  - Read
+  - Edit
+  - Write
+  - Glob
+  - AskUserQuestion
+---
+
+# Meals Assist
+
+Help Forni plan a week of plant based, seasonal, batch prep friendly meals and produce a single primary shopping list. The goal is less decision fatigue mid week and more momentum on the healthy eating front.
+
+## Why This Matters
+
+Forni's 2026 growth edge is eliminating overconsumption. The most visible form is defaulting to takeout when the week gets tired. A good meal plan removes the decision and the cravings compound. A bad plan (boring, unrealistic, mismatched to his week) is worse than no plan; it generates friction and a story to push against. Aim for plans he wants to eat, sized to his actual week, using ingredients he actually has or can easily get.
+
+The shopping list is the primary artifact. The meal plan exists mostly to produce a good list and to guide batch prep day.
+
+## Before Every Invocation
+
+1. Read [learned-rules.md](learned-rules.md) in this directory
+2. Read the canonical nutrition context:
+   - `~/Eudaimonia/Constitution/Nutrition/README.md` — daily macro targets, meal budgets, supplement stack
+   - `~/Eudaimonia/Constitution/Nutrition/staples.md` — brand preferences, Yuka scores, store groupings
+   - `~/Eudaimonia/Constitution/Nutrition/pantry.md` — current on hand inventory
+3. Read the most recent plan file in `~/Eudaimonia/Constitution/Nutrition/plans/` (sort by filename) for format reference and to see what we just ate
+4. Read [references/recipe-sources.md](references/recipe-sources.md) for the preferred recipe sites and what's worked in the past
+5. Determine the target week. Default to the current ISO week. Use `date +"%G-W%V"` for the week identifier.
+
+## Source of Truth
+
+| File | Purpose |
+|------|---------|
+| `Constitution/Nutrition/README.md` | Daily macros and meal slot budgets |
+| `Constitution/Nutrition/staples.md` | What brand to buy for recurring items |
+| `Constitution/Nutrition/pantry.md` | What is already on hand |
+| `Constitution/Nutrition/plans/*` | Prior weekly plans (format reference) |
+| `references/recipe-sources.md` | Approved recipe sites and historical ratings |
+| `learned-rules.md` | Corrections learned through use |
+
+The weekly plan file format mirrors `Constitution/Nutrition/plans/2026-W14-meal-plan.md`. Do not invent a new format unless the user asks.
+
+## Principles
+
+- **Plant based.** No meat. Tofu and lentils are the protein backbone. Eggs and Greek yogurt are acceptable but not required.
+- **Seasonal.** Lean on what is actually in season at the target week. Check the date when deciding. Spring (now) favors asparagus, snap peas, radishes, artichokes, spring greens, strawberries, new potatoes. Summer favors tomatoes, stone fruit, corn, zucchini, peppers, cucumbers. Use this as a guideline, not a rule.
+- **Batch prep friendly.** One prep session on Sunday or Monday carries most of the week. A mid week refresh handles the rest. Favor ingredients that survive the fridge for several days.
+- **Macro anchored.** The daily target is 2,112 cal / 118g P / 257g C / 68g F. The shake handles ~32g of protein and ~225 cal. The remaining three meals should roughly split the rest as laid out in README.
+- **Realistic for the week.** Social events, travel, and team lunches eat meals. Do not prep for meals that will not happen.
+- **Repeatable, not boring.** Repeating a lunch twice in a week is fine (batch prep reality). Three or four times in a row is a trap; rotate a second lunch option in.
+
+## The Plan Flow
+
+### Phase 1: Frame the Week
+
+1. Compute the target week's Monday through Sunday dates
+2. Fetch Google Calendar events for that range. Filter out `transparency: "transparent"` (free/informational) events
+3. Identify meals we should NOT plan for:
+   - Social dinners (restaurants, invited events)
+   - Team lunches (e.g., Thursday at Zero Homes)
+   - Out of town travel
+   - Wednesday evening Wine Down (flexible, social)
+4. Note which shopping day is likely this week. Default assumption: Sprouts run after High Noon on Wednesday or Friday. Confirm with Forni if the calendar makes it unclear.
+
+Present the week back as a simple list of planned vs skipped meal slots. Ask Forni if anything is missing before continuing.
+
+### Phase 2: Inventory Check
+
+1. Read `pantry.md` fully
+2. Scan `staples.md` and build a short list of items that likely need a restock. Favor items that get used heavily week to week (tofu, soy milk, kimchi, hummus, greens, lentils, rice, oats) and items the user has mentioned running low.
+3. Ask Forni in one batch (use AskUserQuestion) for what's on hand. Group the questions by pantry section (produce, refrigerated, dry goods, condiments) to keep it scannable. Keep it targeted; do not ask about every staple.
+4. Update `pantry.md` with his answers before generating the plan. This is worth the small extra write; the pantry gets more accurate over time.
+
+### Phase 3: Draft the Plan
+
+1. Pull a small set of candidate recipes from the preferred sites (see recipe-sources.md). Use WebFetch sparingly; favor recipes already referenced in prior plans or recipes Forni has rated. You do not need to fetch every recipe, only the ones being introduced this week.
+2. Build the plan in the format of `2026-W14-meal-plan.md`:
+   - Daily macro budget header
+   - Meal structure (7:30 to 18:30 IF window)
+   - Batch prep section (grains/legumes, proteins, vegetables, sauces)
+   - Daily meals: breakfast, lunch (per day table), dinner (per day table)
+   - Daily macro summary
+3. For meals skipped on social days, show "Social" or the event name in the table rather than leaving blank.
+4. Repeat lunches up to twice per week. Keep breakfast mostly consistent (batch prep reality). Dinners vary more.
+
+Present the draft plan inline before saving. Let Forni redirect before committing to the shopping list.
+
+### Phase 4: Shopping List
+
+The shopping list is the primary artifact. Group by section and store.
+
+```
+## Shopping List
+
+### Sprouts (Wed or Fri after High Noon)
+#### Produce
+- [ ] Asparagus, 1 bunch
+...
+#### Refrigerated
+...
+
+### Costco (if due for a run)
+...
+
+### Already Stocked (from pantry.md)
+...
+```
+
+Rules for the list:
+- Only include items not already in `pantry.md`
+- Flag staples from `staples.md` that are likely low (ask "are we low on tofu?" style) and include them if Forni confirms
+- Use the brand from `staples.md` where one is specified
+- Separate produce by grocery section for efficient store flow (leafy greens, alliums, roots, fruits, etc.)
+- Put anything that is specific to a single recipe in a `recipe specific` subsection so it's easy to skip if Forni decides to cut that meal
+
+### Phase 5: Save and Record
+
+1. Write the full plan to `~/Eudaimonia/Constitution/Nutrition/plans/YYYY-WNN-meal-plan.md` (ISO week). Do not overwrite an existing plan for the same week without confirmation.
+2. Append the recipes used to `references/recipe-sources.md` under "Recipes Used" with week, site, and rating left blank (Forni fills the rating in later).
+3. Print the shopping list cleanly in chat so it's easy to copy to his phone.
+
+## Meal Plan File Format
+
+Match `Constitution/Nutrition/plans/2026-W14-meal-plan.md`. Key sections in order:
+
+1. `# Meal Plan: Week NN (Mon Date – Sun Date, YYYY)`
+2. Short italic subtitle (plant based, seasonal, store)
+3. `## Daily Macro Budget` table
+4. `## Meal Structure` with IF window and meal slots
+5. `## Batch Prep` with grains/legumes, proteins, vegetables, sauces
+6. `## Daily Meals` with breakfast description, lunch table, dinner table
+7. `### Daily Macro Summary` table
+8. `## Shopping List` grouped by store and section
+
+Keep notes and variances in italic after tables. Call out gaps (e.g., "Fat is ~7g under target. Add extra tahini or nuts to close the gap.")
+
+## Recipe Sources
+
+See [references/recipe-sources.md](references/recipe-sources.md) for the full list and ratings history. Primary sites:
+
+- cookieandkate.com
+- simpleveganblog.com
+- halfbakedharvest.com (filter for plant based)
+- budgetbytes.com
+
+When you introduce a new recipe, add a row to the "Recipes Used" table with the week, recipe title, site, and a blank rating. Forni fills ratings in over time. If a recipe turns into a repeat favorite, note it in the "Favorites" section.
+
+Feel free to suggest new sites similar in vibe (plant based, seasonal, approachable). Add candidates to the "Candidate Sites to Try" section rather than introducing them directly.
+
+## Pantry Update Pattern
+
+When Forni mentions outside this skill that he bought or finished something (e.g., "grabbed two blocks of tofu at Sprouts"), update `pantry.md` directly. This keeps the inventory accurate without needing a formal mode. When running the plan, always re read pantry.md fresh rather than trusting cached state.
+
+## Constraints and Defaults
+
+- **IF window**: 7:30 to 18:30. No dinner scheduled after 18:30.
+- **Wednesday evening**: Wine Down. Keep dinner light or flexible.
+- **Thursday lunch**: Team lunch at Zero Homes, usually around 12:30. Do not plan Thursday lunch unless Forni says otherwise.
+- **Weekends**: Saturday is Adventure Day; lunch is often on the go. Sunday is rest and planning; dinner works from leftovers.
+- **Shake timing**: PLNT v2 + 1 cup Silk soy milk. Usually post workout or mid morning. Count toward daily macros.
+
+## Learned Rules
+
+See [learned-rules.md](learned-rules.md). Append to that file when Forni corrects a choice (wrong recipe type, too many chickpeas, missed a staple, etc.) so the skill improves over time.

--- a/.claude/local-skills/plugins/assist/skills/meals/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/meals/SKILL.md
@@ -124,7 +124,32 @@ Rules for the list:
 
 1. Write the full plan to `~/Eudaimonia/Constitution/Nutrition/plans/YYYY-WNN-meal-plan.md` (ISO week). Do not overwrite an existing plan for the same week without confirmation.
 2. Append the recipes used to `references/recipe-sources.md` under "Recipes Used" with week, site, and rating left blank (Forni fills the rating in later).
-3. Print the shopping list cleanly in chat so it's easy to copy to his phone.
+3. Push the primary shopping list (the store being shopped today) to Apple Reminders using the Groceries list. See the Apple Reminders Integration section below. Items for other stores (e.g., Costco next run) stay in the plan file only.
+4. Print the shopping list in chat as a preview and backup.
+
+## Apple Reminders Integration
+
+Forni's shopping list is pushed into the Apple Reminders "Groceries" list so it shows up natively on his phone during the shopping run. Reminders auto groups the list into store sections (Produce, Dairy, Pantry, etc.) when the list type is set to Grocery.
+
+Use AppleScript via `osascript` with a heredoc:
+
+```bash
+osascript <<'APPLESCRIPT'
+tell application "Reminders"
+    tell list "Groceries"
+        make new reminder with properties {name:"Asparagus, 1 bunch"}
+        make new reminder with properties {name:"Snap peas, 1 lb"}
+        # one line per item
+    end tell
+end tell
+APPLESCRIPT
+```
+
+Notes:
+- Keep item names concise but include quantity, e.g. `"Sweet potatoes, 4 large"`. Quantities help the checkout/counting moment.
+- Include brand hints in parens when the brand matters, e.g. `"Pearl couscous, Bob's Red Mill tri color"`.
+- Single quotes inside item names (e.g. "Bob's") are fine inside the heredoc.
+- The Groceries list accumulates items across weeks. Assume Forni will clean up completed items himself. If you see a lot of uncompleted items before pushing, ask before adding more (dupes are annoying).
 
 ## Meal Plan File Format
 

--- a/.claude/local-skills/plugins/assist/skills/meals/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/meals/SKILL.md
@@ -185,11 +185,20 @@ When Forni mentions outside this skill that he bought or finished something (e.g
 
 ## Constraints and Defaults
 
+**Durable constraints** (unlikely to change without Forni flagging):
+
 - **IF window**: 7:30 to 18:30. No dinner scheduled after 18:30.
-- **Wednesday evening**: Wine Down. Keep dinner light or flexible.
-- **Thursday lunch**: Team lunch at Zero Homes, usually around 12:30. Do not plan Thursday lunch unless Forni says otherwise.
-- **Weekends**: Saturday is Adventure Day; lunch is often on the go. Sunday is rest and planning; dinner works from leftovers.
 - **Shake timing**: PLNT v2 + 1 cup Silk soy milk. Usually post workout or mid morning. Count toward daily macros.
+- **Weekends**: Saturday is Adventure Day; lunch is often on the go. Sunday is rest and planning; dinner works from leftovers.
+
+**Current weekly pattern** (things that *can* go stale as jobs and seasons change — **always verify against the calendar pulled in Phase 1**, and update the date stamp below when confirmed or corrected):
+
+- **Wednesday evening**: Wine Down. Keep dinner light or flexible. *(Confirmed 2026-04-17.)*
+- **Thursday lunch**: Team lunch at Zero Homes around 12:30. Do not plan Thursday lunch unless the calendar contradicts. *(Confirmed 2026-04-17.)*
+- **Tuesday evening**: DRC run club meets ~18:00 at Ratio Beerworks. Plan dinner before, optional protein snack after. *(Confirmed 2026-04-17.)*
+- **Wednesday midday**: PAH Kitchen Assistant volunteering ~13:00 to 15:00; lunch goes before leaving at 12:30. *(Confirmed 2026-04-17.)*
+
+The calendar is the source of truth. These patterns are hints for interpreting calendar events, not substitutes for them.
 
 ## Learned Rules
 

--- a/.claude/local-skills/plugins/assist/skills/meals/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/meals/learned-rules.md
@@ -1,0 +1,23 @@
+# Learned Rules: assist:meals
+
+Corrections and preferences specific to meal planning. Read on every invocation. Append when Forni corrects a decision so the skill improves over time. General defaults live in SKILL.md.
+
+## Planning Rules
+
+(none yet)
+
+## Shopping Rules
+
+(none yet)
+
+## Recipe Rules
+
+(none yet)
+
+## Macro Rules
+
+(none yet)
+
+## Pantry Rules
+
+(none yet)

--- a/.claude/local-skills/plugins/assist/skills/meals/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/meals/learned-rules.md
@@ -4,15 +4,36 @@ Corrections and preferences specific to meal planning. Read on every invocation.
 
 ## Planning Rules
 
-(none yet)
+- **Default target week depends on invocation day.** Invoking on Wednesday or later means plan the NEXT week (Mon through Sun), not the current one. Shop on the Fri High Noon Sprouts run, batch prep Sun/Mon.
+  - Why: Forni confirmed this pattern on 2026-04-17 when we tested the skill. Matches the Fri shop cadence and avoids half planning a week that is mostly already spent.
+  - How to apply: if today is Mon or Tue, default to this week; Wed through Sun, default to next week. Still confirm with Forni in Phase 1.
+
+- **DRC on Tuesday evenings is a running event, not social drinking.** Ratio Beerworks is just the meeting point. Plan a normal dinner BEFORE the run and a high protein snack after.
+  - Why: Forni clarified on 2026-04-17 that DRC is Denver Run Club.
+  - How to apply: on weeks with DRC, treat Tuesday dinner as a standard slot timed to eat before the ~18:00 start. Do not skip it and do not plan for a brewery meal.
+
+- **Wednesday PAH volunteering (Kitchen Assistant, 13:00 to 15:00) means lunch goes BEFORE leaving at 12:30.** Pack or eat at home around 11:30 to 12:00. Do not plan a lunch for after PAH since he's driving straight home.
+  - Why: Forni confirmed on 2026-04-17.
+  - How to apply: on weeks with PAH on the calendar, Wednesday lunch is a packed/early lunch slot, not a normal 12:00 to 13:00 window.
+
+- **Thursday "Kitchen Cruising" with Ross is an optional social cooking event**, not a fixed commitment. Don't reorganize the meal plan around it; plan a normal Thursday dinner and let Forni flex if the event is on.
+  - Why: Forni clarified on 2026-04-17 that it's a "fun cooking" thing with Ross, not required.
 
 ## Shopping Rules
 
-(none yet)
+- **All bulk dry goods come from Sprouts, not Costco.** Beans (black, kidney, adzuki), rice (white basmati, brown short grain), lentils (green, red), quinoa, and similar bulk items live in the Sprouts bulk bin section.
+  - Why: Forni said on 2026-04-17 "I LOVE their bulk section."
+  - How to apply: when generating a shopping list, put dried beans, rice, lentils, quinoa, and related bulk staples under Sprouts. Costco is for jarred/packaged items (kimchi, hummus, olives, artichokes, pickled onions, yogurt, nuts, coffee).
+
+- **The primary shopping list goes into Apple Reminders via AppleScript.** Push items to the "Groceries" list; Reminders auto groups by store section on his phone.
+  - Why: Forni confirmed on 2026-04-17 that Reminders is where the list should live, not just inline chat or the plan file.
+  - How to apply: See the "Apple Reminders Integration" section of SKILL.md for the osascript pattern. Only push items for the store being shopped that day; other stores stay in the plan file.
 
 ## Recipe Rules
 
-(none yet)
+- **Forni is experimenting with blender based soups in 2026.** He bought an immersion blender on 2026-04-17 and wants to try pureed soups. Brothy chunky soups remain unappealing; lean toward silky pureed varieties that showcase the blender.
+  - Why: Reversed the earlier "no soup" rule the same day he stated it, specifically because of the new blender.
+  - How to apply: propose pureed soups when spring/fall seasonality supports it (asparagus, pea, leek, cauliflower, broccoli, butternut). Avoid chunky minestrones, chilis, and brothy bean soups unless explicitly requested.
 
 ## Macro Rules
 
@@ -20,4 +41,6 @@ Corrections and preferences specific to meal planning. Read on every invocation.
 
 ## Pantry Rules
 
-(none yet)
+- **Pantry inventory questions go one at a time, not in a batch.** Use AskUserQuestion with structured options rather than asking for a batched reply in chat.
+  - Why: Forni corrected this on 2026-04-17. A long checklist in chat feels tedious; one question at a time keeps the rhythm conversational.
+  - How to apply: loop through pantry items individually. Each question should offer the common answers (Yes on hand, No need to buy, Have some but low, Skip) plus a free text option for quantity or notes.

--- a/.claude/local-skills/plugins/assist/skills/meals/references/recipe-sources.md
+++ b/.claude/local-skills/plugins/assist/skills/meals/references/recipe-sources.md
@@ -31,6 +31,8 @@ Appended automatically when a plan introduces a new recipe. Forni fills in the r
 
 | Week | Recipe | Site | Rating | Notes |
 |------|--------|------|--------|-------|
+| 2026-W17 | Creamy Spring Pea & Mint Soup | — (Claude drafted, no site source) | | Immersion blender showcase. Thu dinner |
+| 2026-W17 | Sweet Nut & Fruit Protein Bars | Forni's Paprika (ChatGPT originated) | | Bonus batch item, 16 bars, post workout snack |
 
 ## Favorites
 

--- a/.claude/local-skills/plugins/assist/skills/meals/references/recipe-sources.md
+++ b/.claude/local-skills/plugins/assist/skills/meals/references/recipe-sources.md
@@ -1,0 +1,47 @@
+# Recipe Sources
+
+Preferred recipe sites for meal plan sourcing and a running log of what we've tried. The skill reads this on every invocation to bias toward recipes that have landed and avoid ones that haven't.
+
+## Preferred Sites
+
+| Site | URL | Vibe | Notes |
+|------|-----|------|-------|
+| Cookie and Kate | https://cookieandkate.com/ | Vegetarian, seasonal, tested | Deep archive, searchable by ingredient |
+| Simple Vegan Blog | https://simpleveganblog.com/ | Plant based, approachable | Good for basics and sauces |
+| Half Baked Harvest | https://www.halfbakedharvest.com/ | Cozy, hearty, photogenic | Filter for plant based (many recipes are not) |
+| Budget Bytes | https://www.budgetbytes.com/ | Practical, cost aware | Good for pantry based meals |
+
+## Candidate Sites to Try
+
+Drop new sites here to evaluate before promoting to Preferred. Consider: Minimalist Baker, Rainbow Plant Life, Feasting at Home, Love and Lemons, Oh She Glows, The First Mess.
+
+| Site | URL | Why interesting | Status |
+|------|-----|-----------------|--------|
+| | | | |
+
+## Rating Scale
+
+- **Hit** — make again, add to core rotation
+- **OK** — fine, not memorable, no rush to repeat
+- **Miss** — skip in the future
+
+## Recipes Used
+
+Appended automatically when a plan introduces a new recipe. Forni fills in the rating after eating.
+
+| Week | Recipe | Site | Rating | Notes |
+|------|--------|------|--------|-------|
+
+## Favorites
+
+Recipes rated Hit and worth rotating in consistently. Move from the table above once a rating lands.
+
+| Recipe | Site | Why it lands |
+|--------|------|--------------|
+
+## Misses
+
+Recipes rated Miss. Do not suggest these again without a reason.
+
+| Recipe | Site | Why it missed |
+|--------|------|--------------|

--- a/setup.sh
+++ b/setup.sh
@@ -231,7 +231,11 @@ link_local_skills() {
     return 1
   fi
 
-  ln -s "$src" "$dst"
+  mkdir -p "$(dirname "$dst")"
+  if ! ln -s "$src" "$dst"; then
+    error "Failed to link $dst -> $src"
+    return 1
+  fi
   info "Linked $dst -> $src"
   SUMMARY+=("local-skills linked")
 }

--- a/setup.sh
+++ b/setup.sh
@@ -192,7 +192,10 @@ install_npm_globals() {
 deploy_homebase() {
   header "Homebase"
 
-  local excluded=(setup.sh README.md .git .github .gitignore .markdownlint.jsonc .markdownlint-cli2.jsonc .coderabbit.yaml brew)
+  # local-skills is symlinked (see link_local_skills below) so skill edits in
+  # the repo go live without re running setup.sh. Exclude it from the rsync so
+  # we do not clobber the symlink with a copy.
+  local excluded=(setup.sh README.md .git .github .gitignore .markdownlint.jsonc .markdownlint-cli2.jsonc .coderabbit.yaml brew .claude/local-skills)
   local rsync_opts=('-a' '--force')
   for item in "${excluded[@]}"; do
     rsync_opts+=(--exclude="$item")
@@ -200,6 +203,37 @@ deploy_homebase() {
   rsync "${rsync_opts[@]}" "$DIR/" "$HOME/" || return 1
   info "Homebase synced to \$HOME"
   SUMMARY+=("Homebase deployed")
+}
+
+link_local_skills() {
+  header "Local skills symlink"
+
+  local src="$DIR/.claude/local-skills"
+  local dst="$HOME/.claude/local-skills"
+
+  if [[ ! -d "$src" ]]; then
+    warn "Source $src does not exist, skipping symlink"
+    return 0
+  fi
+
+  if [[ -L "$dst" ]]; then
+    local current
+    current=$(readlink "$dst")
+    if [[ "$current" == "$src" ]]; then
+      info "local-skills symlink already points at $src"
+      return 0
+    fi
+    warn "Replacing local-skills symlink (was $current)"
+    rm "$dst"
+  elif [[ -e "$dst" ]]; then
+    warn "local-skills is a real directory at $dst; refusing to remove automatically"
+    warn "Move or delete it manually, then re run setup.sh"
+    return 1
+  fi
+
+  ln -s "$src" "$dst"
+  info "Linked $dst -> $src"
+  SUMMARY+=("local-skills linked")
 }
 
 install_ide_extensions() {
@@ -431,6 +465,7 @@ run_phase install_brew_packages
 run_phase setup_node
 run_phase install_npm_globals
 run_phase deploy_homebase
+run_phase link_local_skills
 run_phase install_ide_extensions
 run_phase install_claude_plugins
 run_phase setup_auth


### PR DESCRIPTION
## Summary

- **New `/assist:meals` skill** under the `assist` plugin namespace for weekly meal planning, pantry aware shopping list generation, and Apple Reminders push. Plant based, seasonal, batch prep friendly. Sources from cookieandkate, simpleveganblog, halfbakedharvest, budgetbytes.
- **`setup.sh` now symlinks `~/.claude/local-skills` to the repo** instead of rsyncing a copy, so skill edits go live immediately without re running setup. Adds a `link_local_skills` phase with a safety check that refuses to clobber an existing real directory.
- **Skill is pre tuned with learnings from its first real invocation** (planning W17 meals): bulk dry goods come from Sprouts not Costco, DRC is a run not a brewery meal, pantry questions go one at a time, shopping list pushes to Apple Reminders "Groceries" list via osascript, etc.

## Test plan

- [x] `/assist:meals` triggers and loads the right context from `~/Eudaimonia/Constitution/Nutrition/`
- [x] Pantry questions flow one at a time via AskUserQuestion
- [x] Google Calendar fetch filters transparent (free) events correctly
- [x] Shopping list pushes to Apple Reminders "Groceries" list
- [x] Plan file saves to `~/Eudaimonia/Constitution/Nutrition/plans/YYYY-WNN-meal-plan.md` in the expected format
- [x] Recipes log to `references/recipe-sources.md`
- [ ] Verify `./setup.sh` on a fresh machine creates the symlink without issue (not yet exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)