### PR TITLE
Fold Skillset Plugins into Homebase, Keep Skillset as Public Marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,60 @@
+{
+  "name": "skillset",
+  "owner": {
+    "name": "Matthew Fornaciari",
+    "email": "matt@fornaciari.com",
+    "url": "https://github.com/mattforni"
+  },
+  "metadata": {
+    "version": "2.0.0",
+    "description": "A curated collection of Claude Code plugins for enhanced development workflows"
+  },
+  "plugins": [
+    {
+      "name": "linear-lifecycle",
+      "source": "./plugins/linear-lifecycle",
+      "version": "1.2.0",
+      "license": "MIT",
+      "description": "Manage Linear issues via the Linear CLI with zero-context overhead.",
+      "homepage": "https://github.com/mattforni/homebase",
+      "repository": "https://github.com/mattforni/homebase",
+      "author": {
+        "name": "Matthew Fornaciari",
+        "url": "https://github.com/mattforni"
+      },
+      "category": "development",
+      "keywords": ["linear", "issue-tracking", "cli", "workflow", "context-budget", "project-management"],
+      "strict": false,
+      "skills": [
+        "./skills/linear-lifecycle/SKILL.md"
+      ],
+      "commands": [
+        "./commands/linear-setup.md"
+      ]
+    },
+    {
+      "name": "sdlc",
+      "source": "./plugins/sdlc",
+      "version": "2.0.0",
+      "license": "MIT",
+      "description": "Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.",
+      "homepage": "https://github.com/mattforni/homebase",
+      "repository": "https://github.com/mattforni/homebase",
+      "author": {
+        "name": "Matthew Fornaciari",
+        "url": "https://github.com/mattforni"
+      },
+      "category": "development",
+      "keywords": ["sdlc", "workflow", "git", "pr", "review", "development", "lifecycle"],
+      "strict": false,
+      "skills": [
+        "./skills/plan/SKILL.md",
+        "./skills/design/SKILL.md",
+        "./skills/checkpoint/SKILL.md",
+        "./skills/review/SKILL.md",
+        "./skills/iterate/SKILL.md",
+        "./skills/complete/SKILL.md"
+      ]
+    }
+  ]
+}

--- a/.claude/plugins/marketplace-sources.txt
+++ b/.claude/plugins/marketplace-sources.txt
@@ -1,5 +1,5 @@
 https://github.com/anthropics/claude-code.git
 obra/superpowers-marketplace
 wshobson/agents
