### PR TITLE
Sharpen 2026-04-23: Branches, Symlinks, L7 Mise

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -21,6 +21,10 @@ This is "GC" (Global Claude): the user's private global instructions for every p
 - When creating plans or documents, ALWAYS present them to the user for review before writing to a file. Never write plans directly to files unless explicitly asked.
 - When editing existing files, never overwrite the original without explicit permission. Create a new version file (e.g., v2, draft) instead of modifying the original in place.
 
+### Plan to Codify Bridge
+
+After a plan is accepted (ExitPlanMode), before starting implementation, take one beat to ask Forni whether any durable rule, preference, or pattern inside the plan deserves codification via `assist:codify`. Skip for purely execution focused plans that have no generalizable content (just steps). The goal is to catch durable lessons while they are fresh, not turn every plan into a documentation pass.
+
 ### Git Worktrees
 
 - Claude Code's `EnterWorktree` tool auto prefixes new branches with `worktree-` (e.g., `worktree-body-comp`). Immediately rename the branch to the bare name (`git branch -m worktree-<name> <name>`) right after the worktree is created. Forni dislikes the prefix.
@@ -29,6 +33,10 @@ This is "GC" (Global Claude): the user's private global instructions for every p
 ## Skills
 
 Every skill that makes decisions on behalf of the user should include a `learned-rules.md` file. For the full authoring conventions (SKILL.md vs learned-rules.md split, when to graduate rules, etc.), see `~/.claude/references/skills.md`.
+
+### Levels shorthand
+
+`L{N}` is shorthand for "Level N" of Bassi Eledath's 8 levels of agentic engineering (tracked in `/Users/mattforni/Eudaimonia/LEVELS.md`). E.g., L7 = Level 7 (background agents), L8 = Level 8 (agent teams). Use the shorthand freely in sharpen sessions and related discussion.
 
 ## External App Integration
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,6 +16,15 @@ This is "GC" (Global Claude): the user's private global instructions for every p
 - When the user asks you to do something specific, act on that request immediately. Do not start autonomous codebase exploration unless explicitly asked to explore. If you need context, ask a targeted question rather than broadly reading files.
 - Do not overstate or exaggerate the quality of results. If something looks like it works but has not been thoroughly validated, say so. Let the user judge quality.
 
+## Bash Commands
+
+- **Never use `cd` in Bash tool calls.** Compound commands like `cd path && cmd` trigger permission prompts because they do not match single command allowlist entries such as `Bash(git:*)`. Use path aware flags instead:
+  - `git -C <path> <subcommand>` instead of `cd <path> && git <subcommand>`
+  - `gh --repo <owner>/<repo> <subcommand>` instead of `cd <path> && gh <subcommand>`
+  - Absolute paths for file operations: `grep X /abs/path/foo`, `wc -l /abs/path/*.md`
+  - Pass paths explicitly to scripts and tools: `python3 /abs/path/script.py`
+- Compound commands with `cd` defeat the existing allowlist and slow everything down. The goal is to keep Bash calls to a single command that matches a single allowlist entry, so approvals stay auto.
+
 ## Workflow Conventions
 
 - When creating plans or documents, ALWAYS present them to the user for review before writing to a file. Never write plans directly to files unless explicitly asked.

--- a/.claude/commands/checkpoint.md
+++ b/.claude/commands/checkpoint.md
@@ -1,0 +1,37 @@
+---
+allowed-tools:
+  Bash(git add:*),
+  Bash(git pull:*),
+  Bash(git push:*),
+  Bash(git status:*),
+  Bash(git stash:*)
+description: Creates a checkpoint for the current work in progress
+---
+
+**Usage:** `/checkpoint [optional-message]`
+
+**Description:** Comprehensive checkpoint that analyzes all changes, updates documentation, commits everything, and pushes to remote.
+
+**What it does:**
+1. Makes sure we are on a branch before doing anything.
+2. Analyzes all git changes (staged, unstaged, untracked)
+3. Updates CLAUDE.md with new patterns, components, architectures, or guidelines
+4. Stages all changes in the working directory
+5. Creates an informative commit message based on the changes
+6. Commits everything with proper attribution
+7. Pushes to the remote branch (if on a remote-tracking branch)
+
+**Examples:**
+- `/checkpoint` - Auto-generates commit message from changes
+- `/checkpoint "Add LighterPack import feature"` - Uses custom message prefix
+
+**Safety features:**
+- Validates we're on a feature/fix branch (not main)
+- Shows a summary of changes before committing
+- Confirms remote push operation
+- Handles merge conflicts gracefully
+
+**Requirements:**
+- Must be on a git branch
+- Must have remote tracking set up
+- Changes must be present to analyze

--- a/.claude/commands/checkpoint.md
+++ b/.claude/commands/checkpoint.md
@@ -1,10 +1,6 @@
 ---
 allowed-tools:
-  Bash(git add:*),
-  Bash(git pull:*),
-  Bash(git push:*),
-  Bash(git status:*),
-  Bash(git stash:*)
+  Bash(git:*)
 description: Creates a checkpoint for the current work in progress
 ---
 

