### PR TITLE
Drop Wed Climb From assist:training Placeholder Table

### DIFF
--- a/.claude/local-skills/plugins/assist/skills/training/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/training/SKILL.md
@@ -63,7 +63,7 @@ Fetch the week's calendar events (Monday through Sunday) and check for already e
 
 | Cadence | Items | Action |
 |---------|-------|--------|
-| Recurring (assumed already on calendar) | Mon yoga 12:15, Tue lift 11:00, Tue DRC eve, Thu SPRC morning, Thu lift 11:00, Wed climb / PAH / sauna | Skip if present |
+| Recurring (assumed already on calendar) | Mon yoga 12:15, Tue lift 11:00, Tue DRC eve, Thu SPRC morning, Thu lift 11:00, Wed PAH / sauna | Skip if present |
 | One off (variable, per week) | Fri long run + paired drive blocks | Create fresh each week |
 
 If a recurring placeholder is missing, surface it to the user rather than silently creating it. The user may have skipped the session this week intentionally.


### PR DESCRIPTION
## Summary

- Removes the Wed climb entry from the `assist:training` Phase 1 recurring placeholder table. The skill no longer expects a Wed 11:00 climb on the calendar.
- Tracks the parallel Eudaimonia change that drops the Wednesday climbing anchor from `schedule.md`, the training plan, and the Fitness README.

## Test plan

- [ ] `/assist:training week` for a Wednesday no longer flags missing Wed climb
- [ ] Recurring placeholder detection treats Wed correctly with only PAH + sauna

🤖 Generated with [Claude Code](https://claude.com/claude-code)