### PR TITLE
Notify on Mise Success and Symlink Shell Configs

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -34,6 +34,9 @@ alias docker-stop='docker stop $(docker ps -a -q)'
 # VSCode Aliases
 alias ed-vsc-settings='vim ~/.vscode/settings.json'
 
+# Navigation Aliases
+alias homebase="cd ~/Eudaimonia/Craft/Development/personal/homebase"
+
 # Zsh Aliases
 alias ed-zsh="vim ~/.zshrc"
 alias src-zsh="source ~/.zshrc"

--- a/bin/run-mise
+++ b/bin/run-mise
@@ -42,7 +42,9 @@ notify_failure() {
 
 notify_success() {
   local msg="$1"
-  # Escape double quotes so the message passes cleanly through osascript.
+  # Escape backslashes first, then double quotes, so the message passes
+  # cleanly through osascript's AppleScript string literal.
+  msg="${msg//\\/\\\\}"
   msg="${msg//\"/\\\"}"
   osascript -e "display notification \"$msg\" with title \"Mise\" subtitle \"complete at $(date '+%H:%M')\"" 2>/dev/null || true
 }

--- a/bin/run-mise
+++ b/bin/run-mise
@@ -40,6 +40,13 @@ notify_failure() {
   osascript -e "display notification \"$msg\" with title \"Mise\" subtitle \"failed at $(date '+%H:%M')\"" 2>/dev/null || true
 }
 
+notify_success() {
+  local msg="$1"
+  # Escape double quotes so the message passes cleanly through osascript.
+  msg="${msg//\"/\\\"}"
+  osascript -e "display notification \"$msg\" with title \"Mise\" subtitle \"complete at $(date '+%H:%M')\"" 2>/dev/null || true
+}
+
 load_oauth_token() {
   # Keychain first. -w prints just the password value on stdout.
   local token
@@ -108,6 +115,10 @@ load_oauth_token() {
     notify_failure "skill did not complete. Tail $LOG."
     exit 1
   fi
+
+  # First non-empty line of the skill's result, e.g., "Mise complete ✓".
+  summary=$(echo "$result" | jq -r '.result // ""' | awk 'NF {print; exit}')
+  notify_success "${summary:-Mise complete}"
 
   echo "=== $(date -Iseconds) run-mise success confirmed ==="
 } >> "$LOG" 2>&1

--- a/setup.sh
+++ b/setup.sh
@@ -34,6 +34,8 @@ INTERACTIVE=true
 # deploy_homebase excludes them from rsync so the symlinks survive; sync-dots
 # omits them because edits in $HOME already land in the repo.
 LINKED_CONFIGS=(
+  .aliases
+  .functions
   .claude/local-skills
   .claude/CLAUDE.md
   .claude/commands


### PR DESCRIPTION
## Summary
- Fire a macOS notification from `bin/run-mise` after the skill reports success, surfacing the first non empty line of `.result` (e.g. "Mise complete ✓") so the background run is visible alongside the existing failure path.
- Move `.aliases` and `.functions` into `LINKED_CONFIGS` in `setup.sh` so edits in `$HOME` flow back to the repo through the symlink, matching how the other dotfiles already behave.
- Add a `homebase` navigation alias that jumps straight to the repo.

## Test plan
- [ ] Run `./setup.sh`, confirm `~/.aliases` and `~/.functions` are symlinks back to the repo.
- [ ] Trigger `bin/run-mise` manually (or via the launchd agent) on a healthy morning; confirm a macOS notification titled "Mise" with subtitle "complete at HH:MM" fires and shows the summary line.
- [ ] Force a failure path (e.g. temporarily rename the skill) and confirm the existing failure notification still fires and no success notification is sent.
- [ ] Source the updated `.aliases` and run `homebase`; confirm it lands in the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)