### PR TITLE
Add assist:present skill

### DIFF
--- a/.claude/local-skills/.claude-plugin/marketplace.json
+++ b/.claude/local-skills/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
         "url": "https://github.com/mattforni"
       },
       "category": "productivity",
-      "keywords": ["assist", "email", "schedule", "learn", "bd", "job-apply", "productivity"],
+      "keywords": ["assist", "email", "schedule", "learn", "bd", "job-apply", "present", "productivity"],
       "strict": false,
       "skills": [
         "./skills/emails/SKILL.md",
@@ -31,6 +31,7 @@
         "./skills/meals/SKILL.md",
         "./skills/mise/SKILL.md",
         "./skills/permissions/SKILL.md",
+        "./skills/present/SKILL.md",
         "./skills/sharpen/SKILL.md"
       ]
     }

--- a/.claude/local-skills/plugins/assist/skills/present/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/present/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: assist:present
+description: Build a polished reveal.js presentation deck for an internal demo, talk, or share-out. Generates a single-file HTML deck with RYLLC brand styling, served locally via `npm run preso`. Use this skill whenever Forni says "build a presentation", "make a deck", "let's prep a demo", "create a preso", references an upcoming demo or talk that needs slides, or invokes `/assist:present`. Also trigger when Forni wants to walk through work to an audience and asks how to assemble it. Decks live under `preso/YYYY-MM-DD_<slug>/` in whichever repo the work was done.
+argument-hint: "[optional context, e.g., 'six weeks of growth eng' or 'mtm pilot pitch']"
+allowed-tools:
+  - Bash
+  - Read
+  - Edit
+  - Write
+  - Glob
+  - Grep
+  - WebFetch
+  - AskUserQuestion
+  - TodoWrite
+---
+
+# Present Assist
+
+Build presentations that feel designed, not auto-generated. Single-file reveal.js decks with the RYLLC visual language, served locally, lived in a dated folder per deck.
+
+## Before Every Invocation
+
+1. Read this skill's [learned-rules.md](learned-rules.md) for any prior corrections.
+2. Confirm the host repo: decks live in the repo where the work itself lives (e.g., `growth/preso/...`, `mtm/preso/...`). Not in homebase or Eudaimonia.
+3. Confirm the deck slug + date. Default folder: `preso/YYYY-MM-DD_<slug>/`. Slug should be 2-5 lowercase words separated by hyphens.
+
+## Tooling Stack
+
+- **reveal.js 5.x** via CDN (no bundler, no npm install for the deck itself)
+- Single `index.html` per deck
+- Lato (Google Fonts) is the default; introduce a serif display font only when the brief warrants it
+- Slide viewport: `1280 x 720` (reveal.js defaults set in init script). Treat 720px tall as a hard ceiling
+- Served locally via `npx http-server` wrapped in `bin/preso.sh`
+- Hot reload via `-c-1` no-cache flag
+- No Vercel by default. Deploy only when explicitly asked
+
+## Brand
+
+RYLLC palette, mirrored from the [splat](https://github.com/mattforni/splat) deck:
+
+| Var | Hex | Use |
+|---|---|---|
+| `--ry-soft-black` | `#151515` | Background |
+| `--ry-orange` | `#FC4A1A` | Primary accent |
+| `--ry-gold` | `#F7B733` | Secondary accent |
+| `--ry-soft-white` | `#F1F1F1` | Body text |
+| `--ry-white` | `#FFFFFF` | Headings |
+
+Signature accent: `linear-gradient(120deg, var(--ry-orange), var(--ry-gold))` clipped to text. Use it sparingly for one or two accent words per slide, or for the section divider headlines.
+
+## Workflow
+
+### Step 1: Pick the spine before writing slides
+
+The deck is more than a project list. Find the **narrative spine** that organizes everything else, and check it back with Forni before drafting slides.
+
+Useful spines for growth / engineering work:
+
+- **AARRR pirate funnel**, locating the work at one stage (Acquisition, Activation, etc.)
+- **Define → Attribute → Observe → Feed** (the loop Forni uses for any new system)
+- **Before / After** with a single inflection moment in the middle
+- **Build order** when the work has clear sequential layers
+
+A spine is good if every slide in the deck nests cleanly under it without a "miscellaneous" bucket. If you need a "miscellaneous" act, the spine is wrong.
+
+### Step 2: Find the payoff slide first
+
+The Impact / Payoff slide is the single most important slide. Find the headline number(s) before drafting the rest of the deck. Build backward from there.
+
+For business demos: a metric that moved, a goal that was hit, a leak that was sealed. Pull from the live source (HubSpot dashboard, PostHog insight, Linear cycle stats) and verify numbers against the screen at draft time so the deck does not lie at presentation time.
+
+For technical demos: a benchmark, a regression eliminated, a complexity reduction (lines of code, queries, API hops).
+
+### Step 3: Source the structure
+
+Before writing slides, pull the structural source of truth:
+
+- **Linear projects** (for growth / product work): `mcp__claude_ai_Linear__list_projects` filtered to the right team. Projects become acts or sub-acts.
+- **Roadmap doc** (when one exists): the doc's section structure usually maps cleanly to slide structure.
+- **Git history**: `git log --since=<start-date>` and `gh pr list --state merged --limit 50` for evidence per project.
+- **Live dashboards**: HubSpot, PostHog, Slack canvases — for receipts.
+
+### Step 4: Draft the deck against the splat template
+
+Splat (`mattforni/splat`) is the canonical reference. Pull its style block verbatim:
+
+```bash
+gh api repos/mattforni/splat/contents/pres/index.html --jq '.content' | base64 -d > /tmp/splat-pres.html
+```
+
+Lift the `<style>` block (about lines 14-318 of splat's pres/index.html) and the reveal.js init script (about lines 980-994). The reusable class library covers most slide patterns. See [the splat CLAUDE.md](https://github.com/mattforni/splat/blob/main/CLAUDE.md) for the class catalog.
+
+Slide patterns:
+
+- **Title** — `<section class="v-center">` with a small eyebrow above and a thin (200 weight) headline with one accent-gradient word
+- **Section dividers** — large gradient h2 (about 3.6em) with an eyebrow label like `Act I` or `What's next`
+- **Stat cards** — three-column `.stat-grid` with framed cards on the Impact slide
+- **Receipts** — actual screenshot of the dashboard / artifact, shown after the headline numbers
+- **Two-column splits** — `.split` with two `.callout-box` children for before/after or paired ideas
+
+Nest content slides inside an outer `<section>` per act so vertical navigation works naturally.
+
+### Step 5: File layout
+
+Always:
+
+```
+<host-repo>/
+├── package.json          # one-time setup; references bin/preso.sh
+├── bin/preso.sh          # one-time setup; serves any preso/<folder>/
+└── preso/
+    └── YYYY-MM-DD_<slug>/
+        ├── index.html
+        ├── README.md     # short orienter for this specific deck
+        └── assets/       # images / screenshots
+```
+
+If `package.json` and `bin/preso.sh` already exist in the repo, skip step. If not, scaffold them on first deck. Pattern is in `growth/preso/2026-04-30_six-weeks-in-growth/` as the canonical example.
+
+### Step 6: Run, iterate visually
+
+```bash
+npm run preso                                  # serves the most recent deck
+npm run preso 2026-04-30_six-weeks-in-growth   # serves a specific deck
+```
+
+Refresh the browser to see edits (`-c-1` disables caching). Keyboard: arrow keys, `f` for fullscreen, `s` for speaker notes, `esc` for overview.
+
+### Step 7: Fix overflow first
+
+Slide overflow on 720px tall is the most common bug. Triage in this order:
+
+1. Reduce vertical content density before reducing font sizes
+2. Cut a paragraph rather than shrinking text below 0.75em
+3. Move sub-content into a vertical sub-slide (`<section>` inside a parent `<section>`)
+4. Default body sizes that fit reliably: h1 2.0-2.4em, h2 1.5-1.8em, body 0.85em line-height 1.4
+
+### Step 8: Title last
+
+Forni names the deck himself, often only after the content is mostly there. Do not pre-lock the title in the planning phase. Use a working title and ask once the deck is built.
+
+## Codify Bridge
+
+After the deck ships and the demo lands, prompt Forni: "Anything from this build worth codifying via `assist:codify`?" Common candidates:
+
+- A new narrative spine that worked well (add to "Useful spines" above)
+- A class or layout pattern worth promoting from this deck into the splat reference
+- A category of demo (recurring quarterly, board update, weekly all-hands) that would benefit from a sub-skill or argument
+
+## Output Shape
+
+A `present` session produces:
+
+1. A `preso/YYYY-MM-DD_<slug>/` folder with `index.html`, `README.md`, `assets/`
+2. Top-level `package.json` and `bin/preso.sh` if not present
+3. A live `localhost:3000` running the deck
+4. A feature branch (suggested: `preso/<slug>`) with the work committed
+
+Push and PR only when explicitly asked. Demo timing usually means commit-and-keep-local through the talk, then PR after.
+
+## Anti-patterns
+
+- **Do not** start writing slides before settling the spine. The spine is the deck.
+- **Do not** put PR counts or commit counts on the Impact slide unless the audience is engineering-only and the count itself is the news. Business audiences need outcomes (calls booked, cycle time, revenue), not throughput proxies.
+- **Do not** add decorative elements (corner accents, dividers, asymmetric borders) without an explicit ask. They read as "weird marks", not as design intent.
+- **Do not** introduce new fonts mid-build. The Lato + thin-weight-as-hierarchy pairing carries most decks.
+- **Do not** deploy to Vercel by default. Local-only is the norm.
+- **Do not** name the deck before Forni does. Use a working title.
+
+## Reference
+
+- [splat](https://github.com/mattforni/splat) — canonical reveal.js + RYLLC reference deck
+- [growth/preso/2026-04-30_six-weeks-in-growth/](https://github.com/zero-decarb/growth/tree/main/preso/2026-04-30_six-weeks-in-growth) — first invocation of this skill, full worked example
+- [reveal.js docs](https://revealjs.com/) — slide framework
+
+## Learned Rules
+
+See [learned-rules.md](learned-rules.md).

--- a/.claude/local-skills/plugins/assist/skills/present/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/present/learned-rules.md
@@ -1,0 +1,49 @@
+# Learned Rules
+
+## macOS Screenshot filenames contain narrow no-break spaces
+
+`/Users/mattforni/Screenshots/Screenshot YYYY-MM-DD at H.MM.SS PM.png` looks like it has regular spaces, but the byte between the seconds and `AM`/`PM` is U+202F (NARROW NO-BREAK SPACE), not U+0020.
+
+**Why:** A literal `cp "Screenshot 2026-04-30 at 2.02.02 PM.png"` will fail with "No such file or directory" even though the file appears in `ls`. Burned ~2 minutes during the 2026-04-30 demo build trying to copy a dashboard screenshot.
+
+**How to apply:** Reference these files via glob, not literal path. `cp /Users/mattforni/Screenshots/*"2.02.02"*"PM.png" <dest>` works because the glob matches the actual byte sequence.
+
+## Forni cuts hard during planning — trust the cuts
+
+In the 2026-04-30 deck plan, the initial cut had 8 Linear projects. Forni cut it to 4 in one round, dropping projects with no shipped artifacts (Estimate Experience, Minnesota Launch) and pre-tenure work that closed during his tenure (Website Performance, 26Q1 Content Foundations). This made the deck stronger.
+
+**Why:** A deck does not need to be comprehensive. It needs to be true. Anything you have to apologize for ("we haven't done much there yet") weakens the rest.
+
+**How to apply:** When proposing the project list / section count, present the maximal set and the recommended cuts in the same breath. Default to fewer sections, not more. If a section has only one slide of substance, fold it into a neighbor or drop it.
+
+## "Where we're looking" slides want the live link, not a description
+
+For dashboard / artifact slides, Forni prefers the title to BE the link to the live thing, with the screenshot underneath. No descriptive caption, no Slack channel callouts, no PR references.
+
+**Why:** Demoing engineers can click through to verify. The screenshot is a snapshot; the link is the truth. Adding context paragraphs around it dilutes the evidence.
+
+**How to apply:** Pattern is `<h2><a href="<live-url>" style="border-bottom: 2px solid var(--ry-orange);">Dashboard Name</a></h2>` followed by the screenshot. Nothing else.
+
+## No decorative corner accents
+
+Tried adding a thin orange-fade bar in the top-left of every content slide via `::before`. Forni called them "weird red dashes" and asked them removed.
+
+**Why:** Decorative additions without a functional purpose read as design noise, not as intentional brand language. The gradient on accent words and the section-divider treatment are already carrying enough flavor.
+
+**How to apply:** Resist adding decorative ornaments without an explicit ask. The splat reference deck has no corner marks; mirror that restraint.
+
+## Demo pacing
+
+For an internal engineering brown-bag, plan ~20 slides for ~20 minutes. About one slide per minute, with section dividers eating less time than content slides.
+
+**Why:** 2026-04-30 demo landed cleanly at this pace. Tighter (12 slides / 10 min) felt rushed when previewed; looser (35 slides / 30 min) felt indulgent.
+
+**How to apply:** Default to 18-22 slides for ~20 min slots. Use vertical sub-slides for "and here's the receipts" moments rather than adding top-level slides.
+
+## Title naming
+
+Forni names the deck. Working titles get refined or replaced once content is built. The 2026-04-30 deck went through "Six Weeks in Growth", "Filling the Top of the Funnel", and landed at "Start at the Beginning."
+
+**Why:** The right title surfaces from sitting with the built artifact, not from planning. Pre-locking it forces a name the deck has to grow into.
+
+**How to apply:** Use a clearly-marked working title in the plan. When the deck is mostly built, ask Forni to name it. Update the title slide and closing slide together.


### PR DESCRIPTION
## Summary
- Adds `assist:present`, the skill for building polished reveal.js demo decks. Codifies the workflow used to ship the [growth six-weeks demo](https://github.com/zero-decarb/growth/pull/25) on 2026-04-30: pick a narrative spine, find the payoff slide first, source structure from the right place (Linear, roadmap, dashboards), draft against the splat-derived template, fix overflow first.
- Registers the skill in `marketplace.json` and adds `present` to the assist plugin keywords.
- Captures the gotchas surfaced during the first invocation in `learned-rules.md` (macOS Screenshot narrow no-break spaces, no decorative corner accents, title naming happens last, ~20 slides for ~20 min slots).

## Test plan
- [x] `/assist:present` triggers from natural language prompts (build a deck, prep a demo, make a presentation)
- [x] First real invocation produced a shippable deck under time pressure (used live during the 14:30 demo)
- [ ] Run `/reload-plugins` after merge to make the skill discoverable in new sessions