### PR TITLE
Extract Training Scheduling Into assist:training Skill

### DIFF
--- a/.claude/local-skills/plugins/assist/skills/schedule/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/schedule/SKILL.md
@@ -3,6 +3,7 @@ name: assist:schedule
 description: Weekly schedule planning, calendar management, and Monday morning task slotting. Use this skill whenever the user mentions their schedule, weekly planning, Monday planning session, slotting tasks, finding free time, checking what their week looks like, moving or swapping calendar events, or wants help fitting something into their week. Also trigger when the user asks about V2MOM measure coverage. Training plan scheduling lives in `assist:training`; this skill calls into it during Monday planning.
 argument-hint: "[plan | week | slot | move]"
 allowed-tools:
+  - Skill
   - Bash
   - mcp__claude_ai_Google_Calendar__*
   - mcp__claude_ai_Todoist__*
@@ -165,7 +166,12 @@ Move or swap an existing event.
 
 1. User describes what to move (e.g., "Move my Wednesday sauna to Thursday")
 2. Fetch the relevant events
-3. Check constraints (transitions, conflicts). When the target event is training (Sage color, training emoji, or session type like sauna / contrast / lift / run / climb), defer to `assist:training` move mode for full constraint validation, including cold plunge sequencing and Thursday SPRC protection.
+3. Check constraints (transitions, conflicts). Defer to `assist:training` move mode when any of these apply:
+   - the target event is training (Sage color, training emoji, or session type like sauna / contrast / lift / run / climb)
+   - the proposed destination lands in Thursday morning (SPRC window is protected regardless of what is being moved)
+   - the move could affect training adjacent sequencing (e.g., a sauna or contrast block landing on a strength day, an event displacing a recurring training session)
+
+   Include cold plunge sequencing and Thursday SPRC protection in that validation pass.
 4. Present the proposed change with any downstream impacts
 5. Execute after confirmation
 

--- a/.claude/local-skills/plugins/assist/skills/schedule/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/schedule/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assist:schedule
-description: Weekly schedule planning, calendar management, and Monday morning task slotting. Use this skill whenever the user mentions their schedule, weekly planning, Monday planning session, slotting tasks, finding free time, checking what their week looks like, moving or swapping calendar events, or wants help fitting something into their week. Also trigger when the user asks about training schedule, sauna timing, or whether they're covering their V2MOM measures.
+description: Weekly schedule planning, calendar management, and Monday morning task slotting. Use this skill whenever the user mentions their schedule, weekly planning, Monday planning session, slotting tasks, finding free time, checking what their week looks like, moving or swapping calendar events, or wants help fitting something into their week. Also trigger when the user asks about V2MOM measure coverage. Training plan scheduling lives in `assist:training`; this skill calls into it during Monday planning.
 argument-hint: "[plan | week | slot | move]"
 allowed-tools:
   - Bash
@@ -33,17 +33,15 @@ When there is a conflict between the template and the calendar, the calendar is 
 
 These constraints exist for real physiological and practical reasons. They are not suggestions.
 
-**Cold plunge timing**: No cold water immersion within 4-6 hours after strength training. Cold exposure blunts the inflammatory response needed for muscle adaptation. Sauna (heat only) is fine after strength. When moving sauna/contrast sessions, check whether strength training happened earlier that day.
-
 **Transitions**: Every movement between locations gets a 30-minute buffer. This is not travel time alone; it includes the mental shift between contexts. Do not schedule events back-to-back without a transition unless they are at the same location.
 
 **Fasting window**: Last meal at 18:30, first meal at 07:30 (13:11 intermittent fasting). Do not schedule dinner events after 18:30 without flagging the fasting impact.
 
-**Work hours**: 8:00-16:00 is the target. Mon/Tue/Thu in office at Zero Homes, Wed/Fri from home. Lunch breaks on Mon (yoga 12:15) and Tue (climbing 12:00) are already spoken for.
+**Work hours**: 8:00-16:00 is the target. Mon/Tue/Thu in office at Zero Homes, Wed/Fri from home. Lunch breaks on Mon (yoga 12:15) and Tue (lift 11:00) are already spoken for.
 
 **Lights out**: 21:30. Events that push past 21:00 should be flagged.
 
