### PR TITLE
Shift headless agent feedback from osascript to Resend email

### DIFF
--- a/.claude/local-skills/plugins/assist/skills/sharpen/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/sharpen/learned-rules.md
@@ -15,3 +15,15 @@ Sharpen sessions are branched as `sharpen-YYYY-MM-DD` in every repo touched by t
 **Why:** Discovered during the 2026-04-23 sharpen session. Attempted to schedule `/assist:mise` for weekday mornings. CronCreate reported the job as session-only even with `durable: true` passed explicitly, and the underlying mechanic requires an open REPL. Net effect: zero background autonomy unless Forni happens to be at Claude when the cron fires.
 
 **How to apply:** When proposing a "schedule X to run in the background" sharpen move, do not default to CronCreate. For true OS-level scheduling on macOS, the right primitive is launchd (plist in `~/Library/LaunchAgents/`) invoking `claude -p "<slash command>"`. That is usually plan sized, not session sized. CronCreate is still useful for in-session reminders ("nudge me in 20 minutes") but not for daily morning routines.
+
+## Audit existing feedback channels before scaling background agents
+
+Before proposing a new headless routine, audit the feedback channels on existing ones. If notifications are the only path for success/failure, that is a gap and the next move should harden it, not add another agent.
+
+**Why:** 2026-05-07 sharpen session. Proposed extending the headless pattern from one routine (mise) to a second (Monday `/assist:schedule`). Forni redirected: "Before we move on to automation another routine, we first need to get better at the feedback and backpressure mechanisms for mise. Right now, it fails silently sometimes (because my notifications are silenced) and even when it succeeds, it tries to tell me some things, but they get cut off in the notification and when I click through, I get nothing else." macOS notifications are best effort and load-bear too much when used as the source of truth.
+
+**How to apply:**
+- For each live headless routine, ask: "If this fails silently, how would Forni find out?" If the answer is "macOS notification" alone, that is insufficient.
+- The current robust pattern is per-run email via Resend with API key in Keychain, recipient in `~/.config/headless-report/recipient`, osascript demoted to a redundant fallback. See `homebase/.claude/references/headless-claude.md` "Email reporting via Resend" section.
+- Apply this scrutiny in proportion to schedule frequency. A weekly routine that fails silently for a week is much worse than a daily one that fails silently once.
+- Adding a second routine without robust feedback compounds the problem because each new agent multiplies the surface area of silent failure.

--- a/.claude/references/headless-claude.md
+++ b/.claude/references/headless-claude.md
@@ -135,9 +135,55 @@ Where `<expected>` is the distinctive success string the skill emits.
 - **`id -u` via subshell in bash `local`**: `local var="$(id -u)"` masks the
   return value (ShellCheck SC2155). Split declare and assign.
 
+## Email reporting via Resend
+
+macOS notifications are best effort: silenced by Focus, get truncated, and
+have no click through to a record. Treat them as a redundant fallback, not
+the source of truth. The source of truth is an email per run.
+
+Shared library: `bin/lib/email-report.sh`. Routine-agnostic. Wrappers source
+it and set `ROUTINE` and `LOG` before calling `email_report`.
+
+    ROUTINE="Mise"
+    LOG="$HOME/.claude/debug/mise.log"
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source "$SCRIPT_DIR/lib/email-report.sh"
+
+Reads:
+
+- API key from macOS Keychain (service `resend-api-key`, sending-only scope).
+- Recipient from `~/.config/headless-report/recipient` (one line, gitignored,
+  shared across all routines).
+- Sender hardcoded to `Claude <claude@atelic.me>` (override via
+  `EMAIL_REPORT_SENDER` env var if a routine needs a distinct identity).
+
+Output:
+
+- Subject `[<Routine> ✅] YYYY-MM-DD HH:MM` on success or `[<Routine> ❌]
+  YYYY-MM-DD HH:MM — <reason>` on failure. Filterable to a Gmail label.
+- Body: status heading, optional reason note, `<pre>` block with the
+  skill's `.result` text (HTML escaped), metadata table (duration, cost,
+  turns, exit code, session id).
+- On any failure (missing key, missing recipient, curl error, Resend HTTP
+  non-2xx): sets `email_error` and returns non-zero. Wrapper falls back to
+  osascript notification carrying the email error.
+
+Tool entry: `Eudy/Admin/tools/resend.md` for vendor context, alternatives
+considered, and pricing. JSON payload assembled via `jq -n --arg ...` to
+dodge bash escaping pitfalls; HTML escaping via `sed`.
+
+Wrapper sourcing trick: `BASH_SOURCE != $0` short circuits the main block
+in each wrapper, so `source ~/bin/run-<routine>` exposes the lib helpers
+for ad hoc testing without firing the routine.
+
+Adding a new headless routine: copy `bin/run-mise`, swap `ROUTINE`,
+`LOG`, the slash command, the `--allowedTools` set, and the success
+predicate. Email path is reused unchanged.
+
 ## Reference
 
 - `claude --help` for current flag list
 - `launchd.plist(5)` and `security(1)` man pages
 - L7 mise source: `homebase/bin/run-mise`, `homebase/launchagents/*.plist`,
   `homebase/setup.sh`'s `install_launchagents` phase
+- Resend API: https://resend.com/docs/api-reference/emails/send-email

--- a/.claude/references/headless-claude.md
+++ b/.claude/references/headless-claude.md
@@ -159,8 +159,9 @@ Reads:
 
 Output:
 
