### PR TITLE
Add atelic Navigation Alias

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -35,6 +35,7 @@ alias docker-stop='docker stop $(docker ps -a -q)'
 alias ed-vsc-settings='vim ~/.vscode/settings.json'
 
 # Navigation Aliases
+alias atelic="cd ~/Eudaimonia/Craft/atelic"
 alias homebase="cd ~/Eudaimonia/Craft/Development/personal/homebase"
 alias eudy="cd ~/Eudaimonia"
 


### PR DESCRIPTION
## Summary

- Add `atelic` to the Navigation Aliases block, alongside `homebase` and `eudy`, for a one keystroke jump to `~/Eudaimonia/Craft/atelic`.
- `~/.aliases` is symlinked to `homebase/.aliases`, so the live shell picks this up automatically; no `setup.sh` rerun needed.

## Test plan

- [x] `type atelic` resolves to `cd ~/Eudaimonia/Craft/atelic`
- [x] Pairs with Eudy's `atelic-promote` PR which moves atelic-api and atelic-app under `Craft/atelic/`