-**Thursday mornings**: No prayer/meditation/journaling on Thursdays. That time is reserved for getting to SPRC at 6:00 AM, which rotates locations.
+**Training adjacent constraints**: Cold plunge sequencing (4 to 6 hour gap after strength), sauna timing post strength, and Thursday SPRC morning protection live in the `assist:training` skill. Defer to that skill when validating moves of training, sauna, contrast, or Thursday morning events.
 
 ## Mode: plan (default)
 
@@ -61,7 +59,7 @@ The Monday morning planning session. This is the primary use case.
 
 - Overlapping busy events (two events claiming the same time)
 - One-off events that displace recurring template activities (e.g., a party during sauna time)
-- Constraint violations (cold plunge timing, missing transitions, fasting window breaches)
+- Constraint violations (missing transitions, fasting window breaches, training adjacent issues per `assist:training`)
 
 Present all conflicts to the user, one at a time or in small batches. For each conflict, propose a resolution:
 
@@ -72,6 +70,10 @@ Present all conflicts to the user, one at a time or in small batches. For each c
 **Never modify existing events without explicit permission.** Always present the conflict and proposed resolution, then wait for approval before taking any action. This is especially critical for events with other attendees or events booked via Reclaim.ai scheduling links (those were scheduled by other people). Be aware that deleting or moving adjacent events can cause Reclaim to auto-reschedule nearby flexible events as a side effect.
 
 Execute only the agreed changes before moving on. The calendar should be clean and conflict-free before the overview.
+
+### Phase 1.5: Training Scheduling
+
+Before the week overview and triage, ensure the week's training events are scheduled. Invoke the `assist:training` skill in `week` mode via the Skill tool. It will detect existing recurring placeholders (Mon yoga, Tue lift, Thu SPRC, Wed climb, etc.), surface what's missing, and create the variable one offs (Friday long run + paired drive blocks) following its own constraint logic. Return here once training scheduling is complete.
 
 ### Phase 2: Week Overview
 
@@ -163,7 +165,7 @@ Move or swap an existing event.
 
 1. User describes what to move (e.g., "Move my Wednesday sauna to Thursday")
 2. Fetch the relevant events
-3. Check constraints (cold plunge timing, transitions, conflicts)
+3. Check constraints (transitions, conflicts). When the target event is training (Sage color, training emoji, or session type like sauna / contrast / lift / run / climb), defer to `assist:training` move mode for full constraint validation, including cold plunge sequencing and Thursday SPRC protection.
 4. Present the proposed change with any downstream impacts
 5. Execute after confirmation
 
@@ -182,38 +184,7 @@ Include the location when the event is at a specific place.
 
 ## Training Plan Scheduling
 
-Schedule the week's training events from the active block plan in `/Users/forni/Eudaimonia/Constitution/Fitness/2026-training-plan.md`. Conventions live in `Constitution/Fitness/CLAUDE.md`. Title formats and color coding follow GC `Calendar Preferences`.
-
-### Detect existing placeholders first
-
-Before creating any training events, fetch the week's calendar and check for already existing recurring or one off events. Do not overwrite or duplicate. Only create what is missing for this specific week.
-
-| Cadence | Items | Action |
-|---------|-------|--------|
-| Recurring (assumed already on calendar) | Mon yoga 12:15, Tue lift 11:00, Tue DRC eve, Thu SPRC morning, Thu lift 11:00, Wed climb / PAH / sauna | Skip if present |
-| One off (variable, per week) | Fri long run + paired drive blocks | Create fresh each week |
-
-### Friday long run workflow
-
-1. Look up the current week row in `2026-training-plan.md` for **Long mi**, **Vert ft**, and **Fri shape** (route candidate or terrain).
-2. Pick a specific route matching those numbers. Use `WebSearch` on alltrails.com to find the trail page when needed.
-3. Confirm the route with the user via `AskUserQuestion` before creating events.
-4. Default start time is **07:00**. Front Range trailheads are ~30 min from Denver; altitude weeks (9, 10) are longer drives.
-5. Long run duration: budget ~15 to 16 min/mi for moderate trail pace with vert (e.g., 8 mi @ 1,500 ft is ~2 hr).
-6. Create three Fri events per GC Calendar Preferences:
-   - `🚙 <Trailhead Name>` — Basil (colorId 10) — drive out. Location = trailhead address. 30 min block aligned to 30 min increments (e.g., 06:30 to 07:00).
-   - `🏃 <MILES> mi Long Run` — Sage (colorId 2) — location = AllTrails URL.
-   - `🚙 Home` — Basil (colorId 10) — drive back. Same 30 min alignment.
-
-### Mon flex
-
-Optional easy ~4 mi run on Mon. Energy dependent. Do not auto schedule.
-
-### Special weeks
-
-- **Cutback weeks (4, 8)**: Fri long is shorter and on lighter terrain. Same workflow, smaller numbers.
-- **Altitude weeks (9, 10)**: Front Range altitude (week 9) or Aspen recon (week 10). Week 10 includes a Thu drive out + overnight; surface logistics to the user before creating events.
-- **Race week (13)**: Fri 7/31 is the FPL race itself. Coordinate the race day plan as a separate workflow, not a training long run.
+Training event creation lives in the `assist:training` skill. See that skill for the recurring placeholder table, Friday long run workflow, special weeks (cutback, altitude, race), Mon flex, and training adjacent constraints. Phase 1.5 above invokes it during Monday planning.
 
 ## Key Locations
 

