### PR TITLE
Add Gmail tooling subsection to External App Integration

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -59,6 +59,7 @@ Use `gws gmail` helpers over the Gmail MCP connector. `gws` preserves full email
 | Draft a reply | `gws gmail +reply --message-id <ID> --html --body '<p>...</p>' --draft` |
 | Draft a reply-all | `gws gmail +reply-all --message-id <ID> --html --body '<p>...</p>' --draft` |
 | Draft a new message | `gws gmail +send --to <EMAIL> --subject '...' --html --body '<p>...</p>' --draft` |
+| Draft a forward | `gws gmail +forward --message-id <ID> --to <EMAIL> --html --body '<p>...</p>' --draft` |
 | Send existing draft | `gws gmail users drafts send --params '{"userId":"me"}' --json '{"id":"<draft-id>"}'` |
 
 Why `gws` over MCP:

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -50,6 +50,22 @@ Two gotchas:
 - `gws` requires upload paths to be inside the current working directory. Use cwd for temp files, not `/tmp`.
 - Drive markdown import creates paged, not Pageless, Docs. Forni prefers Pageless. Toggle manually or use `gws docs documents batchUpdate` to set `documentStyle.documentFormat.documentMode = "PAGELESS"`.
 
+### Gmail (send, reply, forward, draft)
+
+Use `gws gmail` helpers over the Gmail MCP connector. `gws` preserves full email mechanics; MCP `create_draft` does not.
+
+| Action | Command |
+|---|---|
+| Draft a reply | `gws gmail +reply --message-id <ID> --html --body '<p>...</p>' --draft` |
+| Draft a reply-all | `gws gmail +reply-all --message-id <ID> --html --body '<p>...</p>' --draft` |
+| Draft a new message | `gws gmail +send --to <EMAIL> --subject '...' --html --body '<p>...</p>' --draft` |
+| Send existing draft | `gws gmail users drafts send --params '{"userId":"me"}' --json '{"id":"<draft-id>"}'` |
+
+Why `gws` over MCP:
+- `gws` sets In-Reply-To, References, and threadId, so replies are truly threaded. MCP `create_draft` does not accept threadId, so "Re:" subjects only group visually and are not real replies.
+- `gws` supports send-as aliases, attachments via `-a`, and HTML with preserved quoted history via gmail_quote CSS.
+- `--draft` gates sending. Omit the flag for direct send.
+
 ## Code Review
 
 - During PR review iteration, only address NEW or UNRESOLVED review comments. Do not re-address comments that have already been resolved. Ask if unclear which comments are new.


### PR DESCRIPTION
## Summary

Documents the preference for `gws gmail` helpers over the Gmail MCP connector. Adds a new subsection under External App Integration alongside the existing Google Workspace links and Creating Google Docs from markdown subsections.

- Four commands: draft a reply, draft a reply-all, draft a new message, send an existing draft
- Rationale: `gws` preserves In-Reply-To, References, and threadId so replies are truly threaded. MCP `create_draft` does not accept threadId, so "Re:" subjects only group visually.
- `gws` also supports send-as aliases, attachments via `-a`, and HTML with preserved quoted history

Learned from a home buying rate shopping conversation where MCP-created drafts ended up standalone instead of attached to the original thread.

## Test plan

- [ ] `gws gmail +reply --message-id <ID> --html --body '<p>...</p>' --draft` creates a threaded draft
- [ ] `gws gmail users drafts send --params '{"userId":"me"}' --json '{"id":"<draft-id>"}'` sends the draft and the sent message carries the original threadId
- [ ] Table renders in the file rendered on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)