--- a/.claude/commands/code.md
+++ b/.claude/commands/code.md
@@ -1,0 +1,40 @@
+---
+model: claude-opus-4-1-20250805
+plan: true
+argument-hint: bet-XXX
+description: Start working on a Linear issue with automatic branch setup
+allowed-tools: Bash(git:*), mcp__linear-server__get_issue, mcp__linear-server__list_comments, mcp__linear-server__update_issue, TodoWrite, ExitPlanMode
+---
+
+IMPORTANT: This command requires the Opus model. If not already set, please run `/model opus` first.
+
+I'm starting work on Linear issue $1. Let me set up the git repository and fetch the issue details.
+
+First, I need to:
+1. Set up the git branch properly
+2. Fetch the Linear issue details
+3. Create an implementation plan for your review
+
+Let me start by setting up the git repository:
+
+!git diff --quiet && git diff --staged --quiet || git stash push -m "Auto-stash before starting $1"
+!git checkout main
+!git pull origin HEAD
+!git checkout -b "$1"
+!git branch --show-current
+
+Now I'll fetch the Linear issue details and create a comprehensive implementation plan.
+
+<think>
+The user is working on issue $1. I must:
+1. Execute the git commands above to create the branch
+2. Fetch the issue details from Linear
+3. Review any comments on the issue
+4. Create a detailed todo list with TodoWrite
+5. Present the plan clearly
+6. IMPORTANT: DO NOT use ExitPlanMode until the user explicitly approves
+7. Wait for user approval before proceeding to implementation
+8. IMPORTANT: After user approves the plan and says to proceed, update Linear issue status to "Todo" → "In Progress" (only this status - never update to "In Review" or "Done" as those are handled by git/PR automation)
+</think>
+
+Let me fetch the issue details and analyze the requirements to create an implementation plan for your review.

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,85 @@
+---
+allowed-tools:
+  Bash(git add:*),
+  Bash(git commit:*),
+  Bash(git push:*),
+  Bash(git stash:*),
+  Bash(git branch:*),
+  Bash(git diff:*),
+  Bash(git rm:*),
+  Bash(npm run lint),
+  Bash(npm run test:*),
+  Bash(gh pr create:*),
+  Grep,
+  Read,
+  Edit,
+  Bash(rm:*)
+description: Full development workflow - dead code detection, lint, test, commit, push, and create PR
+---
+
+# /push Command
+
+This command automates the complete development workflow: detects and removes dead code, runs quality checks, commits with informative messages, updates documentation, pushes to remote, and creates a PR.
+
+## Workflow Steps
+
+1. **Check git status** - Verify there are changes to commit
+2. **Dead code detection** - Analyze diff for removed references and clean up unreferenced code
+3. **Add all files** - Stage all changes for commit
+4. **Run linter** - Execute `npm run lint` to check code quality
+5. **Run tests** - Execute appropriate test commands to ensure quality
+6. **Update documentation** - Make informative updates to CLAUDE.md and other project docs
+7. **Generate commit message** - Analyze changes and create informative commit with proper attribution
+8. **Push to remote** - Push the branch to origin with upstream tracking
+9. **Create PR** - Open a pull request with comprehensive description
+
+## Usage
+
+Simply type `/push` to execute the full workflow. The command will:
+- Analyze the git diff to detect removed references
+- Automatically find and delete dead code (unreferenced components, functions, variables, types, etc.)
+- Run appropriate quality checks on remaining code
+- Generate appropriate commit messages with Claude attribution
+- Update documentation if significant changes occurred
+- Create a detailed PR with proper base branch selection
+
+## Dead Code Detection
+
+The command includes automatic dead code detection that:
+1. **Analyzes the git diff** - Examines what references (imports, function calls, etc.) have been removed
+2. **Identifies orphaned code** - Finds functions, components, types, or variables no longer referenced anywhere
+3. **Auto-deletes dead code** - Removes unreferenced code to keep the codebase clean
+4. **Reports cleanup actions** - Shows what was removed and why
+
+**Examples of dead code detected:**
+- Unused React components after refactoring
+- Helper functions no longer called after changes
+- TypeScript types/interfaces no longer used
+- Unused imports that remain after code removal
+- Test files for deleted components
+- Styles for removed elements
+
+**Safe deletion strategy:**
+- Only deletes code that has ZERO references in the codebase
+- Preserves exported members that might be used externally
+- Checks both implementation and test files
+- Confirms deletions before committing
+
+## Documentation Updates
+
+When significant patterns, decisions, or architectural changes are made:
+- Update `CLAUDE.md` with new guidelines
+- Add to relevant spec files if needed
+- Document new patterns or conventions
+- Preserve project-specific instructions and workflows
+
+## Error Handling
+
+If any step fails (linting, tests, or other checks), the process stops and reports the issue. No commits or pushes occur until all quality gates pass.
+
+## Base Branch Selection
+
+The command will intelligently select the appropriate base branch:
+- Use `main` for most repositories
+- Use `rebuild` if that's the primary development branch
+- Adapt based on project-specific branching strategy

--- a/.claude/commands/handle-pr.md
+++ b/.claude/commands/handle-pr.md
@@ -1,0 +1,41 @@
+---
+name: address-gemini-feedback
+description: Address Gemini's PR feedback, commit changes, and request re-review
+---
+
+Address all feedback from Gemini in the current PR by following these steps:
+
+1. **Fetch and analyze PR comments**:
+   - Use `gh pr view <PR_NUMBER> --comments` to get all comments
+   - Use `gh pr diff <PR_NUMBER>` to understand the changes
+   - Identify all feedback points from Gemini
+
+2. **Address each feedback item**:
+   - Fix code issues identified by Gemini
+   - Apply suggested improvements
+   - Ensure all concerns are resolved
+
+3. **Verify changes**:
+   - Run the project's lint command
+   - Run the project's typecheck command
+   - Run the project's unit tests
+
+4. **Commit the fixes**:
+   - Stage all changes with `git add -A`
+   - Commit with a clear message: `fix: address code review feedback from Gemini`
+   - Include details of what was fixed in the commit message
+
+5. **Push changes**:
+   - Push to the PR branch with `git push`
+
+6. **Post PR comment**:
+   - Use `gh pr comment <PR_NUMBER> --body "..."` to post a comment
+   - List each addressed feedback item
+   - Thank Gemini for the review
+   - Format the comment professionally
+
+7. **Request re-review**:
+   - Use GitHub CLI to request a re-review from Gemini
+   - Command: `gh pr review <PR_NUMBER> --request`
+
+Make sure to handle any errors gracefully and provide clear feedback about what was done.