--- a/.claude/local-skills/plugins/assist/skills/training/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/training/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: assist:training
+description: Training plan scheduling and training adjacent constraint validation. Use this skill whenever the user mentions training, lifts, runs, climbs, the Friday long run, sauna timing, cold plunge timing, recovery days, cutback weeks, altitude weeks, race week, training restructure, Fitbod, or asks to schedule a training session. Also trigger for "/assist:training", "schedule my long run", "what does training look like this week", or any request that touches the training plan in `Constitution/Fitness/`. Independently usable, and also called by `/assist:schedule` during Monday planning.
+argument-hint: "[week | long-run | move]"
+allowed-tools:
+  - Bash
+  - mcp__claude_ai_Google_Calendar__*
+  - WebSearch
+  - WebFetch
+  - Read
+  - Edit
+  - Write
+  - AskUserQuestion
+---
+
+# Training Assist
+
+Help Forni schedule the week's training events from the active block plan, validate training adjacent constraints, and move training sessions safely. The skill is independently invocable, and also gets called by `/assist:schedule` during Monday planning before triage and slotting.
+
+## Before Every Invocation
+
+1. Read [learned-rules.md](learned-rules.md) in this directory
+2. Read the canonical training context:
+   - `/Users/forni/Eudaimonia/Constitution/Fitness/2026-training-plan.md` — current block plan with weekly Long mi, Vert ft, Fri shape
+   - `/Users/forni/Eudaimonia/Constitution/Fitness/CLAUDE.md` — training conventions
+   - `/Users/forni/Eudaimonia/schedule.md` — recurring weekly anchors (yoga, lifts, climbs, SPRC, sauna)
+3. Determine the target week. Default to the current ISO week. Use `date +"%G-W%V"` for the week identifier.
+
+## Source of Truth
+
+The training plan lives at `Constitution/Fitness/2026-training-plan.md`. The weekly skeleton (recurring anchors) lives at `schedule.md`. Google Calendar holds the live reality, including one off events (Friday long run + paired drives, race weekends, altitude trips).
+
+When there is a conflict between the plan and the calendar, the calendar is the current truth. The plan describes what a "normal" training week should look like.
+
+## Training Constraints
+
+These constraints exist for real physiological and practical reasons. They are not suggestions.
+
+**Cold plunge timing**: No cold water immersion within 4 to 6 hours after strength training. Cold exposure blunts the inflammatory response needed for muscle adaptation. Sauna (heat only) is fine after strength. When moving sauna or contrast sessions, check whether strength training happened earlier that day.
+
+**Thursday mornings**: No prayer, meditation, or journaling on Thursdays. That time is reserved for getting to SPRC at 6:00 AM, which rotates locations.
+
+**Fasting window adjacency**: Last meal at 18:30, first meal at 07:30. Long runs starting at 07:00 begin in the fasted state, ending close to or just after the first meal window. Plan fueling around this. Do not propose long runs that push deep into the fasted window without flagging.
+
+## Calendar Event Conventions
+
+Color coding, transition / travel, and title formats live in GC `Calendar Preferences`. Training specific use:
+
+- Training events use Sage (colorId 2): runs, lifts, yoga, body care, recovery
+- Long runs: `🏃 <MILES> mi Long Run`
+- Travel to trailheads: `🚙 <LOCATION>` with the destination in the title (Basil, colorId 10)
+- Drive home: `🚙 Home` (Basil, colorId 10)
+- Travel events use 30 minute increments aligned to 30 minute blocks (e.g., 06:30 to 07:00, not 06:15 to 07:00)
+- Every change of location needs flanking transition or travel events. A long run is incomplete without its drive flanks.
+
+## Mode: week (default)
+
+Schedule the week's training events from the active block plan. This is the mode `/assist:schedule` calls during Monday planning.
+
+### Phase 1: Detect Existing Placeholders
+
+Fetch the week's calendar events (Monday through Sunday) and check for already existing recurring or one off events. Do not overwrite or duplicate. Only create what is missing for this specific week.
+
+| Cadence | Items | Action |
+|---------|-------|--------|
+| Recurring (assumed already on calendar) | Mon yoga 12:15, Tue lift 11:00, Tue DRC eve, Thu SPRC morning, Thu lift 11:00, Wed climb / PAH / sauna | Skip if present |
+| One off (variable, per week) | Fri long run + paired drive blocks | Create fresh each week |
+
+If a recurring placeholder is missing, surface it to the user rather than silently creating it. The user may have skipped the session this week intentionally.
+
+### Phase 2: Friday Long Run
+
+Run the Friday long run workflow (see Mode: long-run below). This is the primary one off creation each week.
+
+### Phase 3: Special Week Handling
+
+Check the current week number against the training plan and apply special week logic:
+
+- **Cutback weeks (4, 8)**: Fri long is shorter and on lighter terrain. Same workflow, smaller numbers.
+- **Altitude weeks (9, 10)**: Front Range altitude (week 9) or Aspen recon (week 10). Week 10 includes a Thu drive out + overnight; surface logistics to the user before creating events.
+- **Race week (13)**: Fri 7/31 is the FPL race itself. Coordinate the race day plan as a separate workflow, not a training long run.
+
+### Phase 4: Mon Flex
+
+Optional easy ~4 mi run on Mon. Energy dependent. Do not auto schedule. Surface as an option, do not create without explicit user confirmation.
+
+## Mode: long-run
+
+Standalone Friday long run workflow. Use when the user wants to plan or replan just the long run without doing a full week pass.
+
+1. Look up the current week row in `2026-training-plan.md` for **Long mi**, **Vert ft**, and **Fri shape** (route candidate or terrain).
+2. Pick a specific route matching those numbers. Use `WebSearch` on alltrails.com to find the trail page when needed.
+3. Confirm the route with the user via `AskUserQuestion` before creating events.
+4. Default start time is **07:00**. Front Range trailheads are ~30 min from Denver; altitude weeks (9, 10) are longer drives.
+5. Long run duration: budget ~15 to 16 min/mi for moderate trail pace with vert (e.g., 8 mi @ 1,500 ft is ~2 hr).
+6. Create three Fri events per GC Calendar Preferences:
+   - `🚙 <Trailhead Name>` — Basil (colorId 10) — drive out. Location = trailhead address. 30 min block aligned to 30 min increments (e.g., 06:30 to 07:00).
+   - `🏃 <MILES> mi Long Run` — Sage (colorId 2) — location = AllTrails URL.
+   - `🚙 Home` — Basil (colorId 10) — drive back. Same 30 min alignment.
+
+## Mode: move
+
+Move or swap a training event with constraint validation.
+
+1. User describes what to move (e.g., "Move Tuesday's lift to Wednesday", "Reschedule sauna to Friday")
+2. Fetch the relevant events
+3. Validate against training constraints:
+   - Cold plunge sequencing: if moving a cold plunge or contrast session, check that no strength training happened in the prior 4 to 6 hours
+   - Thursday SPRC protection: do not propose moves that displace Thu 06:00 SPRC unless the user explicitly intends to skip
+   - Transition flanks: if the moved event involves a location change, ensure the destination day has the matching drive or transition blocks
+4. Present the proposed change with any downstream impacts
+5. Execute after confirmation
+
+When moving recurring events for just one week, modify only that occurrence, not the entire series. When the user wants a permanent change, update the series and flag that `schedule.md` and the training plan may need updating.
+
+**Never modify existing events without explicit permission.** Always present the proposed move and wait for approval. Reclaim auto reschedule effects can ripple through nearby flexible events; warn when they're at risk.
+
+## Key Locations
+
+| Name | Address |
+|------|---------|
+| Movement RiNo | 3201 Walnut St #107, Denver, CO 80205 |
+| Naosu Sauna | 3145 Larimer St, Denver, CO 80205 |
+
+## Learned Rules
+
+See [learned-rules.md](learned-rules.md) for live, mutable training rules. Stable conventions live in this file; corrections and current life shape rules go there.

