### PR TITLE
GC: Name the File and Capture Worktree Branch Preference

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,3 +1,9 @@
+## About This File
+
+This is "GC" (Global Claude): the user's private global instructions for every project. When Forni says "GC", he means this file.
+
+## Communication
+
 - Ask interactive questions one at a time when clarification is needed
 - Please ask any clarifying questions one at a time so I can be thoughtful in responding?
 - I do not want you to use hyphens ever
@@ -14,6 +20,11 @@
 
 - When creating plans or documents, ALWAYS present them to the user for review before writing to a file. Never write plans directly to files unless explicitly asked.
 - When editing existing files, never overwrite the original without explicit permission. Create a new version file (e.g., v2, draft) instead of modifying the original in place.
+
+### Git Worktrees
+
+- Claude Code's `EnterWorktree` tool auto prefixes new branches with `worktree-` (e.g., `worktree-body-comp`). Immediately rename the branch to the bare name (`git branch -m worktree-<name> <name>`) right after the worktree is created. Forni dislikes the prefix.
+- The statusline already surfaces the worktree with a `🪵 <name>` marker after `🌿 repo:branch`, so the branch name itself should stay clean.
 
 ## Skills
 


### PR DESCRIPTION
## Summary

Small dotfiles update. Two additions to the user level CLAUDE.md:

- **Preamble** identifying this file as "GC" (Global Claude). Forni uses that shorthand in conversation; having it in the file itself means any new Claude session picks up the terminology without a memory round trip.
- **Workflow Convention — Git Worktrees.** Captures a recurring friction: the `EnterWorktree` tool auto prefixes branches with `worktree-` (e.g. `worktree-body-comp`), and Forni wants that renamed to the bare name right after creation. The statusline already surfaces the worktree separately with `🪵 <name>`, so the branch name itself should stay clean.

## Test plan

- [ ] Open a new Claude Code session and confirm GC loads with the new preamble and worktree rule
- [ ] Next time a worktree is created, Claude renames `worktree-<name>` → `<name>` without being prompted

🤖 Generated with [Claude Code](https://claude.com/claude-code)