--- a/.claude/commands/hoist-permissions.md
+++ b/.claude/commands/hoist-permissions.md
@@ -1,0 +1,58 @@
+---
+allowed-tools: Read, Edit
+description: Hoist project permissions to user level settings
+---
+
+# /hoist-permissions
+
+Intelligently move permissions from project-level `.claude/settings.local.json` to user-level `~/.claude/settings.json`. Not every permission belongs at user level, and similar permissions should be collapsed into wildcards.
+
+## Steps
+
+1. Read `.claude/settings.local.json` from current working directory
+2. Read `~/.claude/settings.json` (user-level settings)
+3. Extract `permissions.allow` arrays from both files
+4. Analyze each project-level permission using the rules below
+5. Build the final merged list (collapsing, deduplicating, upgrading as appropriate)
+6. Sort the merged array alphabetically
+7. Update `~/.claude/settings.json` with the merged permissions
+8. Update `.claude/settings.local.json` to set `permissions.allow` to an empty array (preserve other settings like `enabledMcpjsonServers`)
+9. Report a summary organized into sections: hoisted, collapsed, skipped (already covered), and kept at project level
+
+## Collapsing Rules
+
+Before hoisting, collapse similar permissions into wildcards:
+
+**Bash commands for the same CLI tool**: Multiple permissions for the same tool (e.g., `gws --version`, `gws auth:*`, `command -v gws`) should collapse to `Bash(gws:*)`. The `command -v <tool>` pattern is a version/existence check and belongs with that tool's wildcard.
+
+**MCP tools for the same service**: Multiple `mcp__claude_ai_<Service>__<action>` permissions should collapse to `mcp__claude_ai_<Service>__*`. For example, `mcp__claude_ai_Gmail__gmail_get_profile` and `mcp__claude_ai_Gmail__gmail_search_messages` become `mcp__claude_ai_Gmail__*`.
+
+**Always prefer the more permissive form**: When a narrower permission and a broader wildcard overlap, keep only the wildcard. This applies in both directions: if `Bash(gws --version)` already exists at user level and `Bash(gws:*)` is being hoisted, replace the narrow one with the wildcard. If the wildcard already exists at user level and a narrow permission is being hoisted, skip the narrow one. The goal is one entry per tool at the broadest level seen.
+
+## What to Hoist (general purpose)
+
+These are safe to promote to user level because they are useful across projects:
+
+- **Common CLI tools**: Standard unix commands, package managers, language runtimes, dev tools. If it is a general purpose command line tool, hoist it.
+- **MCP service wildcards**: After collapsing individual MCP actions into service-level wildcards, hoist them. Services like Gmail, Calendar, Slack, Linear, Todoist, and Notion are used across projects.
+- **WebFetch domains**: General purpose sites (docs sites, major platforms like medium.com, drive.google.com, npm registries). Hoist these.
+- **WebSearch**: Always general purpose. Hoist.
+- **Skills**: Skill permissions are user-level by nature. Hoist.
+
+## What to Keep at Project Level
+
+These should NOT be hoisted because they are project-specific:
+
+- **Project-specific scripts**: Commands like `bash setup.sh`, `bash deploy.sh`, `bash install.sh`, or any command referencing a repo-specific file path. These only make sense in the context of one project.
+- **Project-specific environment setup**: Commands like `RAILS_ENV=test bundle exec rails db:migrate:status` that reference a specific project's toolchain in a specific way.
+
+When uncertain whether a permission is general or project-specific, default to hoisting. The user approved it once, which signals it is a tool they use. Better to have it available everywhere than to be asked again in a different project.
+
+## Important
+
+- Do NOT delete permissions from user-level settings, only add to them (except when replacing a narrow permission with its broader wildcard)
+- Preserve all other settings in both files (only modify `permissions.allow`)
+- If project has no permissions to hoist, report that and exit
+- Sort is case-sensitive alphabetical
+- When collapsing, remove the narrower permissions from the final list if a wildcard covers them
+- Apply collapsing to both newly hoisted AND existing user-level permissions (clean up the user-level list too)

--- a/.claude/commands/reset.md
+++ b/.claude/commands/reset.md
@@ -1,0 +1,29 @@
+Reset local environment for new development work.
+
+Steps:
+1. Checkout main branch
+2. Pull latest from origin
+3. Delete the local branch we were just working on (if any feature branch exists)
+
+Run these git commands:
+```bash
+git checkout main && git pull origin main
+```
+
+Then prune remote tracking branches and identify merged local branches:
+```bash
+git fetch --prune
+```
+
+```bash
+git branch -vv
+```
+
+For any branches showing `[gone]` (remote was deleted), delete them individually:
+```bash
+git branch -d <branch-name>
+```
+
+Note: Run branch cleanup as separate commands rather than a piped compound command to avoid permission issues.
+
+Confirm the reset is complete by showing current branch and status.

