### PR TITLE
Add Meal Planning Quantity, Banana, and Vanilla Rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -15,6 +15,10 @@
 - When creating plans or documents, ALWAYS present them to the user for review before writing to a file. Never write plans directly to files unless explicitly asked.
 - When editing existing files, never overwrite the original without explicit permission. Create a new version file (e.g., v2, draft) instead of modifying the original in place.
 
+## Skills
+
+Every skill that makes decisions on behalf of the user should include a `learned-rules.md` file. For the full authoring conventions (SKILL.md vs learned-rules.md split, when to graduate rules, etc.), see `~/.claude/references/skills.md`.
+
 ## External App Integration
 
 Preferred methods for connecting Claude to outside apps, in order:

--- a/.claude/local-skills/plugins/assist/skills/meals/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/meals/learned-rules.md
@@ -23,17 +23,29 @@ Corrections and preferences specific to meal planning. Read on every invocation.
 
 - **All bulk dry goods come from Sprouts, not Costco.** Beans (black, kidney, adzuki), rice (white basmati, brown short grain), lentils (green, red), quinoa, and similar bulk items live in the Sprouts bulk bin section.
   - Why: Forni said on 2026-04-17 "I LOVE their bulk section."
-  - How to apply: when generating a shopping list, put dried beans, rice, lentils, quinoa, and related bulk staples under Sprouts. Costco is for jarred/packaged items (kimchi, hummus, olives, artichokes, pickled onions, yogurt, nuts, coffee).
+  - How to apply: when generating a shopping list, put dried beans, rice, lentils, quinoa, and related bulk staples under Sprouts. Costco is for jarred/packaged items (kimchi, hummus, olives, artichokes, pickled onions, yogurt, nuts, coffee, vanilla extract).
 
 - **The primary shopping list goes into Apple Reminders via AppleScript.** Push items to the "Groceries" list; Reminders auto groups by store section on his phone.
   - Why: Forni confirmed on 2026-04-17 that Reminders is where the list should live, not just inline chat or the plan file.
   - How to apply: See the "Apple Reminders Integration" section of SKILL.md for the osascript pattern. Only push items for the store being shopped that day; other stores stay in the plan file.
+
+- **Quantities in lbs, oz, or grams. No "1 bag", "1 carton", "1 bunch", "1 container", "1 loaf".** Packaging sizes vary by store and brand; actual weight or volume is what gets Forni the right amount.
+  - Why: Forni corrected this on 2026-04-17. Container units are ambiguous.
+  - How to apply: convert everything to the unit most natural for the ingredient. Produce by the lb or oz (e.g. asparagus 1 lb, mint 1 oz). Liquids in fl oz. Small specialty amounts in grams or oz. Bread as a loaf weight ("~1 lb loaf"). Bulk bin items by weight.
+
+- **Vanilla extract is a Costco staple.** Sprouts does not reliably carry it; Costco does.
+  - Why: Forni confirmed on 2026-04-17.
+  - How to apply: when vanilla is needed, put it in the Costco section of the shopping list, never Sprouts.
 
 ## Recipe Rules
 
 - **Forni is experimenting with blender based soups in 2026.** He bought an immersion blender on 2026-04-17 and wants to try pureed soups. Brothy chunky soups remain unappealing; lean toward silky pureed varieties that showcase the blender.
   - Why: Reversed the earlier "no soup" rule the same day he stated it, specifically because of the new blender.
   - How to apply: propose pureed soups when spring/fall seasonality supports it (asparagus, pea, leek, cauliflower, broccoli, butternut). Avoid chunky minestrones, chilis, and brothy bean soups unless explicitly requested.
+
+- **No bananas.** Forni does not eat them, anywhere.
+  - Why: Forni said so on 2026-04-17.
+  - How to apply: do not propose recipes that use bananas, and do not include bananas on any shopping list. For the quinoa breakfast alt (previously sweetened with banana), use dates, a small drizzle of agave, or seasonal berries instead.
 
 ## Macro Rules
 

--- a/.claude/local-skills/plugins/assist/skills/meals/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/meals/learned-rules.md
@@ -29,7 +29,7 @@ Corrections and preferences specific to meal planning. Read on every invocation.
   - Why: Forni confirmed on 2026-04-17 that Reminders is where the list should live, not just inline chat or the plan file.
   - How to apply: See the "Apple Reminders Integration" section of SKILL.md for the osascript pattern. Only push items for the store being shopped that day; other stores stay in the plan file.
 
-- **Quantities in lbs, oz, or grams. No "1 bag", "1 carton", "1 bunch", "1 container", "1 loaf".** Packaging sizes vary by store and brand; actual weight or volume is what gets Forni the right amount.
+- **Quantities in lb, oz, fl oz, or grams. No "1 bag", "1 carton", "1 bunch", "1 container", "1 loaf".** Packaging sizes vary by store and brand; actual weight or volume is what gets Forni the right amount.
   - Why: Forni corrected this on 2026-04-17. Container units are ambiguous.
   - How to apply: convert everything to the unit most natural for the ingredient. Produce by the lb or oz (e.g. asparagus 1 lb, mint 1 oz). Liquids in fl oz. Small specialty amounts in grams or oz. Bread as a loaf weight ("~1 lb loaf"). Bulk bin items by weight.
 

--- a/.claude/references/skills.md
+++ b/.claude/references/skills.md
@@ -1,0 +1,19 @@
+# Skill Authoring Conventions
+
+Guidance for authoring and maintaining Claude Code skills. Load when working on a SKILL.md, a learned-rules.md, or when invoking /skill-creator.
+
+## SKILL.md vs learned-rules.md
+
+The two files have distinct jobs. Keeping them clean takes discipline.
+
+**SKILL.md** is the durable spec. It holds stable skill behavior, workflow decisions that have crystallized, and durable user preferences unlikely to change (food dislikes, formatting conventions, routing rules like which store carries what).
+
+**learned-rules.md** stays lightweight. It holds personal context tied to the current life shape: calendar interpretation, job specific defaults, current commitments. When life changes, these rules need updating; SKILL.md should not.
+
+**Rule of thumb:** If a rule would need a "last confirmed" date stamp to avoid going stale, it belongs in learned-rules.md. If it's just how the skill works, it belongs in SKILL.md.
+
+Periodically audit learned-rules.md. Graduate rules that have stabilized to SKILL.md, and prune rules that no longer apply.
+
+## When to use learned-rules.md
+
+Every skill that makes decisions on behalf of the user should include a `learned-rules.md` file. When the user corrects a decision, append the correction. Read learned rules at the start of every invocation. This applies to all skills, whether created via /skill-creator or manually.


### PR DESCRIPTION
## Summary

Follow up to #54. Three rules captured during the first real `/assist:meals` run:

- **Shopping quantities** use lb, oz, fl oz, or grams, never bags, cartons, or containers. Packaging sizes vary by store and brand; real weight or volume is what gets the right amount.
- **No bananas.** Forni does not eat them.
- **Vanilla extract is a Costco staple.** Sprouts does not reliably carry it.

All three are captured in `learned-rules.md` so the skill enforces them on the next invocation. The corresponding W17 plan and staples updates in Eudaimonia are already committed there.

## Test plan

- [x] `learned-rules.md` contains all three rules under the correct sections (Shopping, Recipe)
- [ ] Next `/assist:meals` run produces quantities in lb/oz/grams only (verify on W18 planning)
- [ ] Vanilla extract shows up under Costco, never Sprouts
- [ ] No banana appears in any generated plan or shopping list

🤖 Generated with [Claude Code](https://claude.com/claude-code)