--- a/.claude/local-skills/plugins/assist/skills/training/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/training/learned-rules.md
@@ -1,0 +1,26 @@
+# Learned Rules
+
+Training specific rules tied to current life shape. Read on every invocation. Stable training conventions live in [SKILL.md](SKILL.md); rules that need updating as the season, plan, or body changes go here.
+
+## Pace and Distance
+
+- **Long run pace budget**: ~15 to 16 min/mi for moderate trail pace with vert. Use this when computing duration (e.g., 8 mi @ 1,500 ft is ~2 hr). Adjust upward for altitude weeks.
+- **Default long run start time**: 07:00. Front Range trailheads are ~30 min from Denver, so the drive block starts at 06:30. Altitude weeks (9, 10) need longer drive flanks; surface before creating events.
+
+## Calendar Mechanics
+
+- **30 min alignment for travel blocks**: Drive events use 30 minute increments aligned to 30 minute blocks (06:30 to 07:00, not 06:15 to 07:00). Transitions default to 30 minutes (size, not alignment).
+- **Always create both drive flanks**: A long run event without a paired `🚙 <Trailhead>` and `🚙 Home` is incomplete. Create all three together.
+
+## Mon Flex
+
+- **Never auto schedule Mon flex**: The Monday easy ~4 mi run is energy dependent. Surface as an option, never create without explicit user confirmation.
+
+## Recurring Placeholders
+
+- **Do not silently create missing recurring events**: If a Mon yoga / Tue lift / Thu SPRC / Wed climb is missing this week, surface it to the user. They may have skipped intentionally.
+
+## Constraint Hygiene
+
+- **Cold plunge after strength**: 4 to 6 hour gap is non-negotiable. Sauna (heat only) is fine after strength; the gap rule applies to cold immersion only.
+- **Thursday morning is protected**: SPRC at 06:00 displaces all morning practices on Thursday. No prayer, meditation, or journaling slotted into Thu AM.