-- Subject `[<Routine> ✅] YYYY-MM-DD HH:MM` on success or `[<Routine> ❌]
-  YYYY-MM-DD HH:MM — <reason>` on failure. Filterable to a Gmail label.
+- Subject is always `[<Routine>] YYYY-MM-DD` regardless of status. Status
+  and any failure reason live in the body so the inbox stays calm and date
+  sortable; filter to a Gmail label by routine prefix.
 - Body: status heading, optional reason note, `<pre>` block with the
   skill's `.result` text (HTML escaped), metadata table (duration, cost,
   turns, exit code, session id).

--- a/bin/lib/email-report.sh
+++ b/bin/lib/email-report.sh
@@ -20,7 +20,6 @@
 # later without changing the contract):
 #
 #     <h2>{emoji} {ROUTINE} — {timestamp}</h2>
-#     {note_html if subject_note}
 #     {summary_html}                              ← TL;DR, callouts, the
 #                                                   immediately scannable bit
 #     <details><summary>Full output</summary>
@@ -42,6 +41,10 @@ EMAIL_REPORT_RECIPIENT_FILE="${EMAIL_REPORT_RECIPIENT_FILE:-$HOME/.config/headle
 EMAIL_REPORT_SENDER="${EMAIL_REPORT_SENDER:-Claude <claude@atelic.me>}"
 EMAIL_REPORT_API_URL="${EMAIL_REPORT_API_URL:-https://api.resend.com/emails}"
 
+# Usage: html_escape (reads from stdin, writes escaped HTML to stdout)
+# Escapes &, <, > so untrusted text can be safely embedded in HTML body or
+# attribute contexts. Does not handle quotes or single quotes; use only for
+# element-content insertion, not for unquoted attribute values.
 html_escape() {
   sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
 }
