### PR TITLE
Add Linear CLI to Brewfile

### DIFF
--- a/brew/Brewfile
+++ b/brew/Brewfile
@@ -1,5 +1,6 @@
 # Taps
 tap "heroku/brew"
+tap "schpet/tap"
 tap "supabase/tap"
 
 # CLI essentials
@@ -9,6 +10,7 @@ brew "fzf"
 brew "gh"
 brew "git-filter-repo"
 brew "jq"
+brew "linear"
 brew "poppler"
 brew "mas"
 brew "stow"


### PR DESCRIPTION
## Summary

- Add `schpet/tap` and `brew "linear"` to `brew/Brewfile` so new machines pick up the Linear CLI on `brew bundle`.
- Matches the CLI the `sdlc` (v2.0.0) and `linear-lifecycle` (v1.2.0) skills already target: singular `linear issue view/list/update`, `linear auth login` for auth. Different tool from the previously used `linearis` npm package.

## Test plan

- [ ] `brew bundle check --file=brew/Brewfile` passes on a machine with `linear` installed
- [ ] `brew bundle --file=brew/Brewfile` installs `linear` on a machine without it
- [ ] `linear --version` reports 2.0.0+

🤖 Generated with [Claude Code](https://claude.com/claude-code)