### PR TITLE
Add assist:mise Skill and Reconcile Local-Skills Marketplace

### DIFF
--- a/.claude/local-skills/.claude-plugin/marketplace.json
+++ b/.claude/local-skills/.claude-plugin/marketplace.json
@@ -25,9 +25,13 @@
       "skills": [
         "./skills/emails/SKILL.md",
         "./skills/schedule/SKILL.md",
-        "./skills/learn/SKILL.md",
+        "./skills/codify/SKILL.md",
         "./skills/bd-email/SKILL.md",
-        "./skills/job-apply/SKILL.md"
+        "./skills/job-apply/SKILL.md",
+        "./skills/meals/SKILL.md",
+        "./skills/mise/SKILL.md",
+        "./skills/permissions/SKILL.md",
+        "./skills/sharpen/SKILL.md"
       ]
     }
   ]

--- a/.claude/local-skills/plugins/assist/skills/mise/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/mise/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: assist:mise
+description: Morning prep sync for Forni's workstation. Pulls latest in ~/Eudaimonia and ~/Eudaimonia/Craft/Development/personal/homebase, then runs homebase's setup.sh to deploy dotfiles and refresh brew, npm globals, IDE extensions, and Claude plugins. Use this skill whenever Forni says "mise", "mise en place", "prep the station", "morning sync", "get the station ready", or otherwise wants his dev environment neat and tidy before the day's work. Also trigger for "/assist:mise". Named after mise en place: everything in its place before service.
+allowed-tools:
+  - Bash
+  - Read
+  - Skill
+---
+
+# Mise
+
+Morning prep. Get the station ready for the day's work.
+
+Two repos, one setup script. The skill exists because Forni was running the same three commands by hand every morning: `git pull` in Eudy, `git pull` in homebase, `./setup.sh`. That is a routine, and routines should be automations.
+
+## Before Every Invocation
+
+1. Read this skill's local `learned-rules.md` if present. It overrides anything below.
+2. Read the plugin-wide `../../learned-rules.md` for any cross-skill corrections that also apply.
+
+## Repos
+
+| Shorthand | Absolute path |
+|---|---|
+| Eudy | `/Users/forni/Eudaimonia` |
+| Homebase | `/Users/forni/Eudaimonia/Craft/Development/personal/homebase` |
+
+Both are git repos. Homebase contains the authoritative `setup.sh` that deploys configs and refreshes tooling.
+
+## Workflow
+
+### Step 0: Preflight
+
+Refuse to run inside a git worktree. A worktree signals in-progress work on an isolated branch; mise's branch logic would either fight that context or silently do the wrong thing.
+
+Detect via:
+
+```bash
+test "$(git rev-parse --git-dir 2>/dev/null)" = "$(git rev-parse --git-common-dir 2>/dev/null)"
+```
+
+If the two paths differ, the current session is in a worktree. Abort with a short note telling Forni to `ExitWorktree` first.
+
+### Step 1: Sync Eudy
+
+Run the sync routine below against `/Users/forni/Eudaimonia`. See [Sync Routine](#sync-routine).
+
+If sync produces a merge conflict, stop mise. Do not continue to homebase or setup.sh. Report the conflict so Forni can resolve it.
+
+### Step 2: Sync Homebase
+
+Run the same sync routine against `/Users/forni/Eudaimonia/Craft/Development/personal/homebase`.
+
+Same conflict handling: stop on conflict, do not proceed to setup.sh.
+
+### Step 3: Run setup.sh
+
+From the homebase path, run `./setup.sh` in the foreground so Forni sees output. If it exits non-zero, capture the tail of stderr and stop; do not retry. setup.sh is idempotent, so the right fix for a transient failure is usually to resolve the root cause and re-run mise, not to auto-retry.
+
+### Step 4: Summary
+
+One compact report, per repo:
+
+- branch name at start
+- stash applied? (and whether the pop was clean)
+- merge from `origin/main` applied? (for non-main case)
+- setup.sh outcome
+
+Keep it short. A handful of lines. If everything was already up to date and setup.sh short-circuited, say so in one line.
+
+## Sync Routine
+
+Given a repo path `$REPO`:
+
+### If on `main`
+
+1. Check for dirty tree: `git -C "$REPO" status --porcelain`. Remember whether it was dirty.
+2. If dirty, stash with a tagged message: `git -C "$REPO" stash push -u -m "mise auto-stash $(date -Iseconds)"`.
+3. `git -C "$REPO" pull --ff-only origin main`.
+4. If we stashed, `git -C "$REPO" stash pop`. If the pop reports conflicts, leave the conflict state and surface the details in the summary — do not attempt to resolve.
+
+### If on a non-main branch
+
+The user is mid-feature on this repo. The goal is to preserve their work, bring main current, and merge main forward so the branch keeps pace.
+
+1. Delegate to `/sdlc:checkpoint` via the Skill tool. That skill handles "save WIP with commit and push, no PR" — exactly what's needed here. It already knows the conventions for both repos.
+2. After checkpoint returns, fetch and merge main:
+   ```bash
+   git -C "$REPO" fetch origin main
+   git -C "$REPO" merge origin/main
+   ```
+3. If the merge surfaces conflicts, leave the branch in the conflicted state and abort mise. Forni resolves the merge; he can rerun mise after.
+
+## Why each edge case matters
+
+- **Worktree abort:** In a worktree, the current session's cwd and branch are deliberately detached from main. Running mise here would either re-sync main in the parent checkout (leaving the worktree diverged) or silently pull the worktree's branch (surprising). Cleaner to refuse.
+- **Stash-pop over force-reset:** Dirty working tree on main is almost always half-finished editing, not intentional divergence. Stash preserves it; pop restores it. Conflict on pop is rare but recoverable.
+- **Checkpoint + merge-main over rebase:** On a feature branch, mise keeps the branch alive and in sync rather than rewriting history. Forni's preference is to preserve WIP commits (even ugly ones) and merge main forward. Rebasing would rewrite what was already pushed by checkpoint.
+- **Stop on conflict:** Running setup.sh on a repo in a conflicted state would deploy half-merged config into `$HOME`. Better to stop.
+- **Don't retry setup.sh:** Failures tend to be environmental (sudo, network, brew API). A blind retry masks the cause.
+
+## Output Shape
+
+```
+Mise complete ✓
+
+Eudy (main): pulled, already up to date
+Homebase (main): pulled 2 commits, stash popped clean
+setup.sh: ✓ (brew cache warm, no changes)
+```
+
+Or on partial completion:
+
+```
+Mise aborted after Eudy sync
+
+Eudy (feature-branch): checkpoint pushed, merge from origin/main hit conflicts in
+  - Craft/write/Substack/draft.md
+Homebase: skipped
+setup.sh: skipped
+
+Resolve the merge and re-run /assist:mise.
+```
+
+## Anti-patterns
+
+- Do not stash on a non-main branch. Use `/sdlc:checkpoint` — it commits to the actual branch, which is what Forni expects to find when he resumes.
+- Do not modify `origin` remotes or branches. mise is a local-station operation.
+- Do not skip setup.sh because "nothing changed". Brewfile updates and plugin manifest tweaks are common and cheap to apply.
+- Do not surface setup.sh's full stdout in the summary. Point at where the output went; keep the summary scannable.
+
+## Learned Rules
+
+_(Empty. Populated as Forni corrects mise's judgment over time.)_

--- a/.claude/local-skills/plugins/assist/skills/mise/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/mise/SKILL.md
@@ -2,7 +2,10 @@
 name: assist:mise
 description: Morning prep sync for Forni's workstation. Pulls latest in ~/Eudaimonia and ~/Eudaimonia/Craft/Development/personal/homebase, then runs homebase's setup.sh to deploy dotfiles and refresh brew, npm globals, IDE extensions, and Claude plugins. Use this skill whenever Forni says "mise", "mise en place", "prep the station", "morning sync", "get the station ready", or otherwise wants his dev environment neat and tidy before the day's work. Also trigger for "/assist:mise". Named after mise en place: everything in its place before service.
 allowed-tools:
-  - Bash
+  - Bash(git *)
+  - Bash(test *)
+  - Bash(date *)
+  - Bash(./setup.sh)
   - Read
   - Skill
 ---
@@ -15,7 +18,7 @@ Two repos, one setup script. The skill exists because Forni was running the same
 
 ## Before Every Invocation
 
-1. Read this skill's local `learned-rules.md` if present. It overrides anything below.
+1. Read this skill's local `learned-rules.md`. It overrides anything below.
 2. Read the plugin-wide `../../learned-rules.md` for any cross-skill corrections that also apply.
 
 ## Repos
@@ -31,15 +34,15 @@ Both are git repos. Homebase contains the authoritative `setup.sh` that deploys 
 
 ### Step 0: Preflight
 
-Refuse to run inside a git worktree. A worktree signals in-progress work on an isolated branch; mise's branch logic would either fight that context or silently do the wrong thing.
+Refuse to run if either target repo is a linked worktree. A worktree signals in-progress work on an isolated branch; mise's branch logic would either fight that context or silently do the wrong thing. The check must be scoped to each target repo — the session's cwd can be anywhere, so a bare `git rev-parse` might miss a worktree on a repo mise is about to touch.
 
-Detect via:
+For each `$REPO` (Eudy and Homebase), detect via:
 
 ```bash
-test "$(git rev-parse --git-dir 2>/dev/null)" = "$(git rev-parse --git-common-dir 2>/dev/null)"
+test "$(git -C "$REPO" rev-parse --git-dir 2>/dev/null)" = "$(git -C "$REPO" rev-parse --git-common-dir 2>/dev/null)"
 ```
 
-If the two paths differ, the current session is in a worktree. Abort with a short note telling Forni to `ExitWorktree` first.
+If the two paths differ for either repo, that repo is a linked worktree. Abort with a short note telling Forni which repo is in a worktree and to `ExitWorktree` first.
 
 ### Step 1: Sync Eudy
 
@@ -77,19 +80,21 @@ Given a repo path `$REPO`:
 1. Check for dirty tree: `git -C "$REPO" status --porcelain`. Remember whether it was dirty.
 2. If dirty, stash with a tagged message: `git -C "$REPO" stash push -u -m "mise auto-stash $(date -Iseconds)"`.
 3. `git -C "$REPO" pull --ff-only origin main`.
-4. If we stashed, `git -C "$REPO" stash pop`. If the pop reports conflicts, leave the conflict state and surface the details in the summary — do not attempt to resolve.
+4. If we stashed, `git -C "$REPO" stash pop`. If the pop reports conflicts, leave the conflict state, abort mise immediately, and surface the details in the summary — do not attempt to resolve, do not proceed to the next repo, and do not run `setup.sh`. A conflicted pop means the working tree has unresolved markers; deploying that state via `setup.sh` would land broken config into `$HOME`.
 
 ### If on a non-main branch
 
-The user is mid-feature on this repo. The goal is to preserve their work, bring main current, and merge main forward so the branch keeps pace.
+The user is mid-feature on this repo. The goal is to preserve any in-flight work, bring main current, and merge main forward so the branch keeps pace.
 
-1. Delegate to `/sdlc:checkpoint` via the Skill tool. That skill handles "save WIP with commit and push, no PR" — exactly what's needed here. It already knows the conventions for both repos.
-2. After checkpoint returns, fetch and merge main:
+1. Check for dirty tree: `git -C "$REPO" status --porcelain`.
+2. **If dirty**, delegate to `/sdlc:checkpoint` via the Skill tool. That skill handles "save WIP with commit and push, no PR" — exactly what's needed here. `/sdlc:checkpoint` operates on its caller's cwd, so cd into `$REPO` first (or otherwise scope the invocation to the right repo) — do not let it run against the wrong directory.
+3. **If clean**, skip the checkpoint call entirely. `/sdlc:checkpoint` refuses on a clean tree, and invoking it would either error or become a wasted interaction. A clean feature branch (e.g., one with an open PR that's awaiting review) should flow straight to the merge step.
+4. Fetch and merge main into the current branch:
    ```bash
    git -C "$REPO" fetch origin main
    git -C "$REPO" merge origin/main
    ```
-3. If the merge surfaces conflicts, leave the branch in the conflicted state and abort mise. Forni resolves the merge; he can rerun mise after.
+5. If the merge surfaces conflicts, leave the branch in the conflicted state and abort mise. Forni resolves the merge; he can rerun mise after.
 
 ## Why each edge case matters
 

--- a/.claude/local-skills/plugins/assist/skills/mise/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/mise/learned-rules.md
@@ -1,0 +1,3 @@
+# Learned Rules
+
+_(Empty. Populated as Forni corrects mise's judgment over time.)_

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ claude plugin install linear-lifecycle@skillset
 
 > Migrating from `mattforni/skillset`? That repo is deprecated. Run `claude plugin marketplace remove skillset` then re add from `mattforni/homebase`.
 
+#### Per clone config
+
+`sdlc:review` and `sdlc:iterate` read the re review trigger from `git config sdlc.review-command`. The plugin default is `/gemini review`, but this repo uses CodeRabbit. `setup.sh` sets the local config automatically, or you can run it by hand:
+
+```bash
+git config sdlc.review-command "@coderabbitai review"
+```
+
 ### local-skills (private)
 
 Personal productivity skills. Lives under [.claude/local-skills](.claude/local-skills/) and is added as a local `directory` source only. Not installable via GitHub.

--- a/setup.sh
+++ b/setup.sh
@@ -367,6 +367,24 @@ for k, v in d.get('enabledPlugins', {}).items():
   SUMMARY+=("Claude plugins configured")
 }
 
+configure_repo() {
+  header "Repo config"
+
+  # sdlc:review and sdlc:iterate read the re review trigger from
+  # `git config sdlc.review-command`. The plugin default is "/gemini review"
+  # but this repo uses CodeRabbit, so pin it locally.
+  local desired="@coderabbitai review"
+  local current
+  current="$(git -C "$DIR" config --get sdlc.review-command 2>/dev/null || true)"
+  if [[ "$current" == "$desired" ]]; then
+    info "sdlc.review-command already set to '$desired'"
+  else
+    git -C "$DIR" config sdlc.review-command "$desired" || return 1
+    info "sdlc.review-command set to '$desired'"
+    SUMMARY+=("git config: sdlc.review-command set")
+  fi
+}
+
 setup_auth() {
   header "Authentication"
 
@@ -475,5 +493,6 @@ run_phase deploy_homebase
 run_phase link_local_skills
 run_phase install_ide_extensions
 run_phase install_claude_plugins
+run_phase configure_repo
 run_phase setup_auth
 print_summary


### PR DESCRIPTION
## Summary

Adds a new `/assist:mise` skill and cleans up long-standing drift in the local-skills marketplace manifest.

**New skill: `/assist:mise`** — Morning-prep sync named after *mise en place* (everything in its place before service). One command pulls latest in `~/Eudaimonia` and `~/Eudaimonia/Craft/Development/personal/homebase`, then runs `homebase/setup.sh`. Handles dirty working trees via stash/pop on main, delegates to `/sdlc:checkpoint` and merges `origin/main` forward on feature branches, refuses to run inside a worktree (signal of in-progress work), and stops cleanly on merge conflict or `setup.sh` failure rather than retrying.

**Marketplace reconciliation** — `.claude-plugin/marketplace.json` was drifting from disk:
- Renamed stale `./skills/learn/SKILL.md` to `./skills/codify/SKILL.md` (was throwing `Path not found` on every `claude plugin list`)
- Registered four skills that already existed on disk but were never declared: `meals`, `permissions`, `sharpen`, and the new `mise`

## Test plan

- [x] `claude plugin list` runs clean with zero errors on the assist plugin (was showing `Path not found: learn/SKILL.md` before)
- [x] `/assist:mise` is discoverable via the skills list
- [ ] Invoke `/assist:mise` on a clean state (both repos on main, clean tree) — should pull, run setup.sh, report success
- [ ] Invoke `/assist:mise` with a dirty edit in `~/Eudaimonia` — should stash, pull, pop cleanly
- [ ] Invoke `/assist:mise` from inside a worktree — should abort with the expected message

🤖 Generated with [Claude Code](https://claude.com/claude-code)