### PR TITLE
GC: Calendar Preferences and training plan scheduling

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -182,6 +182,40 @@ For meeting recaps, ecosystem updates, and similar share out posts to a channel,
 
 Use ZWSP (U+200B) on its own line between sections to force whitespace (per the existing Slack formatting rule).
 
+## Calendar Preferences
+
+When creating Google Calendar events, follow these conventions.
+
+**Color coding by pillar:**
+
+- **Constitution** events → Sage (colorId 2). Runs, lifts, yoga, body care, recovery.
+- **Community** events → Tangerine (colorId 6). Family, friends, social gatherings.
+- **Transition and travel** blocks → Basil (colorId 10). See the distinction below.
+
+**Transition vs travel** (both Basil, different purposes):
+
+- **↔️ Transition** — *holding space* between contexts. The mental shift buffer between activities, not necessarily vehicle time. Title is literally `↔️ Transition`; destination goes in the description (e.g., `→ Office`, `→ Home`). 30 minutes by default. Use when the gap is about context shift more than physical movement.
+- **🚙 Travel** — *explicit* drive or transit. Vehicle / flight / transit time. Title is `🚙 <LOCATION>` with the destination in the title. Use when the block is concretely about getting somewhere.
+
+They are complementary, not interchangeable. A short walk between adjacent rooms is a transition; a 30 minute drive to a trailhead is travel.
+
+**Flanking on location shifts:**
+
+Any event that involves a change of location (training session, therapy, PAH, sauna, meetings off site, social plans at a venue, etc.) needs flanking transition or travel events on the sides that involve movement. An event without its matching flanks is incomplete. No flank needed when adjacent events share a location.
+
+When deleting a recurring event, also delete the paired transition or travel recurring series. Stranded flanks clutter the calendar and quietly break the mental model.
+
+**Title formats:**
+
+- Long runs: `🏃 <MILES> mi Long Run` (e.g., `🏃 7.5 mi Long Run`)
+- Travel: `🚙 <LOCATION>` (e.g., `🚙 Mt Falcon East Trailhead`)
+- Transition: `↔️ Transition` with destination in description
+
+**Time alignment:**
+
+- Travel events use 30 minute increments aligned to 30 minute blocks (e.g., 06:30 to 07:00, not 06:15 to 07:00).
+- Transitions default to 30 minutes (size, not alignment).
+
 ## Todoist Preferences
 
 - Tasks that need scheduling go on the following Monday

--- a/.claude/local-skills/plugins/assist/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/learned-rules.md
@@ -6,6 +6,12 @@ Rules added from triage corrections. Read on every invocation. These override de
 
 - `scheduling@acuityscheduling.com` (NAOSU SAUNA) -> 🍏 Constitution/🧖 Personal Care (NOT Athlete)
 - `heather.frechette@gmail.com` (Heather Frechette, HNGC secretary) -> 🍏 Constitution/🍾 Sobriety. Auto-reply "Thank you for your service! 🙏", then label and archive. HNGC = High Noon Group Conscience (AA home group business meeting).
+- `info@bluesprucemaids.com` (Blue Spruce Maids cleaning reminders) -> 🍏 Constitution/🧖 Personal Care. Mark read, archive. Recurring 7-day cleaning reminders.
+- `EnergyReport@xcelenergy.com` (Xcel Home Energy Report, usage marketing email distinct from actual Xcel bills) -> Informational only. Unsubscribe (URL only, no mailto) and archive without label. The actual Xcel utility bill goes to Bills; this monthly usage/marketing report has no value to keep.
+- `dor_taxreminder-state.co.us@shared1.ccsend.com` (Colorado Department of Revenue withholding tax reminders) -> 🍏 Constitution/💰 Financial/💸 Taxes. Forni files a $0 return for these. Label, mark read, archive.
+- `UHC@benefits.unitedhealthcare.com` with "UHC Rewards" subject -> 🍏 Constitution/🏥 Benefits + GREEN_STAR. Action: enroll in rewards program ($1000 potential). Keep in inbox until enrolled.
+- `prime@amazon.com` membership change confirmations (renewal, cancellation) -> 📑 Admin/🛒 Purchases. Mark read, archive.
+- `support@email.mill.com` (Mill food waste device) -> 📑 Admin/🛒 Purchases. Mark read, archive.
 
 ## Subject Rules
 

