### PR TITLE
Finish Skillset Marketplace Migration and Skip Cask Adoption Sudo

### DIFF
--- a/.claude/plugins/marketplace-sources.txt
+++ b/.claude/plugins/marketplace-sources.txt
@@ -1,5 +1,5 @@
 https://github.com/anthropics/claude-code.git
 obra/superpowers-marketplace
 wshobson/agents
-mattforni/skillset
+mattforni/homebase
 anthropics/claude-plugins-official

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -146,22 +146,16 @@
   "enabledPlugins": {
     "pr-review-toolkit@claude-code-plugins": true,
     "feature-dev@claude-code-plugins": true,
-    "linear-lifecycle@skillset": true,
-    "sdlc@skillset": true,
     "skill-creator@claude-plugins-official": true,
-    "assist@local-skills": true
+    "assist@local-skills": true,
+    "linear-lifecycle@skillset": true,
+    "sdlc@skillset": true
   },
   "extraKnownMarketplaces": {
     "claude-code-workflows": {
       "source": {
         "source": "github",
         "repo": "wshobson/agents"
-      }
-    },
-    "skillset": {
-      "source": {
-        "source": "github",
-        "repo": "mattforni/homebase"
       }
     },
     "claude-plugins-official": {
@@ -192,6 +186,12 @@
       "source": {
         "source": "directory",
         "path": "/Users/forni/.claude/local-skills"
+      }
+    },
+    "skillset": {
+      "source": {
+        "source": "github",
+        "repo": "mattforni/homebase"
       }
     }
   },

--- a/setup.sh
+++ b/setup.sh
@@ -95,9 +95,12 @@ setup_prerequisites() {
 install_brew_packages() {
   header "Brew packages"
 
-  # Casks that require sudo for installation. Skip them in non-interactive
-  # sessions (e.g. Claude Code) so they don't cause repeated failures.
-  local sudo_casks="whatsapp zoom"
+  # Casks that require sudo in non-interactive sessions, either because the
+  # installer prompts (whatsapp, zoom) or because brew needs to adopt an
+  # existing /Applications copy (chmod -R a+rX requires sudo). Skip in
+  # non-interactive sessions (e.g. Claude Code); run setup.sh in a terminal
+  # to pick them up.
+  local sudo_casks="whatsapp zoom docker-desktop google-chrome protonvpn raycast slack todoist-app"
   local skip_env=""
   if [[ "$INTERACTIVE" != true ]]; then
     skip_env="$sudo_casks"


### PR DESCRIPTION
## Summary

Cleans up two lingering issues that made non-interactive setup.sh runs noisy:

- **Skillset marketplace** still sourced from `mattforni/skillset`, which #58 deprecated to an empty marketplace pointing back at homebase. Point `marketplace-sources.txt` at `mattforni/homebase` so `linear-lifecycle@skillset` and `sdlc@skillset` resolve.
- **Cask adoption failures** on `docker-desktop`, `google-chrome`, `protonvpn`, `raycast`, `slack`, `todoist-app`. Each already lives in `/Applications` but isn't in the brew caskroom, so every run retries adoption and fails on the `sudo chmod -R a+rX` step. Extend the existing `sudo_casks` skip list (previously just `whatsapp zoom`) to include them. Running setup.sh in a terminal will still pick them up properly with a sudo prompt.
- Reconcile `enabledPlugins` and `extraKnownMarketplaces` ordering in `.claude/settings.json` with what the `claude plugin` CLI writes.

## Test plan

- [x] `brew bundle check --file=brew/Brewfile` with the extended `HOMEBREW_BUNDLE_CASK_SKIP` env passes
- [x] `claude plugin install linear-lifecycle@skillset` and `sdlc@skillset` succeed after the marketplace swap
- [x] `claude plugin list` shows both plugins enabled and loaded
- [ ] Next human-driven `./setup.sh` run in a terminal should pick up the six adoption casks cleanly with a single sudo prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)