@@ -74,7 +77,7 @@ email_report() {
   fi
 
   local api_key
-  api_key=$(security find-generic-password -s "$EMAIL_REPORT_RESEND_KEY_SERVICE" -w 2>/dev/null)
+  api_key=$(security find-generic-password -s "$EMAIL_REPORT_RESEND_KEY_SERVICE" -w 2>>"${LOG:-/dev/stderr}")
   if [[ -z "$api_key" ]]; then
     email_error="Resend API key missing in Keychain (service $EMAIL_REPORT_RESEND_KEY_SERVICE)"
     return 2
@@ -84,10 +87,17 @@ email_report() {
     email_error="Recipient file missing or unreadable: $EMAIL_REPORT_RECIPIENT_FILE"
     return 3
   fi
+  # Take the first non-empty, non-comment line. tr strips any trailing CR/LF or
+  # accidental whitespace. This fails loud if the file ever grows comments or
+  # multiple addresses, rather than silently sending to a Frankenstein recipient.
   local recipient
-  recipient=$(tr -d '[:space:]' < "$EMAIL_REPORT_RECIPIENT_FILE")
+  recipient=$(awk 'NF && !/^[[:space:]]*#/ {print; exit}' "$EMAIL_REPORT_RECIPIENT_FILE" | tr -d '[:space:]')
   if [[ -z "$recipient" ]]; then
-    email_error="Recipient file empty: $EMAIL_REPORT_RECIPIENT_FILE"
+    email_error="Recipient file empty or only comments: $EMAIL_REPORT_RECIPIENT_FILE"
+    return 4
+  fi
+  if [[ "$recipient" != *@*.* ]]; then
+    email_error="Recipient does not look like an email address: $recipient"
     return 4
   fi
 
@@ -100,6 +110,9 @@ email_report() {
 
   local subject="[$ROUTINE] $date_only"
 
+  local routine_html
+  routine_html=$(printf '%s' "$ROUTINE" | html_escape)
+
   local full_html=""
   if [[ -n "$full_text" ]]; then
     local escaped
@@ -109,7 +122,7 @@ email_report() {
 
   local html
   html="<!DOCTYPE html><html><body style=\"font-family:-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;font-size:14px;color:#1d1d1f;line-height:1.5;\">
-<h2 style=\"margin:0 0 8px 0;font-size:18px;\">$emoji $ROUTINE — $timestamp</h2>
+<h2 style=\"margin:0 0 8px 0;font-size:18px;\">$emoji $routine_html — $timestamp</h2>
 $summary_html
 $full_html
 $meta_block_html
@@ -147,7 +160,7 @@ $meta_block_html
 
   if [[ ! "$resp_code" =~ ^2 ]]; then
     local resp_text
-    resp_text=$(head -c 500 "$resp_body" 2>/dev/null)
+    resp_text=$(head -c 500 "$resp_body" 2>>"${LOG:-/dev/stderr}")
     email_error="Resend API HTTP $resp_code: $resp_text"
     rm -f "$resp_body"
     return 8
@@ -175,13 +188,13 @@ build_summary_block() {
   local expected_pattern="$3"
 
   local subtype is_error err_field result_text
-  subtype=$(printf '%s' "$result_json" | jq -r '.subtype // empty' 2>/dev/null)
-  is_error=$(printf '%s' "$result_json" | jq -r '.is_error // false' 2>/dev/null)
-  err_field=$(printf '%s' "$result_json" | jq -r '.error // empty' 2>/dev/null)
-  result_text=$(printf '%s' "$result_json" | jq -r '.result // empty' 2>/dev/null)
+  subtype=$(printf '%s' "$result_json" | jq -r '.subtype // empty' 2>>"${LOG:-/dev/stderr}")
+  is_error=$(printf '%s' "$result_json" | jq -r '.is_error // false' 2>>"${LOG:-/dev/stderr}")
+  err_field=$(printf '%s' "$result_json" | jq -r '.error // empty' 2>>"${LOG:-/dev/stderr}")
+  result_text=$(printf '%s' "$result_json" | jq -r '.result // empty' 2>>"${LOG:-/dev/stderr}")
 
   local denials_count=0
-  denials_count=$(printf '%s' "$result_json" | jq -r '.permission_denials // [] | length' 2>/dev/null)
+  denials_count=$(printf '%s' "$result_json" | jq -r '.permission_denials // [] | length' 2>>"${LOG:-/dev/stderr}")
   [[ -z "$denials_count" ]] && denials_count=0
 
   local is_success=false
@@ -232,7 +245,7 @@ build_summary_block() {
 
     if [[ "$denials_count" -gt 0 ]]; then
       local denials_list
-      denials_list=$(printf '%s' "$result_json" | jq -r '.permission_denials[] | "\(.tool_name // "?"): \(.tool_input // .reason // "?" | tostring)"' 2>/dev/null)
+      denials_list=$(printf '%s' "$result_json" | jq -r '.permission_denials[] | "\(.tool_name // "?"): \(.tool_input // .reason // "?" | tostring)"' 2>>"${LOG:-/dev/stderr}")
       local denials_html
       denials_html=$(printf '%s' "$denials_list" | html_escape)
       out+="<p style=\"margin:0 0 4px 0;font-size:12px;color:#666;\"><strong>Permission denials ($denials_count)</strong></p>"
@@ -250,10 +263,10 @@ build_meta_block() {
   local result_json="$1"
   local rc="$2"
   local duration_ms cost turns session
-  duration_ms=$(printf '%s' "$result_json" | jq -r '.duration_ms // empty' 2>/dev/null)
-  cost=$(printf '%s' "$result_json" | jq -r '.total_cost_usd // empty' 2>/dev/null)
-  turns=$(printf '%s' "$result_json" | jq -r '.num_turns // empty' 2>/dev/null)
-  session=$(printf '%s' "$result_json" | jq -r '.session_id // empty' 2>/dev/null)
+  duration_ms=$(printf '%s' "$result_json" | jq -r '.duration_ms // empty' 2>>"${LOG:-/dev/stderr}")
+  cost=$(printf '%s' "$result_json" | jq -r '.total_cost_usd // empty' 2>>"${LOG:-/dev/stderr}")
+  turns=$(printf '%s' "$result_json" | jq -r '.num_turns // empty' 2>>"${LOG:-/dev/stderr}")
+  session=$(printf '%s' "$result_json" | jq -r '.session_id // empty' 2>>"${LOG:-/dev/stderr}")
   local duration_s=""
   if [[ -n "$duration_ms" ]]; then
     duration_s=$(awk -v ms="$duration_ms" 'BEGIN { printf "%.1fs", ms/1000 }')

--- a/bin/lib/email-report.sh
+++ b/bin/lib/email-report.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# Shared email reporting helpers for headless Claude routines.
+#
+# Source from a wrapper script before calling email_report. The wrapper sets
+# ROUTINE and LOG, then sources this file:
+#
+#     ROUTINE="Mise"
+#     LOG="$HOME/.claude/debug/mise.log"
+#     source "$HOME/bin/lib/email-report.sh"
+#
+# Required external tools: jq, curl, security, sed, mktemp, awk, tr.
+#
+# Reads:
+#   - Resend API key from macOS Keychain (service "resend-api-key")
+#   - Recipient address from ~/.config/headless-report/recipient (one line)
+#
+# Sends from: Claude <claude@atelic.me>. Verified domain on Resend.
+#
+# Body shape (kept stable so the same library can carry richer briefings
+# later without changing the contract):
+#
+#     <h2>{emoji} {ROUTINE} — {timestamp}</h2>
+#     {note_html if subject_note}
+#     {summary_html}                              ← TL;DR, callouts, the
+#                                                   immediately scannable bit
+#     <details><summary>Full output</summary>
+#       <pre>{html_escape(full_text)}</pre>
+#     </details>
+#     {meta_block_html}
+#
+# The summary block is what makes the email self-contained: a reader sees
+# what happened without expanding the full output or tailing a log. The
+# wrapper builds it via build_summary_block (or its own logic) and passes
+# raw HTML.
+#
+# When the daily email evolves beyond a status report (calendar pulls,
+# training plan, news, etc.), extend the wrapper to pass richer
+# summary_html or meta_block_html. The outer template stays put.
+
+EMAIL_REPORT_RESEND_KEY_SERVICE="${EMAIL_REPORT_RESEND_KEY_SERVICE:-resend-api-key}"
+EMAIL_REPORT_RECIPIENT_FILE="${EMAIL_REPORT_RECIPIENT_FILE:-$HOME/.config/headless-report/recipient}"
+EMAIL_REPORT_SENDER="${EMAIL_REPORT_SENDER:-Claude <claude@atelic.me>}"
+EMAIL_REPORT_API_URL="${EMAIL_REPORT_API_URL:-https://api.resend.com/emails}"
+
+html_escape() {
+  sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
+
+# Usage: email_report <status> <summary_html> <full_text> <meta_block_html>
+#   status:           "success" | "failure" — drives only the body H2 emoji.
+#   summary_html:     raw HTML for the TL;DR block above the fold; the
+#                     scannable bit. Empty string skips it.
+#   full_text:        plain-text full output, HTML-escaped and wrapped in
+#                     a collapsed <details><pre> block.
+#   meta_block_html:  raw HTML appended after the full output (run metadata).
+#
+# Subject is always "[<ROUTINE>] YYYY-MM-DD" so the inbox stays calm and the
+# user can scan by date. Status and reason live in the body, where there is
+# room to be expressive.
+#
+# On success: returns 0.
+# On failure: sets $email_error to a one-line reason and returns non-zero.
+# Requires $ROUTINE to be set in the caller's environment.
+email_report() {
+  local status="$1"
+  local summary_html="$2"
+  local full_text="$3"
+  local meta_block_html="$4"
+  email_error=""
+
+  if [[ -z "${ROUTINE:-}" ]]; then
+    email_error="ROUTINE env var unset; caller must export it before calling email_report"
+    return 1
+  fi
+
+  local api_key
+  api_key=$(security find-generic-password -s "$EMAIL_REPORT_RESEND_KEY_SERVICE" -w 2>/dev/null)
+  if [[ -z "$api_key" ]]; then
+    email_error="Resend API key missing in Keychain (service $EMAIL_REPORT_RESEND_KEY_SERVICE)"
+    return 2
+  fi
+
+  if [[ ! -r "$EMAIL_REPORT_RECIPIENT_FILE" ]]; then
+    email_error="Recipient file missing or unreadable: $EMAIL_REPORT_RECIPIENT_FILE"
+    return 3
+  fi
+  local recipient
+  recipient=$(tr -d '[:space:]' < "$EMAIL_REPORT_RECIPIENT_FILE")
+  if [[ -z "$recipient" ]]; then
+    email_error="Recipient file empty: $EMAIL_REPORT_RECIPIENT_FILE"
+    return 4
+  fi
+
+  local emoji
+  if [[ "$status" == "success" ]]; then emoji="✅"; else emoji="❌"; fi
+
+  local date_only timestamp
+  date_only=$(date '+%Y-%m-%d')
+  timestamp=$(date '+%Y-%m-%d %H:%M')
+
+  local subject="[$ROUTINE] $date_only"
+
+  local full_html=""
+  if [[ -n "$full_text" ]]; then
+    local escaped
+    escaped=$(printf '%s' "$full_text" | html_escape)
+    full_html="<details style=\"margin:0 0 12px 0;\"><summary style=\"cursor:pointer;color:#666;font-size:12px;padding:4px 0;\">Full output</summary><pre style=\"background:#f5f5f7;padding:12px;border-radius:6px;font-size:12px;line-height:1.4;overflow-x:auto;white-space:pre-wrap;margin:8px 0 0 0;\">$escaped</pre></details>"
+  fi
+
+  local html
+  html="<!DOCTYPE html><html><body style=\"font-family:-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;font-size:14px;color:#1d1d1f;line-height:1.5;\">
+<h2 style=\"margin:0 0 8px 0;font-size:18px;\">$emoji $ROUTINE — $timestamp</h2>
+$summary_html
+$full_html
+$meta_block_html
+</body></html>"
+
+  local payload
+  payload=$(jq -n \
+    --arg from "$EMAIL_REPORT_SENDER" \
+    --arg to "$recipient" \
+    --arg subject "$subject" \
+    --arg html "$html" \
+    '{from: $from, to: [$to], subject: $subject, html: $html}') || {
+      email_error="jq failed to construct JSON payload"
+      return 5
+    }
+
+  local resp_body resp_code curl_rc
+  resp_body=$(mktemp -t headless-resend.XXXXXX) || {
+    email_error="mktemp failed"
+    return 6
+  }
+  resp_code=$(curl -sS -o "$resp_body" -w '%{http_code}' \
+    --max-time 30 \
+    -X POST "$EMAIL_REPORT_API_URL" \
+    -H "Authorization: Bearer $api_key" \
+    -H "Content-Type: application/json" \
+    --data-binary "$payload" 2>>"${LOG:-/dev/null}")
+  curl_rc=$?
+
+  if [[ $curl_rc -ne 0 ]]; then
+    email_error="curl failed (rc=$curl_rc) calling Resend API"
+    rm -f "$resp_body"
+    return 7
+  fi
+
+  if [[ ! "$resp_code" =~ ^2 ]]; then
+    local resp_text
+    resp_text=$(head -c 500 "$resp_body" 2>/dev/null)
+    email_error="Resend API HTTP $resp_code: $resp_text"
+    rm -f "$resp_body"
+    return 8
+  fi
+
+  rm -f "$resp_body"
+  return 0
+}
+
+# Usage: build_summary_block <claude_json_result> <exit_code> <expected_pattern>
+# Builds a scannable TL;DR HTML block for the email above-the-fold area.
+#
+# On success (exit 0, subtype=success, is_error=false, .result contains
+# expected_pattern): emits a green callout with the first non-empty line
+# of .result.
+#
+# On failure: emits a red callout with the most likely reason (subtype,
+# is_error, error field, last meaningful lines of .result), plus a
+# permission_denials list when non-empty.
+#
+# Output is one line of HTML. Pass directly as summary_html to email_report.
+build_summary_block() {
+  local result_json="$1"
+  local rc="$2"
+  local expected_pattern="$3"
+
+  local subtype is_error err_field result_text
+  subtype=$(printf '%s' "$result_json" | jq -r '.subtype // empty' 2>/dev/null)
+  is_error=$(printf '%s' "$result_json" | jq -r '.is_error // false' 2>/dev/null)
+  err_field=$(printf '%s' "$result_json" | jq -r '.error // empty' 2>/dev/null)
+  result_text=$(printf '%s' "$result_json" | jq -r '.result // empty' 2>/dev/null)
+
+  local denials_count=0
+  denials_count=$(printf '%s' "$result_json" | jq -r '.permission_denials // [] | length' 2>/dev/null)
+  [[ -z "$denials_count" ]] && denials_count=0
+
+  local is_success=false
+  if [[ "$rc" -eq 0 ]] && [[ "$subtype" == "success" ]] && [[ "$is_error" == "false" ]]; then
+    if [[ -z "$expected_pattern" ]] || printf '%s' "$result_text" | grep -qF -- "$expected_pattern"; then
+      is_success=true
+    fi
+  fi
+
+  local out=""
+
+  if [[ "$is_success" == "true" ]]; then
+    local first_line
+    first_line=$(printf '%s' "$result_text" | awk 'NF {print; exit}')
+    [[ -z "$first_line" ]] && first_line="Completed."
+    local first_line_html
+    first_line_html=$(printf '%s' "$first_line" | html_escape)
+    out+="<div style=\"background:#e8f5e9;border-left:4px solid #43a047;padding:10px 14px;border-radius:4px;margin:0 0 12px 0;\"><strong style=\"color:#1b5e20;\">$first_line_html</strong></div>"
+  else
+    local reason=""
+    if [[ "$rc" -ne 0 ]]; then
+      reason="Process exit $rc"
+    elif [[ -n "$err_field" ]]; then
+      reason=$(printf '%s' "$err_field" | tr '\n' ' ' | head -c 200)
+    elif [[ "$is_error" == "true" ]]; then
+      reason="is_error=true in result JSON"
+    elif [[ "$subtype" != "success" ]] && [[ -n "$subtype" ]]; then
+      reason="subtype=$subtype"
+    elif [[ -n "$expected_pattern" ]]; then
+      reason="missing expected pattern: $expected_pattern"
+    else
+      reason="unknown failure"
+    fi
+    local reason_html
+    reason_html=$(printf '%s' "$reason" | html_escape)
+    out+="<div style=\"background:#ffebee;border-left:4px solid #c62828;padding:10px 14px;border-radius:4px;margin:0 0 12px 0;\"><strong style=\"color:#b71c1c;\">$reason_html</strong></div>"
+
+    if [[ -n "$result_text" ]]; then
+      local tail_lines
+      tail_lines=$(printf '%s' "$result_text" | awk 'NF' | tail -n 8)
+      if [[ -n "$tail_lines" ]]; then
+        local tail_html
+        tail_html=$(printf '%s' "$tail_lines" | html_escape)
+        out+="<p style=\"margin:0 0 4px 0;font-size:12px;color:#666;\"><strong>Last lines of output</strong></p>"
+        out+="<pre style=\"background:#fff5f5;border-left:3px solid #ef5350;padding:10px 12px;border-radius:0 4px 4px 0;font-size:12px;line-height:1.4;overflow-x:auto;white-space:pre-wrap;margin:0 0 12px 0;\">$tail_html</pre>"
+      fi
+    fi
+
+    if [[ "$denials_count" -gt 0 ]]; then
+      local denials_list
+      denials_list=$(printf '%s' "$result_json" | jq -r '.permission_denials[] | "\(.tool_name // "?"): \(.tool_input // .reason // "?" | tostring)"' 2>/dev/null)
+      local denials_html
+      denials_html=$(printf '%s' "$denials_list" | html_escape)
+      out+="<p style=\"margin:0 0 4px 0;font-size:12px;color:#666;\"><strong>Permission denials ($denials_count)</strong></p>"
+      out+="<pre style=\"background:#fff8e1;border-left:3px solid #ffa000;padding:10px 12px;border-radius:0 4px 4px 0;font-size:12px;line-height:1.4;overflow-x:auto;white-space:pre-wrap;margin:0 0 12px 0;\">$denials_html</pre>"
+    fi
+  fi
+
+  printf '%s' "$out"
+}
+
+# Usage: build_meta_block <claude_json_result> <exit_code>
+# Builds an HTML <table> with run metadata: duration, cost, turns, exit
+# code, session id. Output is one line. Safe to embed directly in email body.
+build_meta_block() {
+  local result_json="$1"
+  local rc="$2"
+  local duration_ms cost turns session
+  duration_ms=$(printf '%s' "$result_json" | jq -r '.duration_ms // empty' 2>/dev/null)
+  cost=$(printf '%s' "$result_json" | jq -r '.total_cost_usd // empty' 2>/dev/null)
+  turns=$(printf '%s' "$result_json" | jq -r '.num_turns // empty' 2>/dev/null)
+  session=$(printf '%s' "$result_json" | jq -r '.session_id // empty' 2>/dev/null)
+  local duration_s=""
+  if [[ -n "$duration_ms" ]]; then
+    duration_s=$(awk -v ms="$duration_ms" 'BEGIN { printf "%.1fs", ms/1000 }')
+  fi
+  local cost_fmt=""
+  if [[ -n "$cost" ]]; then
+    cost_fmt=$(awk -v c="$cost" 'BEGIN { printf "$%.4f", c }')
+  fi
+  local rows=""
+  [[ -n "$duration_s" ]] && rows+="<tr><td style=\"padding:2px 12px 2px 0;color:#888;\">duration</td><td style=\"padding:2px 0;\">$duration_s</td></tr>"
+  [[ -n "$cost_fmt" ]] && rows+="<tr><td style=\"padding:2px 12px 2px 0;color:#888;\">cost</td><td style=\"padding:2px 0;\">$cost_fmt</td></tr>"
+  [[ -n "$turns" ]] && rows+="<tr><td style=\"padding:2px 12px 2px 0;color:#888;\">turns</td><td style=\"padding:2px 0;\">$turns</td></tr>"
+  rows+="<tr><td style=\"padding:2px 12px 2px 0;color:#888;\">exit code</td><td style=\"padding:2px 0;\">$rc</td></tr>"
+  [[ -n "$session" ]] && rows+="<tr><td style=\"padding:2px 12px 2px 0;color:#888;\">session</td><td style=\"padding:2px 0;font-family:ui-monospace,Menlo,monospace;font-size:11px;\">$session</td></tr>"
+  printf '<table style="border-collapse:collapse;font-size:12px;color:#444;margin-top:16px;">%s</table>' "$rows"
+}

--- a/bin/run-mise
+++ b/bin/run-mise
@@ -45,7 +45,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EMAIL_LIB="$SCRIPT_DIR/lib/email-report.sh"
 if [[ ! -r "$EMAIL_LIB" ]]; then
   echo "FATAL: email lib missing at $EMAIL_LIB" >&2
-  osascript -e "display notification \"email lib missing\" with title \"$ROUTINE\"" 2>/dev/null || true
+  osascript -e "display notification \"email lib missing\" with title \"$ROUTINE\"" >&2 || true
   exit 1
 fi
 # shellcheck source=lib/email-report.sh
@@ -55,12 +55,41 @@ notify_failure() {
   local msg="$1"
   msg="${msg//\\/\\\\}"
   msg="${msg//\"/\\\"}"
-  osascript -e "display notification \"$msg\" with title \"$ROUTINE\" subtitle \"failed at $(date '+%H:%M')\"" 2>/dev/null || true
+  osascript -e "display notification \"$msg\" with title \"$ROUTINE\" subtitle \"failed at $(date '+%H:%M')\"" 2>>"$LOG" || true
+}
+
+# fatal_report logs a preflight failure (one that happens before claude runs,
+# so there is no JSON to summarize), sends a failure email, and notifies via
+# osascript only when the email path itself fails. Caller is responsible for
+# `exit 1` afterward.
+fatal_report() {
+  local reason="$1"
+  echo "FATAL: $reason"
+  local summary="<div style=\"background:#ffebee;border-left:4px solid #c62828;padding:10px 14px;border-radius:4px;margin:0 0 12px 0;\"><strong style=\"color:#b71c1c;\">$reason</strong></div>"
+  if email_report "failure" "$summary" "" ""; then
+    echo "email: report sent ($reason)"
+  else
+    echo "email: failed — $email_error"
+    notify_failure "$reason; email also failed: $email_error"
+  fi
+}
+
+# runtime_failure_report sends a post-claude failure email using the already
+# computed summary/full text/metadata blocks, and notifies via osascript only
+# when the email path itself fails. Caller is responsible for the exit code.
+runtime_failure_report() {
+  local reason="$1"
+  if email_report "failure" "$summary_block" "$result_text" "$meta_block"; then
+    echo "email: report sent ($reason)"
+  else
+    echo "email: report failed — $email_error"
+    notify_failure "$ROUTINE $reason; email also failed: $email_error"
+  fi
 }
 
 load_oauth_token() {
   local token
-  token=$(security find-generic-password -s "$KEYCHAIN_SERVICE" -w 2>/dev/null) || token=""
+  token=$(security find-generic-password -s "$KEYCHAIN_SERVICE" -w 2>>"$LOG") || token=""
   if [[ -n "$token" ]]; then
     export CLAUDE_CODE_OAUTH_TOKEN="$token"
     return 0
@@ -84,31 +113,13 @@ fi
   echo "=== $(date -Iseconds) run-mise start ==="
 
   if ! cd "$HOMEBASE"; then
-    reason="homebase dir missing at $HOMEBASE"
-    echo "FATAL: $reason"
-    summary="<div style=\"background:#ffebee;border-left:4px solid #c62828;padding:10px 14px;border-radius:4px;margin:0 0 12px 0;\"><strong style=\"color:#b71c1c;\">$reason</strong></div>"
-    if email_report "failure" "$summary" "" ""; then
-      echo "email: report sent"
-    else
-      echo "email: failed — $email_error"
-      notify_failure "$reason; email also failed: $email_error"
-    fi
-    notify_failure "$reason"
+    fatal_report "homebase dir missing at $HOMEBASE"
     exit 1
   fi
 
   for tool in claude jq curl security; do
     if ! command -v "$tool" &>/dev/null; then
-      reason="$tool not on PATH ($PATH)"
-      echo "FATAL: $reason"
-      summary="<div style=\"background:#ffebee;border-left:4px solid #c62828;padding:10px 14px;border-radius:4px;margin:0 0 12px 0;\"><strong style=\"color:#b71c1c;\">$reason</strong></div>"
-      if email_report "failure" "$summary" "" ""; then
-        echo "email: report sent"
-      else
-        echo "email: failed — $email_error"
-        notify_failure "$reason; email also failed: $email_error"
-      fi
-      notify_failure "$reason"
+      fatal_report "$tool not on PATH ($PATH)"
       exit 1
     fi
   done
@@ -129,30 +140,16 @@ fi
 
   meta_block=$(build_meta_block "$result" "$rc")
   summary_block=$(build_summary_block "$result" "$rc" "Mise complete")
-  result_text=$(echo "$result" | jq -r '.result // ""' 2>/dev/null)
+  result_text=$(echo "$result" | jq -r '.result // ""' 2>>"$LOG")
   [[ -z "$result_text" ]] && result_text="$result"
 
   if [[ $rc -ne 0 ]]; then
-    reason="claude exit $rc"
-    if email_report "failure" "$summary_block" "$result_text" "$meta_block"; then
-      echo "email: report sent ($reason)"
-    else
-      echo "email: report failed — $email_error"
-      notify_failure "$ROUTINE $reason; email also failed: $email_error"
-    fi
-    notify_failure "$reason. See email."
+    runtime_failure_report "claude exit $rc"
     exit "$rc"
   fi
 
-  if ! echo "$result" | jq -e '.subtype == "success" and .is_error == false and ((.result // "") | contains("Mise complete"))' > /dev/null 2>&1; then
-    reason="skill did not complete"
-    if email_report "failure" "$summary_block" "$result_text" "$meta_block"; then
-      echo "email: report sent ($reason)"
-    else
-      echo "email: report failed — $email_error"
-      notify_failure "$ROUTINE $reason; email also failed: $email_error"
-    fi
-    notify_failure "$reason. See email."
+  if ! echo "$result" | jq -e '.subtype == "success" and .is_error == false and ((.result // "") | contains("Mise complete"))' >>"$LOG" 2>&1; then
+    runtime_failure_report "skill did not complete"
     exit 1
   fi
 

--- a/bin/run-mise
+++ b/bin/run-mise
@@ -1,22 +1,26 @@
 #!/usr/bin/env bash
 # Wrapper invoked by launchd (com.mattforni.mise) to run /assist:mise
-# headlessly each weekday morning. Fires a macOS notification on any
-# failure (process error, skill not found, or skill not reporting
-# "Mise complete") so Forni sees it in Notification Center.
+# headlessly each weekday morning. Sends a Resend email after every run
+# (success or failure) so reports survive silenced macOS notifications.
+# Falls back to osascript only when the email path itself fails.
+#
+# Email reporting lives in bin/lib/email-report.sh and is shared across all
+# headless routines. See homebase/.claude/references/headless-claude.md for
+# the playbook and Eudy's Admin/tools/resend.md for the tool entry.
 #
 # Auth: prefer the macOS Keychain entry (service "claude-code-oauth").
 # Falls back to a gitignored ~/.claude/.oauth-token file for environments
-# where Keychain access is not available. Claude will fall through to its
-# own auth resolution if neither is set.
+# where Keychain access is not available.
 #
 # Permissions: instead of --dangerously-skip-permissions, the invocation
 # pre allows only the tools mise actually needs. If mise grows new
 # dependencies, the dry run will surface the missing permissions via
-# claude's JSON error output and the notification will fire.
+# claude's JSON error output and the email will surface it.
 set -uo pipefail
 
 export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
+ROUTINE="Mise"
 LOG="$HOME/.claude/debug/mise.log"
 TOKEN_FILE="$HOME/.claude/.oauth-token"
 HOMEBASE="$HOME/Eudaimonia/Craft/Development/personal/homebase"
@@ -35,59 +39,79 @@ ALLOWED_TOOLS=(
 
 mkdir -p "$(dirname "$LOG")"
 
+# Source shared email helpers. Resolve relative to this script's actual
+# location so it works whether running from the repo or from ~/bin/.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EMAIL_LIB="$SCRIPT_DIR/lib/email-report.sh"
+if [[ ! -r "$EMAIL_LIB" ]]; then
+  echo "FATAL: email lib missing at $EMAIL_LIB" >&2
+  osascript -e "display notification \"email lib missing\" with title \"$ROUTINE\"" 2>/dev/null || true
+  exit 1
+fi
+# shellcheck source=lib/email-report.sh
+source "$EMAIL_LIB"
+
 notify_failure() {
   local msg="$1"
-  osascript -e "display notification \"$msg\" with title \"Mise\" subtitle \"failed at $(date '+%H:%M')\"" 2>/dev/null || true
-}
-
-notify_success() {
-  local msg="$1"
-  # Escape backslashes first, then double quotes, so the message passes
-  # cleanly through osascript's AppleScript string literal.
   msg="${msg//\\/\\\\}"
   msg="${msg//\"/\\\"}"
-  osascript -e "display notification \"$msg\" with title \"Mise\" subtitle \"complete at $(date '+%H:%M')\"" 2>/dev/null || true
+  osascript -e "display notification \"$msg\" with title \"$ROUTINE\" subtitle \"failed at $(date '+%H:%M')\"" 2>/dev/null || true
 }
 
 load_oauth_token() {
-  # Keychain first. -w prints just the password value on stdout.
   local token
   token=$(security find-generic-password -s "$KEYCHAIN_SERVICE" -w 2>/dev/null) || token=""
   if [[ -n "$token" ]]; then
     export CLAUDE_CODE_OAUTH_TOKEN="$token"
     return 0
   fi
-  # File fallback.
   if [[ -r "$TOKEN_FILE" ]]; then
     export CLAUDE_CODE_OAUTH_TOKEN="$(cat "$TOKEN_FILE")"
     return 0
   fi
-  # Neither available: claude will try its own resolution, which likely
-  # fails in launchd context. The failure path is fine; it'll notify.
   return 1
 }
+
+# Allow sourcing this script to expose helpers (email_report, build_meta_block,
+# html_escape) without firing the full mise routine. Useful for verifying
+# Resend wiring in isolation.
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  return 0 2>/dev/null || true
+fi
 
 {
   echo ""
   echo "=== $(date -Iseconds) run-mise start ==="
 
   if ! cd "$HOMEBASE"; then
-    echo "FATAL: homebase dir missing at $HOMEBASE"
-    notify_failure "homebase dir missing"
+    reason="homebase dir missing at $HOMEBASE"
+    echo "FATAL: $reason"
+    summary="<div style=\"background:#ffebee;border-left:4px solid #c62828;padding:10px 14px;border-radius:4px;margin:0 0 12px 0;\"><strong style=\"color:#b71c1c;\">$reason</strong></div>"
+    if email_report "failure" "$summary" "" ""; then
+      echo "email: report sent"
+    else
+      echo "email: failed — $email_error"
+      notify_failure "$reason; email also failed: $email_error"
+    fi
+    notify_failure "$reason"
     exit 1
   fi
 
-  if ! command -v claude &>/dev/null; then
-    echo "FATAL: claude CLI not on PATH ($PATH)"
-    notify_failure "claude CLI missing"
-    exit 1
-  fi
-
-  if ! command -v jq &>/dev/null; then
-    echo "FATAL: jq not on PATH ($PATH). Success detection depends on jq."
-    notify_failure "jq missing"
-    exit 1
-  fi
+  for tool in claude jq curl security; do
+    if ! command -v "$tool" &>/dev/null; then
+      reason="$tool not on PATH ($PATH)"
+      echo "FATAL: $reason"
+      summary="<div style=\"background:#ffebee;border-left:4px solid #c62828;padding:10px 14px;border-radius:4px;margin:0 0 12px 0;\"><strong style=\"color:#b71c1c;\">$reason</strong></div>"
+      if email_report "failure" "$summary" "" ""; then
+        echo "email: report sent"
+      else
+        echo "email: failed — $email_error"
+        notify_failure "$reason; email also failed: $email_error"
+      fi
+      notify_failure "$reason"
+      exit 1
+    fi
+  done
 
   if load_oauth_token; then
     echo "auth: token loaded"
@@ -95,10 +119,6 @@ load_oauth_token() {
     echo "auth: no token found in keychain or file; relying on claude default"
   fi
 
-  # Run claude with explicit tool allowlist. No --dangerously-skip-permissions.
-  # Capture stdout only so $result stays pure JSON. stderr from claude (auth
-  # warnings, progress lines) falls through to the surrounding log block via
-  # its own redirect so it stays visible without corrupting jq parsing.
   result=$(claude -p "/assist:mise" \
     --allowedTools "${ALLOWED_TOOLS[@]}" \
     --output-format json)
@@ -107,20 +127,41 @@ load_oauth_token() {
   echo "$result"
   echo "=== $(date -Iseconds) run-mise end (exit $rc) ==="
 
+  meta_block=$(build_meta_block "$result" "$rc")
+  summary_block=$(build_summary_block "$result" "$rc" "Mise complete")
+  result_text=$(echo "$result" | jq -r '.result // ""' 2>/dev/null)
+  [[ -z "$result_text" ]] && result_text="$result"
+
   if [[ $rc -ne 0 ]]; then
-    notify_failure "claude exit $rc. Tail $LOG."
+    reason="claude exit $rc"
+    if email_report "failure" "$summary_block" "$result_text" "$meta_block"; then
+      echo "email: report sent ($reason)"
+    else
+      echo "email: report failed — $email_error"
+      notify_failure "$ROUTINE $reason; email also failed: $email_error"
+    fi
+    notify_failure "$reason. See email."
     exit "$rc"
   fi
 
-  # Positive confirmation: success subtype, no error, "Mise complete" in result.
   if ! echo "$result" | jq -e '.subtype == "success" and .is_error == false and ((.result // "") | contains("Mise complete"))' > /dev/null 2>&1; then
-    notify_failure "skill did not complete. Tail $LOG."
+    reason="skill did not complete"
+    if email_report "failure" "$summary_block" "$result_text" "$meta_block"; then
+      echo "email: report sent ($reason)"
+    else
+      echo "email: report failed — $email_error"
+      notify_failure "$ROUTINE $reason; email also failed: $email_error"
+    fi
+    notify_failure "$reason. See email."
     exit 1
   fi
 
-  # First non-empty line of the skill's result, e.g., "Mise complete ✓".
-  summary=$(echo "$result" | jq -r '.result // ""' | awk 'NF {print; exit}')
-  notify_success "${summary:-Mise complete}"
+  if email_report "success" "$summary_block" "$result_text" "$meta_block"; then
+    echo "email: success report sent"
+  else
+    echo "email: success report failed — $email_error"
+    notify_failure "$ROUTINE complete but email report failed: $email_error"
+  fi
 
   echo "=== $(date -Iseconds) run-mise success confirmed ==="
 } >> "$LOG" 2>&1


### PR DESCRIPTION
## Summary

- Per run email reports replace truncatable, silenceable osascript notifications as the source of truth for headless Claude agent runs. Body carries a green or red TL;DR callout, collapsed full output, last lines tail on failure, permission denials, and a run metadata table.
- New `bin/lib/email-report.sh` holds routine agnostic helpers (`email_report`, `build_summary_block`, `build_meta_block`, `html_escape`). Reads API key from Keychain (`resend-api-key`), recipient from `~/.config/headless-report/recipient`, sends from `Claude <claude@atelic.me>`. Subject is always `[<Routine>] YYYY-MM-DD` so the inbox stays calm and date sortable.
- `bin/run-mise` slimmed to source the lib and orchestrate. `BASH_SOURCE != $0` gate exposes helpers when the wrapper is sourced for ad hoc testing without firing mise.
- osascript demoted to a redundant fallback that fires only when the email path itself fails (missing key, missing recipient, curl error, Resend HTTP non-2xx).
- `.claude/references/headless-claude.md` updated to point new routines at the shared library.
- `.claude/local-skills/plugins/assist/skills/sharpen/learned-rules.md` adds a rule: audit existing routines' feedback channels before scaling to new ones.

## Test plan

- [x] Three live test sends through Resend after each iteration (initial pipeline, failure shape, post rotation). All `rc=0`, emails landed in `mattforni@gmail.com`.
- [x] API key in Keychain confirmed sending only scope (401 `restricted_api_key` on `GET /domains` rejects programmatic snooping).
- [x] Sourcing `bin/run-mise` exposes lib helpers without firing mise (`BASH_SOURCE` gate works).
- [x] `email_report` fail fast paths verified: missing API key returns rc=2, missing recipient returns rc=3, missing ROUTINE returns rc=1.
- [ ] Run `./setup.sh` to deploy the new `~/bin/run-mise` and `~/bin/lib/email-report.sh` so Monday's launchd fire uses the new pipeline.
- [ ] Confirm Monday morning live mise run lands as `[Mise] 2026-05-12` email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)