--- a/.claude/local-skills/plugins/assist/skills/schedule/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/schedule/SKILL.md
@@ -171,17 +171,49 @@ When moving recurring events for just one week, modify only that occurrence, not
 
 ## Calendar Event Conventions
 
-When creating or modifying events, follow these patterns from the existing calendar:
+Color coding, transition / travel, and title formats live in GC `Calendar Preferences`. The conventions below are skill specific additions.
 
-- **Emoji prefix**: All personal events use an emoji prefix (e.g., "🏋️ Strength", "↔️ Transition", "✍️ Writing")
-- **Transitions**: Use "↔️ Transition" with colorId "10" (Basil)
-- **Constitution events**: Use colorId "2" (Sage) for training, yoga, sauna
-- **Community events**: Use colorId "6" (Tangerine) for run clubs, volunteering, social
+- **Emoji prefix**: All personal events use an emoji prefix (e.g., "🏋️ Strength", "✍️ Writing")
 - **Contemplation events**: Use colorId "4" (Flamingo) for recovery meetings
 - **Craft events**: Use colorId "6" (Tangerine) for writing, personal projects
 - **Heads Down (deep work)**: Use "🙈 Heads Down" with colorId "8" (Graphite). Protected focus blocks. Recurring template lives Tue/Wed 7:00–10:30; can also be created as one-offs when a particular day needs a protected window. No transitions needed (block stays at current location).
 
 Include the location when the event is at a specific place.
+
+## Training Plan Scheduling
+
+Schedule the week's training events from the active block plan in `/Users/forni/Eudaimonia/Constitution/Fitness/2026-training-plan.md`. Conventions live in `Constitution/Fitness/CLAUDE.md`. Title formats and color coding follow GC `Calendar Preferences`.
+
+### Detect existing placeholders first
+
+Before creating any training events, fetch the week's calendar and check for already existing recurring or one off events. Do not overwrite or duplicate. Only create what is missing for this specific week.
+
+| Cadence | Items | Action |
+|---------|-------|--------|
+| Recurring (assumed already on calendar) | Mon yoga 12:15, Tue lift 11:00, Tue DRC eve, Thu SPRC morning, Thu lift 11:00, Wed climb / PAH / sauna | Skip if present |
+| One off (variable, per week) | Fri long run + paired drive blocks | Create fresh each week |
+
+### Friday long run workflow
+
+1. Look up the current week row in `2026-training-plan.md` for **Long mi**, **Vert ft**, and **Fri shape** (route candidate or terrain).
+2. Pick a specific route matching those numbers. Use `WebSearch` on alltrails.com to find the trail page when needed.
+3. Confirm the route with the user via `AskUserQuestion` before creating events.
+4. Default start time is **07:00**. Front Range trailheads are ~30 min from Denver; altitude weeks (9, 10) are longer drives.
+5. Long run duration: budget ~15 to 16 min/mi for moderate trail pace with vert (e.g., 8 mi @ 1,500 ft is ~2 hr).
+6. Create three Fri events per GC Calendar Preferences:
+   - `🚙 <Trailhead Name>` — Basil (colorId 10) — drive out. Location = trailhead address. 30 min block aligned to 30 min increments (e.g., 06:30 to 07:00).
+   - `🏃 <MILES> mi Long Run` — Sage (colorId 2) — location = AllTrails URL.
+   - `🚙 Home` — Basil (colorId 10) — drive back. Same 30 min alignment.
+
+### Mon flex
+
+Optional easy ~4 mi run on Mon. Energy dependent. Do not auto schedule.
+
+### Special weeks
+
+- **Cutback weeks (4, 8)**: Fri long is shorter and on lighter terrain. Same workflow, smaller numbers.
+- **Altitude weeks (9, 10)**: Front Range altitude (week 9) or Aspen recon (week 10). Week 10 includes a Thu drive out + overnight; surface logistics to the user before creating events.
+- **Race week (13)**: Fri 7/31 is the FPL race itself. Coordinate the race day plan as a separate workflow, not a training long run.
 
 ## Key Locations
 