--- a/.claude/local-skills/plugins/assist/skills/sharpen/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/sharpen/learned-rules.md
@@ -1,0 +1,17 @@
+# Learned Rules
+
+## Branch naming
+
+Sharpen sessions are branched as `sharpen-YYYY-MM-DD` in every repo touched by the session (currently Eudy and homebase). Same branch name across repos so a given session's work correlates at a glance.
+
+**Why:** Forni wants a consistent way to find any sharpen session's work across both repos without hunting commit messages.
+
+**How to apply:** At the start of the implementation step of a sharpen session, create the branch in each touched repo (`git -C <repo> checkout -b sharpen-YYYY-MM-DD`). If the branch already exists (rerun or continuation), check it out instead.
+
+## CronCreate is not a Level 7 primitive
+
+`CronCreate` (and by extension the `/loop` and `/schedule` skills that wrap it) only fires while a Claude REPL is live and idle. `durable: true` persists the job across Claude restarts but still requires a live session at fire time. Auto expires after 7 days either way.
+
+**Why:** Discovered during the 2026-04-23 sharpen session. Attempted to schedule `/assist:mise` for weekday mornings. CronCreate reported the job as session-only even with `durable: true` passed explicitly, and the underlying mechanic requires an open REPL. Net effect: zero background autonomy unless Forni happens to be at Claude when the cron fires.
+
+**How to apply:** When proposing a "schedule X to run in the background" sharpen move, do not default to CronCreate. For true OS-level scheduling on macOS, the right primitive is launchd (plist in `~/Library/LaunchAgents/`) invoking `claude -p "<slash command>"`. That is usually plan sized, not session sized. CronCreate is still useful for in-session reminders ("nudge me in 20 minutes") but not for daily morning routines.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -185,7 +185,7 @@
     "local-skills": {
       "source": {
         "source": "directory",
-        "path": "/Users/forni/.claude/local-skills"
+        "path": "/Users/mattforni/.claude/local-skills"
       }
     },
     "skillset": {

--- a/.functions
+++ b/.functions
@@ -319,7 +319,11 @@ sync-dots() {
   # bash arrays are 0-indexed, so ${candidates[0]} is empty in zsh.
   HOMEBASE_REPO=$(printf '%s\n' "${candidates[@]}" | head -n 1)
 
-  # List of files to sync (both files and directories)
+  # List of files to sync (both files and directories).
+  # Entries in setup.sh's LINKED_CONFIGS array (.claude/local-skills,
+  # .claude/CLAUDE.md, .claude/commands, .claude/references, .claude/statusline.sh)
+  # are intentionally omitted here: they live as symlinks in $HOME, so edits
+  # already land in the repo without syncing.
   SYNC_FILES=(
     ".aliases"
     ".bashrc"
@@ -332,13 +336,8 @@ sync-dots() {
     ".zshrc"
     ".vscode/settings.json"
     ".vscode/extensions.txt"
-    ".claude/commands"
-    ".claude/mcps"
-    ".claude/memory"
     ".claude/plugins"
     ".claude/skills"
-    ".claude/local-skills"
-    ".claude/CLAUDE.md"
     ".claude/settings.json"
     "bin"
   )

--- a/.functions
+++ b/.functions
@@ -321,9 +321,9 @@ sync-dots() {
 
   # List of files to sync (both files and directories).
   # Entries in setup.sh's LINKED_CONFIGS array (.claude/local-skills,
-  # .claude/CLAUDE.md, .claude/commands, .claude/references, .claude/statusline.sh)
-  # are intentionally omitted here: they live as symlinks in $HOME, so edits
-  # already land in the repo without syncing.
+  # .claude/CLAUDE.md, .claude/commands, .claude/references, .claude/statusline.sh,
+  # bin) are intentionally omitted here: they live as symlinks in $HOME, so
+  # edits already land in the repo without syncing.
   SYNC_FILES=(
     ".aliases"
     ".bashrc"
@@ -339,7 +339,6 @@ sync-dots() {
     ".claude/plugins"
     ".claude/skills"
     ".claude/settings.json"
-    "bin"
   )
 
   if [ $DRY_RUN -eq 1 ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@
 .claude/plugins/known_marketplaces.json
 .claude/plugins/marketplaces/
 .claude/.credentials.json
+.claude/.oauth-token
 .claude.json

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 .claude/file-history
 .claude/history.jsonl
 .claude/debug/
+.claude/scheduled_tasks.lock
 .claude/plugins/cache/
 .claude/plugins/install-counts-cache.json
 .claude/plugins/installed_plugins.json

--- a/bin/run-mise
+++ b/bin/run-mise
@@ -1,22 +1,21 @@
 #!/usr/bin/env bash
 # Wrapper invoked by launchd (com.mattforni.mise) to run /assist:mise
-# headlessly each weekday morning. On failure, fires a macOS notification
-# so Forni sees it in Notification Center.
+# headlessly each weekday morning. Fires a macOS notification on any
+# failure (process error, skill not found, or skill not reporting
+# "Mise complete") so Forni sees it in Notification Center.
 set -uo pipefail
 
-export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
 LOG="$HOME/.claude/debug/mise.log"
+TOKEN_FILE="$HOME/.claude/.oauth-token"
 HOMEBASE="$HOME/Eudaimonia/Craft/Development/personal/homebase"
 
 mkdir -p "$(dirname "$LOG")"
 
 # Fire a macOS notification. osascript is built in (no brew dependency).
-# Title is the notifier, subtitle is the status, message is the pointer
-# at the log. Background noop if osascript is unavailable for any reason.
 notify_failure() {
-  local code="$1"
-  local msg="mise exit $code. Tail $LOG for details."
+  local msg="$1"
   osascript -e "display notification \"$msg\" with title \"Mise\" subtitle \"failed at $(date '+%H:%M')\"" 2>/dev/null || true
 }
 
@@ -26,24 +25,43 @@ notify_failure() {
 
   if ! cd "$HOMEBASE"; then
     echo "FATAL: homebase dir missing at $HOMEBASE"
-    notify_failure 1
+    notify_failure "homebase dir missing"
     exit 1
   fi
 
   if ! command -v claude &>/dev/null; then
     echo "FATAL: claude CLI not on PATH ($PATH)"
-    notify_failure 1
+    notify_failure "claude CLI missing"
     exit 1
   fi
 
-  claude -p "/assist:mise" --dangerously-skip-permissions
+  # Source the long lived OAuth token for headless auth. Generated once via
+  # `claude setup-token` and stored mode 600. If missing, claude will try
+  # keychain (works only when keychain is unlocked).
+  if [[ -r "$TOKEN_FILE" ]]; then
+    CLAUDE_CODE_OAUTH_TOKEN=$(cat "$TOKEN_FILE")
+    export CLAUDE_CODE_OAUTH_TOKEN
+  fi
+
+  # Capture stdout so we can inspect the skill's result text. stderr goes
+  # alongside in the log for visibility.
+  result=$(claude -p "/assist:mise" --dangerously-skip-permissions --output-format json 2>&1)
   rc=$?
 
+  echo "$result"
   echo "=== $(date -Iseconds) run-mise end (exit $rc) ==="
 
   if [[ $rc -ne 0 ]]; then
-    notify_failure "$rc"
+    notify_failure "claude exit $rc. Tail $LOG."
+    exit "$rc"
   fi
 
-  exit $rc
+  # Positive confirmation required: mise should report "Mise complete".
+  # Anything less (Unknown skill, auth error, partial output) is a failure.
+  if ! echo "$result" | jq -r '.result // empty' 2>/dev/null | grep -q "Mise complete"; then
+    notify_failure "skill did not complete. Tail $LOG."
+    exit 1
+  fi
+
+  echo "=== $(date -Iseconds) run-mise success confirmed ==="
 } >> "$LOG" 2>&1

--- a/bin/run-mise
+++ b/bin/run-mise
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Wrapper invoked by launchd (com.mattforni.mise) to run /assist:mise
+# headlessly each weekday morning. On failure, fires a macOS notification
+# so Forni sees it in Notification Center.
+set -uo pipefail
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+LOG="$HOME/.claude/debug/mise.log"
+HOMEBASE="$HOME/Eudaimonia/Craft/Development/personal/homebase"
+
+mkdir -p "$(dirname "$LOG")"
+
+# Fire a macOS notification. osascript is built in (no brew dependency).
+# Title is the notifier, subtitle is the status, message is the pointer
+# at the log. Background noop if osascript is unavailable for any reason.
+notify_failure() {
+  local code="$1"
+  local msg="mise exit $code. Tail $LOG for details."
+  osascript -e "display notification \"$msg\" with title \"Mise\" subtitle \"failed at $(date '+%H:%M')\"" 2>/dev/null || true
+}
+
+{
+  echo ""
+  echo "=== $(date -Iseconds) run-mise start ==="
+
+  if ! cd "$HOMEBASE"; then
+    echo "FATAL: homebase dir missing at $HOMEBASE"
+    notify_failure 1
+    exit 1
+  fi
+
+  if ! command -v claude &>/dev/null; then
+    echo "FATAL: claude CLI not on PATH ($PATH)"
+    notify_failure 1
+    exit 1
+  fi
+
+  claude -p "/assist:mise" --dangerously-skip-permissions
+  rc=$?
+
+  echo "=== $(date -Iseconds) run-mise end (exit $rc) ==="
+
+  if [[ $rc -ne 0 ]]; then
+    notify_failure "$rc"
+  fi
+
+  exit $rc
+} >> "$LOG" 2>&1

--- a/bin/run-mise
+++ b/bin/run-mise
@@ -3,6 +3,16 @@
 # headlessly each weekday morning. Fires a macOS notification on any
 # failure (process error, skill not found, or skill not reporting
 # "Mise complete") so Forni sees it in Notification Center.
+#
+# Auth: prefer the macOS Keychain entry (service "claude-code-oauth").
+# Falls back to a gitignored ~/.claude/.oauth-token file for environments
+# where Keychain access is not available. Claude will fall through to its
+# own auth resolution if neither is set.
+#
+# Permissions: instead of --dangerously-skip-permissions, the invocation
+# pre allows only the tools mise actually needs. If mise grows new
+# dependencies, the dry run will surface the missing permissions via
+# claude's JSON error output and the notification will fire.
 set -uo pipefail
 
 export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
@@ -10,13 +20,42 @@ export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 LOG="$HOME/.claude/debug/mise.log"
 TOKEN_FILE="$HOME/.claude/.oauth-token"
 HOMEBASE="$HOME/Eudaimonia/Craft/Development/personal/homebase"
+KEYCHAIN_SERVICE="claude-code-oauth"
+
+# Tools mise needs. Keep tight. If a new tool is required, add it here
+# and document why.
+ALLOWED_TOOLS=(
+  "Bash(git:*)"
+  "Bash(./setup.sh:*)"
+  "Bash(date:*)"
+  "Read"
+  "Skill"
+  "SlashCommand"
+)
 
 mkdir -p "$(dirname "$LOG")"
 
-# Fire a macOS notification. osascript is built in (no brew dependency).
 notify_failure() {
   local msg="$1"
   osascript -e "display notification \"$msg\" with title \"Mise\" subtitle \"failed at $(date '+%H:%M')\"" 2>/dev/null || true
+}
+
+load_oauth_token() {
+  # Keychain first. -w prints just the password value on stdout.
+  local token
+  token=$(security find-generic-password -s "$KEYCHAIN_SERVICE" -w 2>/dev/null) || token=""
+  if [[ -n "$token" ]]; then
+    export CLAUDE_CODE_OAUTH_TOKEN="$token"
+    return 0
+  fi
+  # File fallback.
+  if [[ -r "$TOKEN_FILE" ]]; then
+    export CLAUDE_CODE_OAUTH_TOKEN="$(cat "$TOKEN_FILE")"
+    return 0
+  fi
+  # Neither available: claude will try its own resolution, which likely
+  # fails in launchd context. The failure path is fine; it'll notify.
+  return 1
 }
 
 {
@@ -35,17 +74,16 @@ notify_failure() {
     exit 1
   fi
 
-  # Source the long lived OAuth token for headless auth. Generated once via
-  # `claude setup-token` and stored mode 600. If missing, claude will try
-  # keychain (works only when keychain is unlocked).
-  if [[ -r "$TOKEN_FILE" ]]; then
-    CLAUDE_CODE_OAUTH_TOKEN=$(cat "$TOKEN_FILE")
-    export CLAUDE_CODE_OAUTH_TOKEN
+  if load_oauth_token; then
+    echo "auth: token loaded"
+  else
+    echo "auth: no token found in keychain or file; relying on claude default"
   fi
 
-  # Capture stdout so we can inspect the skill's result text. stderr goes
-  # alongside in the log for visibility.
-  result=$(claude -p "/assist:mise" --dangerously-skip-permissions --output-format json 2>&1)
+  # Run claude with explicit tool allowlist. No --dangerously-skip-permissions.
+  result=$(claude -p "/assist:mise" \
+    --allowedTools "${ALLOWED_TOOLS[@]}" \
+    --output-format json 2>&1)
   rc=$?
 
   echo "$result"
@@ -56,9 +94,8 @@ notify_failure() {
     exit "$rc"
   fi
 
-  # Positive confirmation required: mise should report "Mise complete".
-  # Anything less (Unknown skill, auth error, partial output) is a failure.
-  if ! echo "$result" | jq -r '.result // empty' 2>/dev/null | grep -q "Mise complete"; then
+  # Positive confirmation: success subtype, no error, "Mise complete" in result.
+  if ! echo "$result" | jq -e '.subtype == "success" and .is_error == false and ((.result // "") | contains("Mise complete"))' > /dev/null 2>&1; then
     notify_failure "skill did not complete. Tail $LOG."
     exit 1
   fi

--- a/bin/run-mise
+++ b/bin/run-mise
@@ -74,6 +74,12 @@ load_oauth_token() {
     exit 1
   fi
 
+  if ! command -v jq &>/dev/null; then
+    echo "FATAL: jq not on PATH ($PATH). Success detection depends on jq."
+    notify_failure "jq missing"
+    exit 1
+  fi
+
   if load_oauth_token; then
     echo "auth: token loaded"
   else
@@ -81,9 +87,12 @@ load_oauth_token() {
   fi
 
   # Run claude with explicit tool allowlist. No --dangerously-skip-permissions.
+  # Capture stdout only so $result stays pure JSON. stderr from claude (auth
+  # warnings, progress lines) falls through to the surrounding log block via
+  # its own redirect so it stays visible without corrupting jq parsing.
   result=$(claude -p "/assist:mise" \
     --allowedTools "${ALLOWED_TOOLS[@]}" \
-    --output-format json 2>&1)
+    --output-format json)
   rc=$?
 
   echo "$result"

--- a/launchagents/com.mattforni.mise.plist
+++ b/launchagents/com.mattforni.mise.plist
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.mattforni.mise</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/mattforni/bin/run-mise</string>
+  </array>
+
+  <key>StartCalendarInterval</key>
+  <array>
+    <dict>
+      <key>Hour</key><integer>7</integer>
+      <key>Minute</key><integer>7</integer>
+      <key>Weekday</key><integer>1</integer>
+    </dict>
+    <dict>
+      <key>Hour</key><integer>7</integer>
+      <key>Minute</key><integer>7</integer>
+      <key>Weekday</key><integer>2</integer>
+    </dict>
+    <dict>
+      <key>Hour</key><integer>7</integer>
+      <key>Minute</key><integer>7</integer>
+      <key>Weekday</key><integer>3</integer>
+    </dict>
+    <dict>
+      <key>Hour</key><integer>7</integer>
+      <key>Minute</key><integer>7</integer>
+      <key>Weekday</key><integer>4</integer>
+    </dict>
+    <dict>
+      <key>Hour</key><integer>7</integer>
+      <key>Minute</key><integer>7</integer>
+      <key>Weekday</key><integer>5</integer>
+    </dict>
+  </array>
+
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>HOME</key>
+    <string>/Users/mattforni</string>
+  </dict>
+
+  <key>StandardOutPath</key>
+  <string>/Users/mattforni/.claude/debug/mise-launchd.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/mattforni/.claude/debug/mise-launchd.log</string>
+</dict>
+</plist>

--- a/launchagents/com.mattforni.mise.plist
+++ b/launchagents/com.mattforni.mise.plist
@@ -7,7 +7,7 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/Users/mattforni/bin/run-mise</string>
+    <string>{{HOME}}/bin/run-mise</string>
   </array>
 
   <key>StartCalendarInterval</key>
@@ -45,15 +45,13 @@
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
-    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
-    <key>HOME</key>
-    <string>/Users/mattforni</string>
+    <string>{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
   </dict>
 
   <key>StandardOutPath</key>
-  <string>/Users/mattforni/.claude/debug/mise-launchd.log</string>
+  <string>{{HOME}}/.claude/debug/mise-launchd.log</string>
 
   <key>StandardErrorPath</key>
-  <string>/Users/mattforni/.claude/debug/mise-launchd.log</string>
+  <string>{{HOME}}/.claude/debug/mise-launchd.log</string>
 </dict>
 </plist>

--- a/setup.sh
+++ b/setup.sh
@@ -30,6 +30,17 @@ done
 INTERACTIVE=true
 [[ ! -t 0 ]] && INTERACTIVE=false
 
+# Paths (relative to both $DIR and $HOME) that are symlinked instead of rsynced.
+# deploy_homebase excludes them from rsync so the symlinks survive; sync-dots
+# omits them because edits in $HOME already land in the repo.
+LINKED_CONFIGS=(
+  .claude/local-skills
+  .claude/CLAUDE.md
+  .claude/commands
+  .claude/references
+  .claude/statusline.sh
+)
+
 # Colors & helpers
 GREEN=$'\033[0;32m'
 YELLOW=$'\033[1;33m'
@@ -195,10 +206,13 @@ install_npm_globals() {
 deploy_homebase() {
   header "Homebase"
 
-  # local-skills is symlinked (see link_local_skills below) so skill edits in
-  # the repo go live without re running setup.sh. Exclude it from the rsync so
-  # we do not clobber the symlink with a copy.
-  local excluded=(setup.sh README.md .git .github .gitignore .markdownlint.jsonc .markdownlint-cli2.jsonc .coderabbit.yaml brew .claude/local-skills)
+  # Paths in LINKED_CONFIGS are symlinked (see link_tracked_configs below) so
+  # edits in $HOME go live without re running setup.sh. Exclude them from rsync
+  # so we do not clobber the symlinks with copies.
+  local excluded=(setup.sh README.md .git .github .gitignore .markdownlint.jsonc .markdownlint-cli2.jsonc .coderabbit.yaml brew)
+  for item in "${LINKED_CONFIGS[@]}"; do
+    excluded+=("$item")
+  done
   local rsync_opts=('-a' '--force')
   for item in "${excluded[@]}"; do
     rsync_opts+=(--exclude="$item")
@@ -208,39 +222,52 @@ deploy_homebase() {
   SUMMARY+=("Homebase deployed")
 }
 
-link_local_skills() {
-  header "Local skills symlink"
+link_tracked_configs() {
+  header "Tracked config symlinks"
 
-  local src="$DIR/.claude/local-skills"
-  local dst="$HOME/.claude/local-skills"
+  local failed=0
+  local linked=0
+  for item in "${LINKED_CONFIGS[@]}"; do
+    local src="$DIR/$item"
+    local dst="$HOME/$item"
 
-  if [[ ! -d "$src" ]]; then
-    warn "Source $src does not exist, skipping symlink"
-    return 0
-  fi
-
-  if [[ -L "$dst" ]]; then
-    local current
-    current=$(readlink "$dst")
-    if [[ "$current" == "$src" ]]; then
-      info "local-skills symlink already points at $src"
-      return 0
+    if [[ ! -e "$src" ]]; then
+      warn "Source $src does not exist, skipping"
+      continue
     fi
-    warn "Replacing local-skills symlink (was $current)"
-    rm "$dst"
-  elif [[ -e "$dst" ]]; then
-    warn "local-skills is a real directory at $dst; refusing to remove automatically"
-    warn "Move or delete it manually, then re run setup.sh"
-    return 1
-  fi
 
-  mkdir -p "$(dirname "$dst")"
-  if ! ln -s "$src" "$dst"; then
-    error "Failed to link $dst -> $src"
+    if [[ -L "$dst" ]]; then
+      local current
+      current=$(readlink "$dst")
+      if [[ "$current" == "$src" ]]; then
+        info "$item symlink already points at $src"
+        continue
+      fi
+      warn "Replacing $item symlink (was $current)"
+      rm "$dst"
+    elif [[ -e "$dst" ]]; then
+      warn "$item is a real file/directory at $dst; refusing to remove automatically"
+      warn "Move or delete it manually, then re run setup.sh"
+      failed=1
+      continue
+    fi
+
+    mkdir -p "$(dirname "$dst")"
+    if ! ln -s "$src" "$dst"; then
+      error "Failed to link $dst -> $src"
+      failed=1
+      continue
+    fi
+    info "Linked $dst -> $src"
+    linked=$((linked + 1))
+  done
+
+  if [[ $failed -ne 0 ]]; then
     return 1
   fi
-  info "Linked $dst -> $src"
-  SUMMARY+=("local-skills linked")
+  if [[ $linked -gt 0 ]]; then
+    SUMMARY+=("$linked tracked configs linked")
+  fi
 }
 
 install_ide_extensions() {
@@ -490,7 +517,7 @@ run_phase install_brew_packages
 run_phase setup_node
 run_phase install_npm_globals
 run_phase deploy_homebase
-run_phase link_local_skills
+run_phase link_tracked_configs
 run_phase install_ide_extensions
 run_phase install_claude_plugins
 run_phase configure_repo

--- a/setup.sh
+++ b/setup.sh
@@ -274,6 +274,11 @@ link_tracked_configs() {
 install_launchagents() {
   header "Launch agents"
 
+  # Plists in launchagents/ are templates: {{HOME}} is substituted with the
+  # current user's $HOME at install time. The rendered plist lives at
+  # $HOME/Library/LaunchAgents/ as a real file (not a symlink) so launchd
+  # sees absolute, user specific paths. Re running setup.sh re renders and
+  # re bootstraps.
   local src_dir="$DIR/launchagents"
   local dst_dir="$HOME/Library/LaunchAgents"
   local domain="gui/$(id -u)"
@@ -294,24 +299,23 @@ install_launchagents() {
     local label="${base%.plist}"
     local dst="$dst_dir/$base"
 
-    if [[ -L "$dst" ]]; then
-      local current
-      current=$(readlink "$dst")
-      if [[ "$current" == "$src" ]]; then
-        info "$label plist already linked"
-      else
-        warn "Replacing $label plist symlink (was $current)"
-        rm "$dst"
-        ln -s "$src" "$dst"
-      fi
-    elif [[ -e "$dst" ]]; then
-      warn "$label plist is a real file at $dst; refusing to replace automatically"
-      warn "Move or delete it manually, then re run setup.sh"
-      failed=1
-      continue
+    # Render the template with $HOME substituted. sed uses | delimiter to
+    # avoid escaping / in the path.
+    local rendered
+    rendered=$(sed "s|{{HOME}}|$HOME|g" "$src")
+
+    # If the existing dst content is identical, skip the write to keep
+    # mtimes stable and avoid spurious reloads.
+    if [[ -f "$dst" ]] && [[ ! -L "$dst" ]] && [[ "$(cat "$dst")" == "$rendered" ]]; then
+      info "$label plist already rendered"
+    elif [[ -L "$dst" ]]; then
+      warn "Removing stale symlink at $dst"
+      rm "$dst"
+      printf '%s\n' "$rendered" > "$dst"
+      info "Rendered $dst"
     else
-      ln -s "$src" "$dst"
-      info "Linked $dst -> $src"
+      printf '%s\n' "$rendered" > "$dst"
+      info "Rendered $dst"
     fi
 
     # Reload into launchd. bootout is tolerant; bootstrap reads the plist.

--- a/setup.sh
+++ b/setup.sh
@@ -39,6 +39,7 @@ LINKED_CONFIGS=(
   .claude/commands
   .claude/references
   .claude/statusline.sh
+  bin
 )
 
 # Colors & helpers
@@ -209,7 +210,7 @@ deploy_homebase() {
   # Paths in LINKED_CONFIGS are symlinked (see link_tracked_configs below) so
   # edits in $HOME go live without re running setup.sh. Exclude them from rsync
   # so we do not clobber the symlinks with copies.
-  local excluded=(setup.sh README.md .git .github .gitignore .markdownlint.jsonc .markdownlint-cli2.jsonc .coderabbit.yaml brew)
+  local excluded=(setup.sh README.md .git .github .gitignore .markdownlint.jsonc .markdownlint-cli2.jsonc .coderabbit.yaml brew launchagents)
   for item in "${LINKED_CONFIGS[@]}"; do
     excluded+=("$item")
   done
@@ -267,6 +268,70 @@ link_tracked_configs() {
   fi
   if [[ $linked -gt 0 ]]; then
     SUMMARY+=("$linked tracked configs linked")
+  fi
+}
+
+install_launchagents() {
+  header "Launch agents"
+
+  local src_dir="$DIR/launchagents"
+  local dst_dir="$HOME/Library/LaunchAgents"
+  local domain="gui/$(id -u)"
+
+  if [[ ! -d "$src_dir" ]]; then
+    info "No launchagents/ directory in repo, skipping"
+    return 0
+  fi
+
+  mkdir -p "$dst_dir"
+
+  local count=0
+  local failed=0
+  for src in "$src_dir"/*.plist; do
+    [[ -f "$src" ]] || continue
+    local base
+    base=$(basename "$src")
+    local label="${base%.plist}"
+    local dst="$dst_dir/$base"
+
+    if [[ -L "$dst" ]]; then
+      local current
+      current=$(readlink "$dst")
+      if [[ "$current" == "$src" ]]; then
+        info "$label plist already linked"
+      else
+        warn "Replacing $label plist symlink (was $current)"
+        rm "$dst"
+        ln -s "$src" "$dst"
+      fi
+    elif [[ -e "$dst" ]]; then
+      warn "$label plist is a real file at $dst; refusing to replace automatically"
+      warn "Move or delete it manually, then re run setup.sh"
+      failed=1
+      continue
+    else
+      ln -s "$src" "$dst"
+      info "Linked $dst -> $src"
+    fi
+
+    # Reload into launchd. bootout is tolerant; bootstrap reads the plist.
+    if launchctl print "$domain/$label" &>/dev/null; then
+      launchctl bootout "$domain/$label" &>/dev/null || true
+    fi
+    if launchctl bootstrap "$domain" "$dst"; then
+      info "Launch agent $label active"
+      count=$((count + 1))
+    else
+      error "Failed to bootstrap $label"
+      failed=1
+    fi
+  done
+
+  if [[ $failed -ne 0 ]]; then
+    return 1
+  fi
+  if [[ $count -gt 0 ]]; then
+    SUMMARY+=("$count launch agent(s) installed")
   fi
 }
 
@@ -518,6 +583,7 @@ run_phase setup_node
 run_phase install_npm_globals
 run_phase deploy_homebase
 run_phase link_tracked_configs
+run_phase install_launchagents
 run_phase install_ide_extensions
 run_phase install_claude_plugins
 run_phase configure_repo

--- a/setup.sh
+++ b/setup.sh
@@ -281,7 +281,8 @@ install_launchagents() {
   # re bootstraps.
   local src_dir="$DIR/launchagents"
   local dst_dir="$HOME/Library/LaunchAgents"
-  local domain="gui/$(id -u)"
+  local domain
+  domain="gui/$(id -u)"
 
   if [[ ! -d "$src_dir" ]]; then
     info "No launchagents/ directory in repo, skipping"
@@ -304,10 +305,13 @@ install_launchagents() {
     local rendered
     rendered=$(sed "s|{{HOME}}|$HOME|g" "$src")
 
-    # If the existing dst content is identical, skip the write to keep
-    # mtimes stable and avoid spurious reloads.
+    # Track whether the installed plist actually changed. Avoids tearing down
+    # and re bootstrapping an unchanged agent on every setup.sh run, which
+    # would kill an in flight job if one were running.
+    local changed=1
     if [[ -f "$dst" ]] && [[ ! -L "$dst" ]] && [[ "$(cat "$dst")" == "$rendered" ]]; then
       info "$label plist already rendered"
+      changed=0
     elif [[ -L "$dst" ]]; then
       warn "Removing stale symlink at $dst"
       rm "$dst"
@@ -318,16 +322,21 @@ install_launchagents() {
       info "Rendered $dst"
     fi
 
-    # Reload into launchd. bootout is tolerant; bootstrap reads the plist.
-    if launchctl print "$domain/$label" &>/dev/null; then
-      launchctl bootout "$domain/$label" &>/dev/null || true
-    fi
-    if launchctl bootstrap "$domain" "$dst"; then
-      info "Launch agent $label active"
-      count=$((count + 1))
+    # Reload only when the plist changed or the agent is not currently loaded.
+    local loaded=0
+    launchctl print "$domain/$label" &>/dev/null && loaded=1
+
+    if [[ $changed -eq 1 ]] || [[ $loaded -eq 0 ]]; then
+      [[ $loaded -eq 1 ]] && launchctl bootout "$domain/$label" &>/dev/null || true
+      if launchctl bootstrap "$domain" "$dst"; then
+        info "Launch agent $label active"
+        count=$((count + 1))
+      else
+        error "Failed to bootstrap $label"
+        failed=1
+      fi
     else
-      error "Failed to bootstrap $label"
-      failed=1
+      info "Launch agent $label already loaded"
     fi
   done
 


### PR DESCRIPTION
## Summary

- **Branch convention**: sharpen sessions go on `sharpen-YYYY-MM-DD` in every touched repo. Codified in the sharpen skill's `learned-rules.md`.
- **Symlink expansion**: Tier 1 paths (`.claude/CLAUDE.md`, `commands/`, `references/`, `statusline.sh`, plus `bin/`) now symlinked from `$HOME` to the repo via a generalized `link_tracked_configs` phase in `setup.sh`. Edits in `$HOME` land in the repo immediately, no more `sync-dots` roundtrip for these.
- **L7 mise**: `com.mattforni.mise` launchd agent fires `/assist:mise` headless at 7:07am weekdays with wake catchup. Plist templated (`{{HOME}}` placeholders rendered at install time). Wrapper `bin/run-mise` uses `--output-format json`, requires positive "Mise complete" confirmation, authenticates via `CLAUDE_CODE_OAUTH_TOKEN` from a gitignored token file, and fires a native macOS notification via `osascript` on failure.

## Test plan

- [x] `./setup.sh` runs green: homebase deployed, 6 tracked configs linked, 1 launch agent installed
- [x] `~/bin`, `~/.claude/CLAUDE.md`, `~/.claude/commands`, `~/.claude/references`, `~/.claude/statusline.sh` are symlinks into the repo
- [x] `launchctl print gui/$(id -u)/com.mattforni.mise` shows the agent active with 7:07 weekday schedule
- [x] `~/bin/run-mise` dry run: exit 0, log shows "Mise complete" confirmed, no notification fired
- [x] `~/.claude/.oauth-token` gitignored; token never enters the repo
- [ ] First live firing: tomorrow 2026-04-24 7:07am (or first wake after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)