-mattforni/skillset
+mattforni/homebase
 anthropics/claude-plugins-official

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -160,7 +160,7 @@
     "skillset": {
       "source": {
         "source": "github",
-        "repo": "mattforni/skillset"
+        "repo": "mattforni/homebase"
       }
     },
     "claude-plugins-official": {

--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
 # Homebase
 
 Personal development environment: shell configs, Claude Code skills, dev tooling, and workstation setup.
+
+## Claude Code Marketplaces
+
+Homebase hosts two plugin marketplaces.
+
+### skillset (public)
+
+Curated, single purpose plugins for development workflows. Hosted at the repo root (`.claude-plugin/marketplace.json`).
+
+```bash
+claude plugin marketplace add mattforni/homebase
+claude plugin install sdlc@skillset
+claude plugin install linear-lifecycle@skillset
+```
+
+| Plugin | Description |
+|--------|-------------|
+| [sdlc](plugins/sdlc/) | Plan, design, checkpoint, review, iterate, complete. See [docs/plugins/sdlc.md](docs/plugins/sdlc.md). |
+| [linear-lifecycle](plugins/linear-lifecycle/) | Manage Linear issues via the Linear CLI with zero context overhead. See [docs/plugins/linear-lifecycle.md](docs/plugins/linear-lifecycle.md). |
+
+> Migrating from `mattforni/skillset`? That repo is deprecated. Run `claude plugin marketplace remove skillset` then re add from `mattforni/homebase`.
+
+### local-skills (private)
+
+Personal productivity skills. Lives under [.claude/local-skills](.claude/local-skills/) and is added as a local `directory` source only. Not installable via GitHub.
+
+| Plugin | Description |
+|--------|-------------|
+| [assist](.claude/local-skills/plugins/assist/) | Emails, schedule, codify, sharpen, BD, job apply, meals, permissions. |

--- a/docs/plugins/linear-lifecycle.md
+++ b/docs/plugins/linear-lifecycle.md
@@ -1,0 +1,192 @@
+# linear-lifecycle
+
+Linear issue management using the Linear CLI with zero-context overhead.
+
+## Overview
+
+The `linear-lifecycle` plugin enables Claude to manage Linear issues efficiently without loading heavy MCP servers. Instead of consuming 20k tokens with Linear MCP tools, it uses the lightweight [Linear CLI](https://github.com/schpet/linear-cli) which returns structured output for parsing.
+
+**Context savings: 100%** - No MCP loaded, just bash commands.
+
+## Features
+
+### Zero Context Overhead
+
+- Uses the Linear CLI instead of 20k token Linear MCP
+- Returns structured output for parsing
+- Saves ~92% of context even for reference material
+- 200k/200k tokens remain available for actual work
+
+### Complete Linear Workflow Integration
+
+- Get issue details when starting work
+- Create new issues from discovered bugs/features
+- Update issue status during development
+- Add comments and progress updates
+- Search across teams and projects
+- Close issues when work is complete
+
+## Requirements
+
+- **Homebrew** (for Linear CLI installation)
+- **jq** - JSON processor for parsing Linear API responses
+  - macOS: `brew install jq`
+  - Debian/Ubuntu: `sudo apt-get install jq`
+  - Other systems: See [jq installation guide](https://jqlang.github.io/jq/download/)
+
+## Installation
+
+```bash
+# Add the marketplace
+claude plugin marketplace add mattforni/homebase
+
+# Install the plugin
+claude plugin install linear-lifecycle@skillset
+```
+
+> **Migrating from `mattforni/skillset`?** The `skillset` marketplace moved to `mattforni/homebase`. Remove the old source first: `claude plugin marketplace remove skillset`, then follow the steps above.
+
+## Setup
+
+After installing the plugin, configure it:
+
+### Automated Setup (Recommended)
+
+Run the setup command in Claude Code:
+
+```
+/linear-setup
+```
+
+This will:
+
+1. Install the Linear CLI if not present (via `brew install schpet/tap/linear`)
+2. Authenticate with `linear auth login`
+3. Verify connection to Linear API
+
+### Manual Setup
+
+```bash
+# 1. Install Linear CLI
+brew install schpet/tap/linear
+
+# 2. Authenticate (requires API key from Linear Settings > Security & Access)
+linear auth login
+
+# 3. Verify connection
+linear issue list
+```
+
+## Usage Examples
+
+Once installed and configured, Claude will automatically use the linear-lifecycle skill when appropriate:
+
+### Start Work on an Issue
+
+```
+You: Start working on BET-123
+
+Claude: Fetching issue details...
+
+Issue: BET-123 - Implement dark mode toggle
+Status: Todo
+Description: Add dark mode toggle to settings page with persistent preference storage
+Labels: feature, ui
+Branch: bet-123-dark-mode-toggle
+
+Creating branch bet-123-dark-mode-toggle...
+```
+
+### Create a New Issue
+
+```
+You: Create a Linear issue for fixing the avatar crop bug
+
+Claude: Created issue BET-145: Fix avatar crop bug
+https://linear.app/your-workspace/issue/BET-145
+
+Avatar images are cropping incorrectly on mobile devices. Need to adjust aspect ratio handling.
+```
+
+### Update Issue Status
+
+```
+You: Update BET-456 to in progress
+
+Claude: Updated BET-456 to In Progress
+```
+
+### Add Comments
+
+```
+You: Add comment to BET-789 about the refactor being done
+
+Claude: Added comment to BET-789
+"Completed auth refactor. Moved from Context API to Zustand for better performance. All tests passing."
+```
+
+### Close Completed Work
+
+```
+You: Close BET-789, PR merged
+
+Claude: Added completion comment to BET-789
+Marked BET-789 as Done
+
+Feature complete. PR #456 merged to main.
+```
+
+## How It Works
+
+The skill:
+
+1. Executes Linear CLI commands with appropriate flags
+2. Parses output to extract relevant information
+3. Formats results cleanly for the user
+4. Never consumes context with MCP tool definitions
+
+## Performance Comparison
+
+### Before (Linear MCP)
+
+- 20k tokens consumed at session start
+- All tools loaded in context
+- Context budget: 180k/200k remaining (10% overhead)
+
+### After (Linear CLI via this plugin)
+
+- 0 tokens in session (just bash commands)
+- Lightweight per operation
+- Context budget: 200k/200k remaining (0% overhead)
+- **100% context savings**
+
+## Troubleshooting
+
+### Not Authenticated
+
+If you see authentication errors:
+
+1. Run `linear auth login`
+2. Provide your Linear API token
+3. Token source: **Linear Settings > Security & Access > Personal API keys**
+4. Verify with `linear issue list`
+
+### Linear CLI Not Installed
+
+```bash
+brew install schpet/tap/linear
+```
+
+## Credits
+
+- **Linear CLI**: [github.com/schpet/linear-cli](https://github.com/schpet/linear-cli) by schpet
+- **Plugin Author**: Matthew Fornaciari [@mattforni](https://github.com/mattforni)
+
+## License
+
+MIT License - see LICENSE for details
+
+## Support
+
+- Issues: [GitHub Issues](https://github.com/mattforni/homebase/issues)
+- Discussions: [GitHub Discussions](https://github.com/mattforni/homebase/discussions)

--- a/docs/plugins/sdlc.md
+++ b/docs/plugins/sdlc.md
@@ -1,0 +1,195 @@
+# sdlc
+
+Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.
+
+## Overview
+
+This plugin provides a complete workflow for managing the software development lifecycle with Claude Code. Each skill maps to a phase of development, creating a consistent and repeatable process.
+
+## Skills
+
+| Skill | Phase | Description |
+|-------|-------|-------------|
+| `/sdlc:plan` | Plan | Refine requirements on a Linear ticket through Socratic dialogue |
+| `/sdlc:design` | Design | Start work on an issue with branch setup and implementation design |
+| `/sdlc:checkpoint` | Implement | Save work in progress (commit + push, no PR) |
+| `/sdlc:review` | Review | Create PR and request code review |
+| `/sdlc:iterate` | Review | Address PR feedback, request re-review |
+| `/sdlc:complete` | Complete | Reset environment for next task |
+
+## Workflow
+
+The typical flow is:
+
+```text
+/sdlc:plan <issue-id>     # Refine requirements, build out ticket
+    ↓
+/sdlc:design <issue-id>   # Create branch, explore codebase, design approach
+    ↓
+[implement features]      # Write code
+    ↓
+/sdlc:checkpoint          # Save progress (optional, repeatable)
+    ↓
+/sdlc:review              # Create PR, request review
+    ↓
+/sdlc:iterate             # Address feedback (repeatable)
+    ↓
+/sdlc:complete            # Cleanup, ready for next task
+```
+
+## Installation
+
+```bash
+# Add the marketplace
+claude plugin marketplace add mattforni/homebase
+
+# Install the plugin
+claude plugin install sdlc@skillset
+```
+
+> **Migrating from `mattforni/skillset`?** The `skillset` marketplace moved to `mattforni/homebase`. Remove the old source first: `claude plugin marketplace remove skillset`, then follow the steps above.
+
+## Requirements
+
+- **Git** for version control
+- **GitHub CLI** (`gh`) for PR operations
+- **Linear CLI** (`linear`) for Linear integration (optional, used by plan/design/complete). Install via `brew install schpet/tap/linear`.
+
+## Skill Details
+
+### /sdlc:plan
+
+Refines requirements on a Linear ticket through Socratic dialogue:
+
+1. Fetches issue details from Linear
+2. Reads the current title and description
+3. Asks probing questions one at a time to surface requirements, context, and options
+4. Iteratively updates the Linear ticket body to build out the plan template (Overview, Requirements, Options, Recommendation, Open Questions)
+5. Continues until open questions are resolved and the ticket is ready for design
+
+The plan lives on the Linear ticket. No local files are created.
+
+**Usage:** `/sdlc:plan ATE-123`
+
+### /sdlc:design
+
+Starts work on an issue:
+
+1. Fetches issue details from Linear (if available)
+2. Prompts user to handle uncommitted changes (stash, commit, or abort)
+3. Sets up work environment based on branching strat:
+   - **worktree**: creates a new worktree directory with a feature branch (default)
+   - **branch**: checks out a new feature branch in the current directory
+4. Enters plan mode for implementation design
+5. Posts a design summary comment on the Linear ticket after approval
+6. Updates Linear status to "In Progress" after approval
+
+**Usage:** `/sdlc:design ATE-123` or `/sdlc:design feature-name`
+
+### /sdlc:checkpoint
+
+Saves work in progress without creating a PR:
+
+1. Verifies on feature branch
+2. Stages all changes
+3. Generates commit message (or uses provided message)
+4. Pushes to remote
+
+**Usage:** `/sdlc:checkpoint` or `/sdlc:checkpoint "WIP: auth refactor"`
+
+### /sdlc:review
+
+Creates a PR and requests review:
+
+1. Detects and removes dead code
+2. Creates commit with proper attribution
+3. Pushes and creates PR
+4. Requests code review (configurable command, defaults to `/gemini review`)
+
+**Usage:** `/sdlc:review`
+
+### /sdlc:iterate
+
+Addresses PR review feedback:
+
+1. Fetches all review comments
+2. Addresses each issue
+3. Commits and pushes
+4. Requests re-review (configurable command)
+
+**Usage:** `/sdlc:iterate` or `/sdlc:iterate 123`
+
+### /sdlc:complete
+
+Finishes work and resets environment:
+
+1. Verifies PR is merged
+2. Updates Linear issue to "Done"
+3. Cleans up based on how work was set up:
+   - **worktree**: removes the worktree directory and deletes the branch
+   - **branch**: checks out main, pulls latest, and deletes the branch
+4. Prunes remote tracking branches
+
+**Usage:** `/sdlc:complete`
+
+## Configuration
+
+All skills use `disable-model-invocation: true`, meaning they are only triggered by explicit user invocation (not automatically by Claude).
+
+### Branching Strat
+
+Controls how `/sdlc:design` sets up your working environment and how `/sdlc:complete` cleans up.
+
+| Strat | Behavior |
+|-------|----------|
+| `worktree` (default) | Creates an isolated worktree directory per task. Multiple tasks run in parallel without stashing or switching. |
+| `branch` | Traditional checkout. Switches the current directory to a new branch. One task at a time. |
+
+**Git config (recommended):**
+
+```bash
+# Set branching strat (default: worktree)
+git config sdlc.branch-strat worktree
+
+# Set worktree directory (default: .worktrees)
+git config sdlc.worktree-dir .worktrees
+```
+
+**Environment variables:**
+
+```bash
+export SDLC_BRANCH_STRAT="worktree"
+export SDLC_WORKTREE_DIR=".worktrees"
+```
+
+When using worktree mode, the plugin automatically adds the worktree directory to `.gitignore` on first use.
+
+### Review Command
+
+The review and iterate skills use a configurable review command. Configure via:
+
+**Git config (recommended):**
+
+```bash
+git config sdlc.review-command "/gemini review"
+```
+
+**Environment variable:**
+
+```bash
+export SDLC_REVIEW_COMMAND="/gemini review"
+```
+
+**Default:** `/gemini review`
+
+### Linear Integration
+
+The plan, design, and complete skills optionally integrate with Linear via the Linear CLI. If the CLI is installed and the issue ID looks like a Linear issue (e.g., `ATE-123`), the skills will:
+
+- Fetch issue details for context
+- Update issue status ("In Progress", "Done")
+- Post design summary comments
+
+Install via `brew install schpet/tap/linear` and authenticate with `linear auth login`.
+
+Without the Linear CLI, the design skill works with any branch name. The plan skill requires it.

--- a/plugins/linear-lifecycle/commands/linear-setup.md
+++ b/plugins/linear-lifecycle/commands/linear-setup.md
@@ -1,0 +1,10 @@
+---
+name: linear-setup
+description: Configure Linear API token and team key for the linear-lifecycle plugin
+---
+
+Copying setup command to clipboard...
+
+```bash
+echo "bash ~/.claude/plugins/marketplaces/skillset/plugins/linear-lifecycle/skills/linear-lifecycle/scripts/setup.sh" | pbcopy && echo "✓ Command copied to clipboard! Paste it in your terminal to run the setup."
+```

--- a/plugins/linear-lifecycle/plugin.json
+++ b/plugins/linear-lifecycle/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "linear-lifecycle",
+  "description": "Manage Linear issues via the Linear CLI with zero-context overhead.",
+  "version": "1.2.0",
+  "author": {
+    "name": "Matthew Fornaciari",
+    "url": "https://github.com/mattforni"
+  },
+  "repository": "https://github.com/mattforni/homebase",
+  "license": "MIT",
+  "keywords": ["linear", "issue-tracking", "cli", "workflow", "context-budget", "project-management"]
+}

--- a/plugins/linear-lifecycle/skills/linear-lifecycle/SKILL.md
+++ b/plugins/linear-lifecycle/skills/linear-lifecycle/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: linear-lifecycle
+description: Use when working with Linear issues, issue tracking, or project management. Uses the Linear CLI for zero-context issue management as a CLI alternative to MCP.
+---
+
+# Linear Lifecycle Management with Linear CLI
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Setup](#setup)
+- [When to Use](#when-to-use)
+- [Token Check](#token-check)
+- [Quick Reference](#quick-reference)
+- [Reference Files](#reference-files)
+
+## Overview
+
+**Core principle:** Use the Linear CLI for all Linear operations instead of loading the 20k token Linear MCP. CLI returns structured output for parsing without context overhead.
+
+**Tool:** [linear-cli](https://github.com/schpet/linear-cli) - Linear CLI with ~1000 token footprint vs 13k+ for MCP. Install via `brew install schpet/tap/linear`.
+
+**Context savings:** 100% at session start. No MCP loaded, just bash commands. See [advanced.md](reference/advanced.md) for the full comparison table.
+
+## Setup
+
+**One-time install:** Use `/linear-setup` to install the Linear CLI and authenticate (required for this skill to work).
+
+**Authentication:** Run `linear auth login` after creating an API key at linear.app/settings/account/security. See [troubleshooting.md](reference/troubleshooting.md) for auth issues.
+
+**Get your token:** Linear Settings > Security & Access > Personal API keys
+
+## When to Use
+
+**Use this skill when:**
+
+- Starting work on a Linear issue (need issue details)
+- Creating new issues from bugs or features discovered
+- Updating issue status during development
+- Adding comments or progress updates
+- Searching for issues across teams/projects
+
+**Don't use when:**
+
+- Issue tracking not needed for current work
+- Working on non-Linear projects
+
+## Token Check
+
+**IMPORTANT: Always verify auth on first Linear operation in a skill invocation:**
+
+```bash
+linear issue list
+```
+
+If the command fails with an auth error, prompt the user to run `linear auth login` and provide their API token.
+
+## Quick Reference
+
+| Operation | Command Pattern |
+|-----------|----------------|
+| List recent issues | `linear issue list` |
+| Get issue details | `linear issue view ABC-123` |
+| Create issue | `linear issue create -t "Title" -d "Desc" --team TEAM_KEY` |
+| Update status | `linear issue update ABC-123 -s "In Progress"` |
+| Add comment | `linear issue comment add ABC-123 "Comment text"` |
+| List teams | `linear team list` |
+
+**Key rules for issue creation:**
+
+- Use `--team TEAM_KEY` (e.g. BET, ENG)
+- Use `-t` for title, `-d` for description
+- Use `-s` for state changes on update
+
+## Reference Files
+
+Detailed walkthroughs, troubleshooting, and advanced usage are in reference files that load on demand:
+
+- [Command Examples](reference/examples.md) - Step-by-step walkthroughs for each operation
+- [Troubleshooting](reference/troubleshooting.md) - Common mistakes, error handling patterns, and auth setup issues
+- [Advanced Usage](reference/advanced.md) - Multi-team operations and context budget comparison table

--- a/plugins/linear-lifecycle/skills/linear-lifecycle/reference/advanced.md
+++ b/plugins/linear-lifecycle/skills/linear-lifecycle/reference/advanced.md
@@ -1,0 +1,44 @@
+# Advanced Usage
+
+Multi-team operations, context budget analysis, and performance comparisons.
+
+## Multi-Team Operations
+
+The Linear CLI accepts `--team` for cross-team operations within the same Linear workspace. No workspace switching needed.
+
+**List issues for a specific team:**
+
+```bash
+linear issue list --team Frontend
+```
+
+```bash
+linear issue list --team Backend
+```
+
+**Create issue in a specific team:**
+
+```bash
+linear issue create -t "Fix API timeout" --team Backend -d "API requests timing out after 30s under load."
+```
+
+## Context Budget Comparison
+
+| Metric | Linear MCP | Linear CLI | Savings |
+|--------|-----------|------------|---------|
+| Tokens at session start | ~20,000 | 0 | 100% |
+| Tool definitions loaded | All Linear tools | None (bash only) | 100% |
+| Reference material size | ~13,000 tokens | ~1,000 tokens | 92% |
+| Context budget remaining | 180k / 200k | 200k / 200k | +20k tokens |
+
+**Key insight:** MCP loads all tool definitions into context immediately. The Linear CLI uses zero context at session start. Reference material (this skill) loads on demand and is 92% smaller than MCP tool definitions.
+
+## When to Use MCP Instead
+
+The Linear CLI covers the most common Linear operations. Consider the Linear MCP if you need:
+
+- Webhook management
+- Custom view creation
+- Batch operations across hundreds of issues
+- Integration configuration
+- Advanced filtering with Linear's query language

--- a/plugins/linear-lifecycle/skills/linear-lifecycle/reference/examples.md
+++ b/plugins/linear-lifecycle/skills/linear-lifecycle/reference/examples.md
@@ -1,0 +1,106 @@
+# Command Examples
+
+Detailed walkthroughs for each Linear CLI operation.
+
+## Creating Issues
+
+**User request:** "Create a Linear issue for fixing the avatar crop bug"
+
+**Command:**
+
+```bash
+linear issue create -t "Fix avatar crop bug" \
+  --team BET \
+  -d "Avatar images are cropping incorrectly on mobile devices. Need to adjust aspect ratio handling."
+```
+
+**Key rules:**
+
+- Use `--team TEAM_KEY` (get from user's Linear workspace, e.g. BET, ENG)
+- Use `-t` for title, `-d` for description
+- Keep description clear and concise
+
+**Response to user:**
+
+```markdown
+Created issue BET-145: Fix avatar crop bug
+https://linear.app/your-workspace/issue/BET-145
+```
+
+## Starting Work on an Issue
+
+**User request:** "Start working on bet-123"
+
+**Command:**
+
+```bash
+linear issue view BET-123
+```
+
+**Response to user:**
+
+```markdown
+Issue: BET-123 - Implement dark mode toggle
+Status: Todo
+Description: Add a toggle in settings to switch between light and dark themes.
+Labels: feature, ui
+
+Creating branch bet-123-implement-dark-mode-toggle...
+```
+
+Then create the branch and proceed with development.
+
+## Updating Issue Status
+
+**User request:** "Update bet-456 to in progress"
+
+**Command:**
+
+```bash
+linear issue update BET-456 -s "In Progress"
+```
+
+**Response to user:**
+
+```markdown
+Updated BET-456 to In Progress
+```
+
+## Adding Comments
+
+**User request:** "Add comment to bet-789 about the refactor being done"
+
+**Command:**
+
+```bash
+linear issue comment add BET-789 "Comment text here"
+```
+
+**Response to user:**
+
+```markdown
+Added comment to BET-789
+```
+
+## Completing Work
+
+**User request:** "Close bet-789, PR merged"
+
+**Step 1: Add completion comment:**
+
+```bash
+linear issue comment add BET-789 "Comment text here"
+```
+
+**Step 2: Update status to done:**
+
+```bash
+linear issue update BET-789 -s "Done"
+```
+
+**Response to user:**
+
+```markdown
+Marked BET-789 as Done
+Added completion comment
+```

--- a/plugins/linear-lifecycle/skills/linear-lifecycle/reference/troubleshooting.md
+++ b/plugins/linear-lifecycle/skills/linear-lifecycle/reference/troubleshooting.md
@@ -1,0 +1,70 @@
+# Troubleshooting
+
+Common mistakes, error handling patterns, and auth setup issues for the Linear CLI.
+
+## Common Mistakes
+
+### Hardcoding Team or Project Names
+
+- Don't assume team structure
+- Let the user specify or discover via Linear commands
+
+```bash
+# Discover available teams
+linear team list
+```
+
+### Using Issue IDs Incorrectly
+
+- Don't lowercase (bet-123) in commands
+- Use proper case (BET-123) for consistency
+- The CLI handles both, but uppercase is the convention
+
+## Auth Setup Issues
+
+### Not Authenticated
+
+If commands fail with authentication errors:
+
+1. Run `linear auth login`
+2. Provide your Linear API token
+3. Get a token from: **Linear Settings > Security & Access > Personal API keys**
+4. Verify the connection with `linear issue list`
+
+### Token Invalid or Expired
+
+If commands return authentication errors:
+
+1. Re-authenticate with `linear auth login`
+2. Generate a new token in Linear settings if needed
+3. Test with a simple command: `linear issue list`
+
+### Permission Errors
+
+If auth works but certain operations fail:
+
+- The token may lack write permissions
+- The user's Linear role may restrict certain operations
+- Confirm the user has appropriate access in their Linear workspace
+
+## Error Handling Patterns
+
+### Command Failures
+
+Always check for non-zero exit codes. Common failure modes:
+
+| Error | Likely Cause | Resolution |
+|-------|-------------|------------|
+| Authentication error | Invalid or expired token | Run `linear auth login` |
+| Not found | Wrong issue ID or team key | Verify the identifier |
+| Rate limited | Too many requests | Wait and retry |
+| Network error | Connectivity issue | Check internet connection |
+
+### Graceful Degradation
+
+When a Linear CLI command fails mid-workflow:
+
+1. Report the specific error to the user
+2. Do not retry silently
+3. Suggest the most likely fix based on the error message
+4. Offer to continue with remaining operations that don't depend on the failed one

--- a/plugins/linear-lifecycle/skills/linear-lifecycle/scripts/setup.sh
+++ b/plugins/linear-lifecycle/skills/linear-lifecycle/scripts/setup.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Linear Lifecycle - Simple Setup Script
+# Installs the Linear CLI and authenticates with Linear
+
+set -e
+
+echo "Linear Lifecycle Setup"
+echo ""
+
+# Step 1: Check/Install Linear CLI
+echo "Step 1: Checking Dependencies..."
+if ! command -v linear &> /dev/null; then
+  command -v brew > /dev/null 2>&1 || { echo "  Error: Homebrew is required. Install it from https://brew.sh/" >&2; exit 1; }
+  echo "  Linear CLI not found. Installing via Homebrew..."
+  brew install schpet/tap/linear
+  echo "  Done: Linear CLI installed"
+else
+  echo "  Done: Linear CLI already installed"
+fi
+
+echo ""
+
+# Step 2: Authenticate
+echo "Step 2: Authenticating with Linear..."
+echo ""
+echo "  You will need a Linear API key."
+echo "  Get one from: Linear Settings > Security & Access > Personal API keys"
+echo ""
+
+linear auth login
+
+echo ""
+
+# Step 3: Verify connection
+echo "Step 3: Verifying connection..."
+if TEST_RESPONSE=$(linear issue list 2>&1); then
+  echo "  Done: Successfully connected to Linear API"
+
+  echo ""
+  echo "Setup complete!"
+  echo ""
+  echo "Next steps:"
+  echo "  List issues:  linear issue list"
+  echo "  View issue:   linear issue view BET-123"
+  echo "  Or just ask Claude to manage Linear issues!"
+else
+  echo "  Warning: Failed to connect to Linear API"
+  echo "     Error: $TEST_RESPONSE"
+  echo ""
+  echo "     Please verify your token is correct."
+  echo ""
+  echo "To re-authenticate, run: linear auth login"
+  exit 1
+fi

--- a/plugins/sdlc/README.md
+++ b/plugins/sdlc/README.md
@@ -1,0 +1,31 @@
+# SDLC Plugin
+
+Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.
+
+## Quick Start
+
+```bash
+claude plugin marketplace add mattforni/homebase
+claude plugin install sdlc@skillset
+```
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| `/sdlc:plan` | Refine requirements on a Linear ticket through Socratic dialogue |
+| `/sdlc:design` | Start work on an issue with branch setup and implementation design |
+| `/sdlc:checkpoint` | Save work in progress (commit + push, no PR) |
+| `/sdlc:review` | Create PR and request code review |
+| `/sdlc:iterate` | Address PR feedback, request re-review |
+| `/sdlc:complete` | Reset environment for next task |
+
+## Workflow
+
+```text
+/sdlc:plan <issue-id> → /sdlc:design <issue-id> → [implement] → (/sdlc:checkpoint)* → /sdlc:review → (/sdlc:iterate)* → /sdlc:complete
+```
+
+## Full Documentation
+
+See [docs/plugins/sdlc.md](../../docs/plugins/sdlc.md) for detailed usage, configuration options, and skill documentation.

--- a/plugins/sdlc/plugin.json
+++ b/plugins/sdlc/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "sdlc",
+  "description": "Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.",
+  "version": "2.0.0",
+  "author": {
+    "name": "Matthew Fornaciari",
+    "url": "https://github.com/mattforni"
+  },
+  "repository": "https://github.com/mattforni/homebase",
+  "license": "MIT",
+  "keywords": ["sdlc", "workflow", "git", "pr", "review", "development", "lifecycle"]
+}

--- a/plugins/sdlc/reference/common-patterns.md
+++ b/plugins/sdlc/reference/common-patterns.md
@@ -1,0 +1,94 @@
+# Common Patterns
+
+Shared procedures used across multiple SDLC skills. Referenced from individual SKILL.md files.
+
+In all bash steps below, substitute placeholder names (like BASE_BRANCH, CURRENT_BRANCH, etc.) with the actual values you stored earlier. Each placeholder appears in ALL_CAPS. Run commands separately; do not chain with `&&` or use `$()`.
+
+## Branch Verification
+
+Determine the base (default) branch and the current branch:
+
+```bash
+../../scripts/get-base-branch.sh
+```
+
+Store the output as BASE_BRANCH.
+
+```bash
+git branch --show-current
+```
+
+Store the output as CURRENT_BRANCH.
+
+## Commit and Push
+
+Stage all changes:
+
+```bash
+git add -A
+```
+
+Analyze the staged changes to generate an appropriate commit message:
+
+- Summarize the nature of changes (feature, fix, refactor, etc.)
+- Focus on the "why" rather than the "what"
+- Keep it concise (1-2 sentences)
+
+If the user provided a message, use it as the commit message.
+
+Use a HEREDOC to commit so multiline messages and special characters are handled cleanly:
+
+```bash
+git commit -m "$(cat <<'EOF'
+<commit message here>
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+Push to remote:
+
+```bash
+git push -u origin HEAD
+```
+
+## Review Command Lookup
+
+Get the configured review command for requesting re-review:
+
+```bash
+../../scripts/get-review-command.sh
+```
+
+Store the output as REVIEW_CMD. This checks git config, then env var, then defaults to `/gemini review`.
+
+## Branching Strat Lookup
+
+Determine the configured branching strategy (used by `plan` to decide how to set up the work environment):
+
+```bash
+../../scripts/get-branch-strat.sh
+```
+
+Store the output as BRANCH_STRAT (`worktree` or `branch`).
+
+## Linked Worktree Detection
+
+Check if the current directory is a linked worktree (used by `complete` to decide cleanup strategy). Compare the git dir with the common dir. They differ in a linked worktree and match in the main working tree:
+
+```bash
+git rev-parse --git-dir
+```
+
+```bash
+git rev-parse --git-common-dir
+```
+
+If the two outputs are different, the current directory is a linked worktree. The main worktree can be found via:
+
+```bash
+git worktree list --porcelain
+```
+
+The first line has the format `worktree /path/to/main`. Extract the path to get the main worktree location.

--- a/plugins/sdlc/scripts/get-base-branch.sh
+++ b/plugins/sdlc/scripts/get-base-branch.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Get the default branch name from the remote
+# Usage: BASE_BRANCH=$(./scripts/get-base-branch.sh)
+
+BASE=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+if [ -z "$BASE" ]; then
+  # Fallback to parsing 'git remote show origin'
+  BASE=$(git remote show origin 2>/dev/null | sed -n 's/^  HEAD branch: //p')
+fi
+
+if [ -z "$BASE" ]; then
+  echo "Error: Could not determine the default branch." >&2
+  exit 1
+fi
+
+echo "$BASE"

--- a/plugins/sdlc/scripts/get-branch-strat.sh
+++ b/plugins/sdlc/scripts/get-branch-strat.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Get the configured branching strat from git config, env var, or default
+# Usage: ../../scripts/get-branch-strat.sh
+# Checks: git config sdlc.branch-strat > $SDLC_BRANCH_STRAT > "worktree"
+# Valid values: "worktree", "branch"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+STRAT=$("$SCRIPT_DIR/get-config.sh" sdlc.branch-strat SDLC_BRANCH_STRAT worktree)
+
+case "$STRAT" in
+  worktree|branch)
+    ;;
+  *)
+    echo "Error: Invalid branch strat '$STRAT'. Must be 'worktree' or 'branch'." >&2
+    exit 1
+    ;;
+esac
+
+echo "$STRAT"

--- a/plugins/sdlc/scripts/get-config.sh
+++ b/plugins/sdlc/scripts/get-config.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Generic config value lookup: git config > env var > default
+# Usage: ../../scripts/get-config.sh <git-config-key> <env-var-name> <default-value>
+# Example: ../../scripts/get-config.sh sdlc.branch-strat SDLC_BRANCH_STRAT worktree
+
+if [ $# -lt 3 ]; then
+  echo "Usage: get-config.sh <git-config-key> <env-var-name> <default-value>" >&2
+  exit 1
+fi
+
+GIT_KEY="$1"
+ENV_VAR="$2"
+DEFAULT="$3"
+
+VALUE=$(git config --get "$GIT_KEY" 2>/dev/null)
+if [ -z "$VALUE" ]; then
+  env_val=${!ENV_VAR}
+  VALUE=${env_val:-"$DEFAULT"}
+fi
+
+echo "$VALUE"

--- a/plugins/sdlc/scripts/get-linear-issue-id.sh
+++ b/plugins/sdlc/scripts/get-linear-issue-id.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Extract a Linear issue ID from the given input string
+# Usage: ../../scripts/get-linear-issue-id.sh "feature/ATE-123-description"
+# Outputs the issue ID (e.g., "ATE-123") or exits with code 1 if no match
+
+INPUT="$1"
+if [ -z "$INPUT" ]; then
+  echo "Error: No input provided." >&2
+  exit 1
+fi
+
+if [[ "$INPUT" =~ [a-zA-Z]+-[0-9]+ ]]; then
+  ISSUE_ID=$(echo "${BASH_REMATCH[0]}" | tr '[:lower:]' '[:upper:]')
+  echo "$ISSUE_ID"
+else
+  echo "Error: No Linear issue ID found in '$INPUT'." >&2
+  exit 1
+fi

--- a/plugins/sdlc/scripts/get-review-command.sh
+++ b/plugins/sdlc/scripts/get-review-command.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Get the configured review command from git config, env var, or default
+# Usage: ../../scripts/get-review-command.sh
+# Checks: git config sdlc.review-command > $SDLC_REVIEW_COMMAND > "/gemini review"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SCRIPT_DIR/get-config.sh" sdlc.review-command SDLC_REVIEW_COMMAND "/gemini review"

--- a/plugins/sdlc/scripts/get-worktree-dir.sh
+++ b/plugins/sdlc/scripts/get-worktree-dir.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Get the configured worktree directory from git config, env var, or default
+# Usage: ../../scripts/get-worktree-dir.sh
+# Checks: git config sdlc.worktree-dir > $SDLC_WORKTREE_DIR > ".worktrees"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DIR=$("$SCRIPT_DIR/get-config.sh" sdlc.worktree-dir SDLC_WORKTREE_DIR ".worktrees")
+
+# Reject directory traversal and absolute paths
+case "$DIR" in
+  /*|-*|..|*/..|../*|*/../*|*\$*|*[[:space:]]*|*[\[\]?*]*)
+    echo "Error: Invalid worktree directory '$DIR'. Must be a relative path without leading hyphens, '..', spaces, glob characters, or shell variables." >&2
+    exit 1
+    ;;
+esac
+
+echo "$DIR"

--- a/plugins/sdlc/scripts/sanitize-branch-name.sh
+++ b/plugins/sdlc/scripts/sanitize-branch-name.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Sanitize input into a valid git branch name
+# Usage: ../../scripts/sanitize-branch-name.sh "ATE-123 My Feature Name"
+# Outputs the sanitized branch name or exits with code 1 if invalid
+
+INPUT="$1"
+if [ -z "$INPUT" ]; then
+  echo "Error: No input provided." >&2
+  exit 1
+fi
+
+BRANCH_NAME=$(echo "$INPUT" | tr -s '[:space:]' '-' | tr -cd '[:alnum:]-./_')
+if [ -z "$BRANCH_NAME" ]; then
+  echo "Error: Could not create a valid branch name from '$INPUT'." >&2
+  exit 1
+fi
+
+if ! git check-ref-format --branch "$BRANCH_NAME" >/dev/null 2>&1; then
+  echo "Error: '$BRANCH_NAME' is not a valid git branch name." >&2
+  exit 1
+fi
+
+echo "$BRANCH_NAME"

--- a/plugins/sdlc/skills/checkpoint/SKILL.md
+++ b/plugins/sdlc/skills/checkpoint/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: sdlc:checkpoint
+description: Save work in progress with commit and push (no PR). Use this when the user wants to save progress, push a checkpoint, or back up current work without creating a pull request.
+argument-hint: [optional commit message]
+allowed-tools:
+  - Bash(git *)
+  - Bash(*get-base-branch.sh*)
+  - Grep
+  - Read
+---
+
+# Checkpoint
+
+Save current work in progress to remote. Creates a commit and pushes but does not create a PR. This is useful for backing up work, switching contexts, or sharing progress before a formal review.
+
+## Workflow
+
+1. **Verify branch state** on a feature branch, not main
+2. **Check for changes** to confirm there is something to commit
+3. **Commit and push** to remote
+
+## Step 1: Verify Branch State
+
+Follow [Branch Verification](../../reference/common-patterns.md#branch-verification).
+
+If CURRENT_BRANCH equals BASE_BRANCH, stop with error: "Cannot checkpoint on default branch. Create a feature branch first."
+
+## Step 2: Check for Changes
+
+```bash
+git status --porcelain
+```
+
+If output is empty, stop: "No changes to checkpoint. Working directory is clean."
+
+Show the user what will be committed:
+
+```bash
+git diff --stat
+```
+
+## Step 3: Commit and Push
+
+Follow [Commit and Push](../../reference/common-patterns.md#commit-and-push).
+
+## Output
+
+```
+Checkpoint saved to <branch-name>
+Commit: <short-hash> <message>
+```

--- a/plugins/sdlc/skills/complete/SKILL.md
+++ b/plugins/sdlc/skills/complete/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: sdlc:complete
+description: Finish work and reset local environment for next task. Use this when the user is done with a feature branch, wants to clean up after a merged PR, or needs to reset their workspace.
+allowed-tools:
+  - Bash(git *)
+  - Bash(gh *)
+  - Bash(linear *)
+  - Bash(*get-base-branch.sh*)
+  - Bash(test *)
+  - Bash(*get-linear-issue-id.sh*)
+---
+
+# Complete Work
+
+Finish the current task and reset the local environment for the next piece of work.
+
+In all bash steps below, substitute placeholder names (like BASE_BRANCH, CURRENT_BRANCH, etc.) with the actual values you stored earlier.
+
+## Workflow
+
+1. **Verify PR is merged** to confirm the work is done
+2. **Update Linear issue** to Done (if applicable)
+3. **Detect environment and cleanup** worktree or branch
+4. **Prune stale branches** that have been merged remotely
+5. **Confirm clean state**
+
+## Step 1: Verify PR is Merged
+
+Follow [Branch Verification](../../reference/common-patterns.md#branch-verification).
+
+If CURRENT_BRANCH equals BASE_BRANCH, note "Already on default branch" and skip to Step 4.
+
+Otherwise, check PR status:
+
+```bash
+gh pr view --json state --jq '.state'
+```
+
+Store the output as PR_STATE (or "NONE" if the command fails).
+
+- If OPEN: warn the user the PR is still open and ask if they want to continue anyway
+- If MERGED: note "PR merged successfully"
+- If NONE: note "No PR found for branch" and proceed
+
+## Step 2: Update Linear Issue
+
+Try to extract a Linear issue ID from the branch name:
+
+```bash
+../../scripts/get-linear-issue-id.sh "CURRENT_BRANCH"
+```
+
+If it succeeds, store the output as ISSUE_ID and update:
+
+```bash
+linear issue update ISSUE_ID -s "Done"
+```
+
+If the Linear CLI is not available or the command fails, continue silently.
+
+## Step 3: Detect Environment and Cleanup
+
+Follow [Linked Worktree Detection](../../reference/common-patterns.md#linked-worktree-detection) to determine if the current directory is a linked worktree. Then follow the matching case below.
+
+### Case A: Linked worktree with SDLC marker
+
+Applies when worktree detection indicates a linked worktree AND the marker file exists:
+
+```bash
+test -f .sdlc-worktree
+```
+
+Get the current worktree path:
+
+```bash
+git rev-parse --show-toplevel
+```
+
+Store as WORKTREE_PATH. Get the main worktree path:
+
+```bash
+git worktree list --porcelain
+```
+
+The first line has the format `worktree /path/to/main`. Extract the path and store as MAIN_WORKTREE.
+
+Remove the worktree:
+
+```bash
+git -C "MAIN_WORKTREE" worktree remove "WORKTREE_PATH"
+```
+
+If this fails because the worktree has uncommitted changes, inform the user and advise manual cleanup. Do not force-remove, as that risks losing work.
+
+### Case B: Linked worktree without SDLC marker
+
+This worktree was not created by `sdlc:design`. Warn the user and advise manual cleanup. Do not attempt any removal.
+
+### Case C: Main working tree
+
+Switch back to the default branch and clean up the feature branch:
+
+```bash
+git checkout "BASE_BRANCH"
+```
+
+```bash
+git pull origin "BASE_BRANCH"
+```
+
+```bash
+git branch -d "CURRENT_BRANCH"
+```
+
+The `-d` flag (lowercase) only deletes if the branch is fully merged, which is a safety net against accidental deletion of unmerged work.
+
+## Step 4: Prune Stale Branches
+
+From the main worktree, clean up remote tracking branches that no longer exist:
+
+```bash
+git fetch --prune
+```
+
+List branches to identify those whose remote was deleted after merge:
+
+```bash
+git branch -vv
+```
+
+For each branch showing `[gone]` in the output, delete it:
+
+```bash
+git branch -d <branch-name-here>
+```
+
+## Step 5: Confirm Reset
+
+```bash
+git worktree list
+```
+
+```bash
+git branch --show-current
+```
+
+```bash
+git status --short
+```
+
+## Output
+
+```
+Environment reset complete
+Branch: main
+Status: (clean)
+
+Ready for next task. Use /sdlc:design <issue-id> to start.
+```

--- a/plugins/sdlc/skills/design/SKILL.md
+++ b/plugins/sdlc/skills/design/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: sdlc:design
+description: Start work on an issue with branch setup and implementation design. Use this whenever the user wants to begin a new task, start on a ticket, or set up a feature branch for development work.
+argument-hint: <issue-id>
+allowed-tools:
+  - Bash(git *)
+  - Bash(linear *)
+  - Bash(*get-base-branch.sh*)
+  - Bash(*get-branch-strat.sh*)
+  - Bash(*get-linear-issue-id.sh*)
+  - Bash(*get-worktree-dir.sh*)
+  - Bash(*sanitize-branch-name.sh*)
+  - Bash(grep *)
+  - Bash(echo *)
+  - Bash(mkdir *)
+  - Read
+  - TodoWrite
+  - ExitPlanMode
+  - AskUserQuestion
+---
+
+# Start Design
+
+Starting work on issue $ARGUMENTS. Setting up git branch and fetching issue details.
+
+In all bash steps below, substitute placeholder names (like BASE_BRANCH, BRANCH_NAME, etc.) with the actual values you stored earlier. Each placeholder appears in ALL_CAPS.
+
+## Workflow
+
+1. **Fetch issue details** from Linear (optional)
+2. **Handle uncommitted changes** if any exist
+3. **Set up work environment** (worktree or branch)
+4. **Enter plan mode** for implementation design
+
+## Step 1: Fetch Issue Details
+
+Try to extract a Linear issue ID from the argument:
+
+```bash
+../../scripts/get-linear-issue-id.sh "$ARGUMENTS"
+```
+
+If the script succeeds, store the output as ISSUE_ID and fetch the full issue:
+
+```bash
+linear issue view ISSUE_ID
+```
+
+Parse and display:
+
+- **Issue ID and Title**
+- **Description** (full text)
+- **Current Status**
+- **Labels** (if any)
+
+If the Linear CLI is not installed or the fetch fails, continue without issue details. The user can provide context manually.
+
+## Step 2: Handle Uncommitted Changes
+
+```bash
+git status --porcelain
+```
+
+If output is non-empty, use AskUserQuestion to prompt:
+
+- **Stash changes** to save them and continue
+- **Commit changes** to create a quick commit first
+- **Abort** to stop and let the user handle it
+
+If clean, proceed.
+
+## Step 3: Set Up Work Environment
+
+Follow [Branch Verification](../../reference/common-patterns.md#branch-verification) to get BASE_BRANCH and CURRENT_BRANCH.
+
+Sanitize the argument into a valid branch name:
+
+```bash
+../../scripts/sanitize-branch-name.sh "$ARGUMENTS"
+```
+
+Store the output as BRANCH_NAME. Check if it already exists:
+
+```bash
+git rev-parse --verify "BRANCH_NAME"
+```
+
+If the branch exists, use AskUserQuestion:
+
+- **Use existing branch** to check it out
+- **Choose a different name** to provide a new one
+- **Abort** to stop
+
+Determine the branching strategy:
+
+```bash
+../../scripts/get-branch-strat.sh
+```
+
+Store the output as BRANCH_STRAT. Fetch the latest from remote:
+
+```bash
+git fetch origin "BASE_BRANCH"
+```
+
+### If BRANCH_STRAT is "worktree"
+
+Get the worktree directory:
+
+```bash
+../../scripts/get-worktree-dir.sh
+```
+
+Store the output as WORKTREE_DIR.
+
+Ensure the worktree directory is in `.gitignore`:
+
+```bash
+test -f .gitignore && grep -qxF "WORKTREE_DIR/" .gitignore
+```
+
+If the command exits non-zero (file missing or pattern not found), append it:
+
+```bash
+echo "WORKTREE_DIR/" >> .gitignore
+```
+
+Ensure the parent directory exists:
+
+```bash
+mkdir -p "WORKTREE_DIR"
+```
+
+Create the worktree with a new branch based on the latest remote:
+
+```bash
+git worktree add "WORKTREE_DIR/BRANCH_NAME" -b "BRANCH_NAME" origin/"BASE_BRANCH"
+```
+
+Report to the user: "Worktree created at WORKTREE_DIR/BRANCH_NAME"
+
+Create a marker file so `sdlc:complete` knows this worktree is SDLC-managed:
+
+```bash
+echo "" > "WORKTREE_DIR/BRANCH_NAME/.sdlc-worktree"
+```
+
+### If BRANCH_STRAT is "branch"
+
+```bash
+git checkout -b "BRANCH_NAME" origin/"BASE_BRANCH"
+```
+
+## Step 4: Create Implementation Plan
+
+You are now in **plan mode**. Your task is to:
+
+1. **Understand the requirement** from the issue description
+2. **Explore the codebase** to understand relevant files and patterns
+3. **Design the implementation approach**
+4. **Create a detailed plan** using TodoWrite with specific tasks
+5. **Present the plan to the user** for approval
+
+Do not start implementing until the user approves. The plan exists so the user can course-correct before any code is written. When the plan is ready, use ExitPlanMode to request approval.
+
+After approval, if a valid ISSUE_ID was found in Step 1, check if the Linear CLI is available:
+
+```bash
+command -v linear
+```
+
+If the command fails, skip the Linear updates and continue. Otherwise:
+
+Write a design summary capturing the planning iterations, key decisions, and the chosen approach. Structure it as:
+
+- **Summary**: One to two sentences on what will be built and why
+- **Key decisions**: Bulleted list of choices made during planning and the reasoning
+- **Approach**: The implementation strategy in brief
+
+Post the summary as a comment on the ticket:
+
+```bash
+linear issue comment add ISSUE_ID "DESIGN_SUMMARY"
+```
+
+Then update the issue status:
+
+```bash
+linear issue update ISSUE_ID -s "In Progress"
+```

--- a/plugins/sdlc/skills/iterate/SKILL.md
+++ b/plugins/sdlc/skills/iterate/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: sdlc:iterate
+description: Address PR review feedback and request re-review. Use this when the user needs to handle PR comments, respond to code review, or iterate on feedback from reviewers.
+argument-hint: [PR number - auto-detected if on feature branch]
+allowed-tools:
+  - Bash(git *)
+  - Bash(gh *)
+  - Bash(*get-review-command.sh*)
+  - Grep
+  - Read
+  - Edit
+---
+
+# Iterate on PR Feedback
+
+Fetch review comments, address each issue, and request re-review.
+
+In all bash steps below, substitute placeholder names (like PR_NUMBER, REVIEW_CMD, etc.) with the actual values you stored earlier.
+
+## Workflow
+
+1. **Identify PR** from branch or argument
+2. **Fetch review comments** focusing on new and unresolved feedback
+3. **Address each comment** with fixes
+4. **Commit and push** changes
+5. **Request re-review** with a summary of what was addressed
+
+## Step 1: Identify PR
+
+If `$ARGUMENTS` is provided, use it as PR_NUMBER. Otherwise, detect from the current branch:
+
+```bash
+gh pr view --json number --jq '.number'
+```
+
+If neither produces a PR number, stop with error: "No PR found for current branch".
+
+Get the repo identifier for API calls:
+
+```bash
+gh repo view --json nameWithOwner --jq '.nameWithOwner'
+```
+
+Store the output as REPO (format: `owner/repo`).
+
+## Step 2: Fetch Review Comments
+
+Only address **new or unresolved** comments. Previously resolved feedback should not be re-addressed, as doing so wastes time and can create confusion. If it is unclear which comments are new, ask the user.
+
+Get inline review comments:
+
+```bash
+gh api repos/REPO/pulls/PR_NUMBER/comments --jq '.[] | {id: .id, path: .path, line: .line, body: .body, author: .author.login, created_at: .created_at}'
+```
+
+Get review-level summaries:
+
+```bash
+gh pr view PR_NUMBER --json reviews --jq '.reviews[] | {author: .author.login, body: .body, state: .state}'
+```
+
+Also check for general PR comments (not attached to specific lines):
+
+```bash
+gh api repos/REPO/issues/PR_NUMBER/comments --jq '.[] | {id: .id, body: .body, author: .author.login, created_at: .created_at}'
+```
+
+Filter out comments that have already been addressed in previous iterations. Look for resolved threads and your own reply comments as signals that work is done.
+
+Triage the remaining comments by impact:
+
+- **High priority**: bugs, security issues, data loss risks, correctness problems
+- **Medium priority**: design improvements, best practices, performance
+- **Low priority**: style, formatting, naming nitpicks
+
+Address high priority items first. This ordering matters because if something blocks you, the most important fixes are already done.
+
+## Step 3: Address Each Comment
+
+For each unresolved comment:
+
+1. Read the file at the referenced path and line to understand context
+2. Apply the fix or improvement
+3. If the suggestion is ambiguous, make a reasonable interpretation and note it in the summary
+4. Track which comments were addressed and which need clarification
+
+If you disagree with a suggestion, still note it in the summary so the reviewer knows it was considered.
+
+## Step 4: Commit and Push
+
+Follow [Commit and Push](../../reference/common-patterns.md#commit-and-push).
+
+## Step 5: Request Re-Review
+
+Get the configured review command:
+
+```bash
+../../scripts/get-review-command.sh
+```
+
+Store the output as REVIEW_CMD.
+
+Post a summary comment on the PR listing what was addressed. This helps the reviewer quickly see what changed without re-reading the entire diff:
+
+```bash
+gh pr comment PR_NUMBER --body "$(cat <<'EOF'
+## Feedback Addressed
+
+- bullet list of changes made per comment
+
+REVIEW_CMD
+EOF
+)"
+```
+
+Replace the bullet list content and REVIEW_CMD with actual values.
+
+## Output
+
+```
+PR #<number> updated
+Addressed <N> review comments
+Re-review requested via: <REVIEW_CMD>
+```

--- a/plugins/sdlc/skills/plan/SKILL.md
+++ b/plugins/sdlc/skills/plan/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: sdlc:plan
+description: Refine requirements on a Linear ticket through Socratic dialogue. Use this when the user wants to think through a problem, clarify requirements, or evaluate options before starting design work.
+argument-hint: <issue-id>
+allowed-tools:
+  - Bash(linear *)
+  - Bash(*get-linear-issue-id.sh*)
+  - Read
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Plan
+
+Refining requirements for $ARGUMENTS through Socratic dialogue.
+
+In all bash steps below, substitute placeholder names (like ISSUE_ID) with the actual values you stored earlier.
+
+## Workflow
+
+1. **Fetch issue details** from Linear
+2. **Understand current state** of the ticket
+3. **Engage in Socratic dialogue** to surface requirements and evaluate options
+4. **Iteratively update the ticket** as clarity emerges
+5. **Confirm readiness** for the design phase
+
+## Step 1: Fetch Issue Details
+
+Extract the Linear issue ID from the argument:
+
+```bash
+../../scripts/get-linear-issue-id.sh "$ARGUMENTS"
+```
+
+Store the output as ISSUE_ID. Fetch the full issue:
+
+```bash
+linear issue view ISSUE_ID
+```
+
+If the fetch fails, inform the user that the plan skill requires a valid Linear issue ID and stop.
+
+## Step 2: Understand Current State
+
+Display the issue title and description to the user. Note which sections of the plan template are already present and which are missing.
+
+**Plan template sections:**
+
+- **Overview** — One to three sentences. What are we doing and why.
+- **Requirements** — Bulleted list of what must be true when this work is done.
+- **Options** — For each viable approach: name, one-sentence description, trade-offs.
+- **Recommendation** — Which option and why. Omit if only one viable option.
+- **Open Questions** — Anything unresolved that needs answers before or during design.
+
+## Step 3: Socratic Dialogue
+
+Begin asking questions to fill in the gaps. Your role is to be a curious, probing thought partner.
+
+**Guiding principles:**
+
+- Ask one question at a time. Give the user space to think.
+- Start with "why" before "what" or "how." Understand the problem before exploring solutions.
+- Challenge assumptions gently. "What happens if we don't do this?" is a valid question.
+- Surface edge cases. "What about when X?" helps catch gaps early.
+- When multiple approaches exist, name them and ask the user to weigh trade-offs.
+- Read codebase files when needed to ground the conversation in reality. Use Read, Grep, and Glob to explore relevant code.
+- Do not discuss implementation details. Stay at the requirements and options level.
+
+**When to move on from a section:**
+
+- Overview: move on when you can articulate the "why" in one to three sentences
+- Requirements: move on when the user agrees the list is complete and testable
+- Options: move on when trade-offs are clear and the user has a preference
+- Recommendation: move on when the choice is made and the reasoning is captured
+- Open Questions: move on when questions are either answered or explicitly deferred to design
+
+## Step 4: Update the Ticket
+
+As each section crystallizes through dialogue, update the Linear ticket body to reflect the current state. Build the description incrementally using the plan template structure.
+
+```bash
+linear issue update ISSUE_ID -d "UPDATED_DESCRIPTION"
+```
+
+Do not wait until the end to update. Update after each meaningful exchange so the ticket stays current. The user should be able to read the ticket at any point and see an accurate picture of where planning stands.
+
+## Step 5: Confirm Readiness
+
+When all sections are filled in and open questions are resolved (or explicitly deferred), summarize the final state of the ticket to the user.
+
+Use AskUserQuestion to confirm:
+
+- **Ready for design** — The ticket is in good shape. Proceed to `/sdlc:design ISSUE_ID`.
+- **Keep refining** — There are still gaps to address. Continue the dialogue.
+
+## Output
+
+When the user confirms readiness:
+
+```
+Planning complete for ISSUE_ID.
+Ticket updated with overview, requirements, options, and recommendation.
+
+Next step: /sdlc:design ISSUE_ID
+```

--- a/plugins/sdlc/skills/review/SKILL.md
+++ b/plugins/sdlc/skills/review/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: sdlc:review
+description: Create PR for code review. Use this when the user is ready to submit their work, create a pull request, or send code for review.
+allowed-tools:
+  - Bash(git *)
+  - Bash(gh *)
+  - Bash(*get-base-branch.sh*)
+  - Grep
+  - Read
+  - Edit
+---
+
+# Submit for Review
+
+Commit, push, and create a PR for code review.
+
+In all bash steps below, substitute placeholder names (like BASE_BRANCH, CURRENT_BRANCH, etc.) with the actual values you stored earlier.
+
+## Workflow
+
+1. **Verify branch state** on a feature branch with changes
+2. **Detect and remove dead code** introduced by this branch
+3. **Commit and push** all changes
+4. **Create PR** with a comprehensive description
+
+## Step 1: Verify Branch State
+
+Follow [Branch Verification](../../reference/common-patterns.md#branch-verification).
+
+If CURRENT_BRANCH equals BASE_BRANCH, stop with error: "Cannot create PR from default branch".
+
+Check if a PR already exists for this branch:
+
+```bash
+gh pr view --json number,state --jq '.number,.state'
+```
+
+If a PR already exists, report its number and state. If it is open, ask the user whether to update the existing PR (just push new commits) or proceed with a new one.
+
+Check for uncommitted changes:
+
+```bash
+git status --porcelain
+```
+
+If output is empty, check for unpushed commits:
+
+```bash
+git log @{u}..HEAD
+```
+
+If both are empty, stop: "No changes to submit."
+
+## Step 2: Dead Code Detection
+
+The goal is to catch orphaned code before it lands in the PR. This matters because deleted imports, renamed functions, and removed type references often leave behind unreferenced code that reviewers have to flag.
+
+Get the full diff against the base branch so you can see what was added and removed:
+
+```bash
+git diff BASE_BRANCH...HEAD
+```
+
+Analyze what was removed or renamed. Specifically:
+
+1. Identify deleted imports, function calls, class references, or type usages in the diff
+2. For each deleted reference, search the codebase to see if anything still uses it
+3. If a function, class, or type has zero remaining references (in both implementation and test files), remove it
+4. If an import was the only consumer of an exported member, check whether that export is still used elsewhere
+
+**Safety guardrails:**
+
+- Only remove code with zero references across the entire codebase
+- Preserve exported members that could be part of a public API
+- When uncertain, leave the code and note it in the PR description
+- Check test files too, as they are valid consumers
+
+Report what was cleaned up (if anything) before proceeding.
+
+## Step 3: Commit and Push
+
+Follow [Commit and Push](../../reference/common-patterns.md#commit-and-push).
+
+## Step 4: Create PR
+
+Get the commit log for the branch:
+
+```bash
+git log BASE_BRANCH..HEAD --pretty=format:"- %s%n%b"
+```
+
+Use the commits to write a clear PR title and body. The title should be concise (under 70 chars). The body should summarize what changed and why, plus a test plan.
+
+Create the PR using a HEREDOC for the body to preserve formatting:
+
+```bash
+gh pr create --base BASE_BRANCH --title "PR title here" --body "$(cat <<'EOF'
+## Summary
+- bullet points summarizing the changes
+
+## Test plan
+- [ ] verification steps
+
+EOF
+)"
+```
+
+## Output
+
+Report success with the PR URL from the `gh pr create` output.


### PR DESCRIPTION
## Summary

- Absorb `mattforni/skillset` into homebase without losing the public `skillset` marketplace brand. One repo to maintain instead of two.
- Root level `.claude-plugin/marketplace.json` now defines the `skillset` marketplace. External users install via `claude plugin marketplace add mattforni/homebase` and continue to `claude plugin install sdlc@skillset` / `linear-lifecycle@skillset`.
- `sdlc` and `linear-lifecycle` plugins copied verbatim into `plugins/` with their long form docs in `docs/plugins/`.
- Private `local-skills` marketplace at `.claude/local-skills/` is untouched. It remains a directory source hosting personal `assist` skills and is not affected by this change.
- Repoint `extraKnownMarketplaces.skillset.source.repo` from `mattforni/skillset` to `mattforni/homebase` in both the tracked settings and the live dotfiles.
- README now documents both marketplaces with install instructions and a migration note for users coming from the old `mattforni/skillset` repo.

## Migration note for existing users

The `skillset` marketplace name can only be registered once. Users who already added the old source need to remove it first:

```bash
claude plugin marketplace remove skillset
claude plugin marketplace add mattforni/homebase
```

Follow up PR will drop a deprecation pointer in `mattforni/skillset` and archive the repo once users have had time to migrate.

## Test plan

- [ ] `jq empty` passes on `.claude-plugin/marketplace.json` and both `settings.json` files
- [ ] Fresh `claude plugin marketplace add mattforni/homebase` resolves to the skillset marketplace and lists `sdlc` and `linear-lifecycle`
- [ ] `claude plugin install sdlc@skillset` installs the plugin cleanly
- [ ] `claude plugin install linear-lifecycle@skillset` installs cleanly and `/linear-setup` still works
- [ ] `local-skills` directory marketplace still resolves `assist` skills (assist:emails, assist:codify, assist:permissions, etc.)
- [ ] Statusline worktree indicator still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)