@@ -227,8 +259,6 @@ Use the `gws` CLI tool (via Bash) for Gmail operations during planning. Common u
 - Add an appropriate emoji prefix to tasks that lack one. Shorten task names to fit well on a calendar.
 - When slotting a task, always set: date/time via reschedule-tasks, then duration + Scheduled label via update-tasks.
 - Todoist deadlineDate is Premium-only. Note deadlines in the task description instead.
-- When creating or rewriting any calendar event that involves a location shift (training, therapy, PAH, sauna, meetings at a different venue, social events, etc.), always create flanking ↔️ Transition events on the sides that involve movement. An event without its matching transitions is incomplete. Transitions are travel time plus mental context shift, not just driving.
-- When deleting a recurring event, also delete the paired transition recurring series. Stranded transitions clutter the calendar and quietly break the mental model.
-- Transition event convention: summary "↔️ Transition", colorId "10" (Basil), 30m, description names the destination only (e.g., "→ Movement", "→ Office", "→ Home"). No transition needed when adjacent events share a location.
+- Transition and travel conventions are in GC `Calendar Preferences`. Both Basil. Transition is *holding space* (context shift, destination in description). Travel is *explicit* (drive / transit, destination in title).
 - When a Todoist bookmark is really an open question rather than an action (description phrased as a question, "Investigate" prefix, no clear next step), capture it as a koan under `/Users/forni/Eudaimonia/koans/<topic>.md` and delete the Todoist task. Don't punt to next Monday — questions don't get less true with time.
 - EnterWorktree at the start of plan mode if any Eudaimonia repo edits are anticipated (schedule.md changes, koan creation, file moves). Don't wait until mid session — relocating uncommitted edits to a worktree later requires stash/pop and is avoidable. Use a date stamped name like `schedule-YYYY-MM-DD` and rename the branch to drop the `worktree-` prefix per global GC instructions.


### PR DESCRIPTION
## Summary

Three bundled changes:

**1. GC: New `Calendar Preferences` section.**
Codifies how Google Calendar events are styled across all scheduling work:

- **Color coding by pillar:** Constitution Sage, Community Tangerine, Transition + Travel Basil.
- **Transition vs travel** (both Basil, complementary):
  - `↔️ Transition` — *holding space* between contexts. Mental shift buffer. Title is literal; destination in description.
  - `🚙 <LOCATION>` — *explicit* drive / transit. Vehicle / flight / transit time. Destination in title.
- **Flanking rule** — any location shift event needs flanking transition or travel events; delete paired flank series when removing a recurring event.
- **Title formats:** `🏃 <MILES> mi Long Run`, `🚙 <LOCATION>`, `↔️ Transition`.
- **Time alignment:** travel events use 30 minute increments aligned to 30 minute blocks.

**2. `assist:schedule` skill — Training Plan Scheduling section.**
New behavior for scheduling the week's training:

- Reads from `Constitution/Fitness/2026-training-plan.md` and `Constitution/Fitness/CLAUDE.md`.
- Detects existing recurring placeholders first; only creates what is missing for the week (mostly Friday long run + paired travel blocks).
- Friday workflow: pick route from the plan's Fri shape column, confirm via `AskUserQuestion`, then create three events per GC Calendar Preferences (`🚙 Trailhead` Basil → `🏃 N mi Long Run` Sage → `🚙 Home` Basil).
- Special case notes for cutback weeks, altitude weeks, and race week.

**3. Hoist transition and travel rules from skill to GC.**
Removed three duplicated rules in the skill's Learned Rules + the redundant entries in the Calendar Event Conventions section. Replaced with a single pointer line. GC is now the single source of truth.

**4. Drive-by: six new email sender triage rules.**
Bundled in the same PR since they were sitting uncommitted. Adds rules for Blue Spruce Maids, Xcel Home Energy Report, CO Dept of Revenue tax reminder, UHC Rewards, Amazon Prime membership confirmations, and Mill food waste device.

## Test plan

- [ ] Run `setup.sh` (or `sync-dots`) to deploy to $HOME and confirm GC is updated.
- [ ] Open the schedule skill in a future session and verify Training Plan Scheduling section is discoverable.
- [ ] Next time a Friday long run is scheduled, confirm the three-event pattern and 30 minute alignment land correctly.
- [ ] On next email triage, confirm the six new sender rules apply as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)