### PR DESCRIPTION
## Summary

- New `assist:training` skill (`SKILL.md` + `learned-rules.md`) that owns recurring training placeholder detection, the Friday long run workflow, special weeks (cutback / altitude / race), Mon flex, cold plunge sequencing, and Thursday SPRC protection.
- `assist:schedule` trimmed: training trigger removed from description, training adjacent constraints replaced with one line pointer, "Training Plan Scheduling" section collapsed to a pointer, new Phase 1.5 invokes `assist:training` via the Skill tool during Monday planning, move mode defers to it for training events.
- Both skills remain independently invocable. Net: schedule loses ~30 lines of training detail; training gains a focused ~290 line spec.

## Test Plan

- [ ] Run `./setup.sh` from homebase to deploy both skills to `$HOME/.claude/`
- [ ] `/assist:training` standalone in `week` mode → reads training plan, surfaces missing recurring events, proposes Friday long run via AskUserQuestion
- [ ] `/assist:training long-run` → goes straight to Friday long run workflow
- [ ] `/assist:training move` → asks which event, validates constraints, executes after confirmation
- [ ] `/assist:schedule` Monday planning → Phase 1 conflict resolution → Phase 1.5 invokes `assist:training` via Skill tool → Phase 2 overview → Phase 2.5 triage → Phase 3 slotting
- [ ] Trigger smoke test: "schedule my Friday long run" selects `assist:training`, "let's do Monday planning" selects `assist:schedule`

🤖 Generated with [Claude Code](https://claude.com/claude-code)