### PR TITLE
Add retro Mode to assist:training and Elevate Vert to First Class

### DIFF
--- a/.claude/local-skills/plugins/assist/skills/training/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/training/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: assist:training
-description: Training plan scheduling and training adjacent constraint validation. Use this skill whenever the user mentions training, lifts, runs, climbs, the Friday long run, sauna timing, cold plunge timing, recovery days, cutback weeks, altitude weeks, race week, training restructure, Fitbod, or asks to schedule a training session. Also trigger for "/assist:training", "schedule my long run", "what does training look like this week", or any request that touches the training plan in `Constitution/Fitness/`. Independently usable, and also called by `/assist:schedule` during Monday planning.
-argument-hint: "[week | long-run | move]"
+description: Training plan scheduling, weekly retrospectives, and training adjacent constraint validation. Use this skill whenever the user mentions training, lifts, runs, climbs, the Friday long run, sauna timing, cold plunge timing, recovery days, cutback weeks, altitude weeks, race week, training restructure, Fitbod, asking to schedule a training session, or asking to look back / retrospect on a past training week. Also trigger for "/assist:training", "schedule my long run", "what does training look like this week", "how did last week go", "training retro", or any request that touches the training plan in `Constitution/Fitness/`. Independently usable, and also called by `/assist:schedule` during Monday planning.
+argument-hint: "[week | long-run | move | retro]"
 allowed-tools:
   - Bash
   - mcp__claude_ai_Google_Calendar__*
+  - mcp__strava__*
   - WebSearch
   - WebFetch
   - Read
@@ -114,6 +115,90 @@ Move or swap a training event with constraint validation.
 When moving recurring events for just one week, modify only that occurrence, not the entire series. When the user wants a permanent change, update the series and flag that `schedule.md` and the training plan may need updating.
 
 **Never modify existing events without explicit permission.** Always present the proposed move and wait for approval. Reclaim auto reschedule effects can ripple through nearby flexible events; warn when they're at risk.
+
+## Mode: retro
+
+Look back on a completed (or in progress) training week. Compare planned vs actual coverage, mileage, vert, and qualitative shape. Save the result to `Constitution/Fitness/retros/YYYY-WNN.md` so adherence can be tracked across the block.
+
+### Phase 1: Determine the Target Week
+
+- Default: the most recently completed ISO week (`date -v-mon -v-7d +"%G-W%V"` style logic, or simply the prior Monday-to-Sunday window).
+- If today is Sunday, the user usually means the current week (Monday through today). Confirm by asking briefly when ambiguous.
+- File name uses the ISO week identifier (e.g., `2026-W19.md`).
+
+### Phase 2: Gather Data
+
+Pull from three sources in parallel:
+
+1. **Training plan**: read the row in `2026-training-plan.md` for the target week. Note **Long mi**, **Vert ft**, **Fri shape**, **Weight** target, **Nutrition focus**.
+2. **Google Calendar**: list opaque events for the week. Filter to training relevant (Sage colorId 2, training emojis, or session keywords like SPRC, DRC, lift, climb, sauna, contrast, long run).
+3. **Strava**: pull all activities for the week via `mcp__strava__get-all-activities` with `startDate` and `endDate`. Then call `mcp__strava__get-activity-details` on each run to get **distance** and **elevation gain in meters** (convert to ft: meters * 3.28084).
+
+### Phase 3: Build the Coverage Table
+
+For every planned session in the week, record actual status. Sources:
+
+- Yoga, lifts, climb (if any): calendar event present = scheduled. Lifts at Movement RiNo do **not** show in Strava — confirm with the user when a lift's status is unclear, do not assume missed.
+- Runs (DRC, SPRC, long run, Mon flex): match Strava activities by date and approximate distance.
+- Recovery (sauna, contrast): calendar event present is the signal.
+
+Mark each session as `✅` (hit), `❌` (missed), `↪️` (shifted), `❓` (open / status unknown), or `n/a` (not applicable this week).
+
+### Phase 4: Compute the Numbers
+
+| Metric | Sources |
+|---|---|
+| Total miles | Sum of Strava run distances (km * 0.621371) |
+| Long run miles | The longest run / trail run of the week |
+| Vert ft | Sum of Strava elevation gain across runs (m * 3.28084) |
+| Weight | Sunday morning weigh-in if available; otherwise note as `pending` |
+
+Compare each against the plan row. Express delta as percentage and direction.
+
+**Vert is co-equal with mileage.** The plan tracks both; the retro evaluates against both. Hitting mileage and missing vert (e.g., long run on flat terrain instead of trail) is a partial hit, not a hit.
+
+### Phase 5: Write the Retro File
+
+Write to `Constitution/Fitness/retros/YYYY-WNN.md` using this skeleton:
+
+```markdown
+# Wk N Retro: ISO YYYY-WNN (Mon Date to Sun Date)
+
+*Block: <block name>. Phase: <phase>. Wk N of <total>.*
+
+## Coverage
+
+| Session | Plan | Actual |
+|---|---|---|
+...
+
+## Numbers
+
+| Metric | Plan | Actual | Delta |
+|---|---|---|---|
+| Total miles | ... | ... | ... |
+| Long run miles | ... | ... | ... |
+| Vert ft | ... | ... | ... |
+| Weight | ... | ... | ... |
+
+## The Read
+
+<2 to 4 short paragraphs on what hit, what slipped, what's open. Be specific and direct. Avoid effusive praise or hedging.>
+
+## Carry Forward
+
+<Bullets for next week: structural fixes, defended slots, calibration adjustments.>
+
+## Open Items
+
+<Things unresolved at retro time, e.g. lift status pending Strava upload or user confirmation.>
+```
+
+Before writing, present the draft inline and ask the user one question via `AskUserQuestion`: anything to add or correct? Save after they confirm or redirect.
+
+### Phase 6: Surface Trends
+
+After saving, briefly check the prior 1 to 2 retros in `Constitution/Fitness/retros/` (if they exist). Surface any pattern: repeated misses, drifting metrics, growing or shrinking adherence. Keep this short — one or two sentences. Do not invent patterns when there is not enough data.
 
 ## Key Locations
 

--- a/.claude/local-skills/plugins/assist/skills/training/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/training/learned-rules.md
@@ -18,9 +18,19 @@ Training specific rules tied to current life shape. Read on every invocation. St
 
 ## Recurring Placeholders
 
-- **Do not silently create missing recurring events**: If a Mon yoga / Tue lift / Thu SPRC / Wed climb is missing this week, surface it to the user. They may have skipped intentionally.
+- **Do not silently create missing recurring events**: If a Mon yoga / Tue lift / Thu SPRC is missing this week, surface it to the user. They may have skipped intentionally.
 
 ## Constraint Hygiene
 
 - **Cold plunge after strength**: 4 to 6 hour gap is non-negotiable. Sauna (heat only) is fine after strength; the gap rule applies to cold immersion only.
 - **Thursday morning is protected**: SPRC at 06:00 displaces all morning practices on Thursday. No prayer, meditation, or journaling slotted into Thu AM.
+
+## Long Run Day
+
+- **Long runs are Friday, not Saturday.** WFH Fri is the slot that makes the long run in the mountains possible; Saturday is open / adventure. A Fri-to-Sat slip should be a deliberate one-time choice, never a default. Flag it explicitly when retros show the long landing on a non-Friday.
+
+## Retro Evaluation
+
+- **Vert is co-equal with mileage.** The training plan tracks both Long mi and Vert ft per week. A retro that only evaluates mileage misses half the point. Always pull elevation gain from Strava activity details and total against the plan's Vert ft target.
+- **Lifts at Movement RiNo do not show in Strava.** When a lift is missing from Strava, the status is **open**, not missed. Confirm with the user before logging it as a miss in the retro. Same applies to climbing at Movement.
+- **Strava run elevation in meters; convert to feet.** `meters * 3.28084`. Worth doing per activity then summing, since the plan's vert target is in feet.


### PR DESCRIPTION
## Summary

- New mode: **`retro`**. Looks back on a completed (or in progress) training week. Pulls data from the block plan, Google Calendar, and Strava (with elevation gain converted from meters to feet) to build a coverage table, numbers comparison vs plan, qualitative read, and carry forward notes. Saves to `Constitution/Fitness/retros/YYYY-WNN.md` so adherence is tracked across the block.
- **Vert is now co-equal with mileage** in evaluation. Hitting mileage on flat terrain when the plan calls for vert is a partial hit, not a hit.
- Frontmatter updated: `allowed-tools` adds `mcp__strava__*`, `argument-hint` adds `retro`, description picks up retrospective triggers ("how did last week go", "training retro", etc.).
- Learned rules added: long runs are Friday (Fri-to-Sat slip is a deliberate one-time choice, not a default); lifts at Movement RiNo do not show in Strava (status open, not missed, until user confirms); Strava elevation is meters and converts via `meters * 3.28084`.

## Test Plan

- [ ] `/assist:training retro` for the prior ISO week produces a coverage table, numbers comparison vs plan (mileage + vert + long run), the read, and carry forward
- [ ] Vert is computed from Strava activity details (`get-activity-details` per run, summed in feet)
- [ ] Retro file saved to the correct path (`Constitution/Fitness/retros/YYYY-WNN.md`) after user confirms or redirects via AskUserQuestion
- [ ] `assist:training week` and `long-run` modes still work (no regression from the frontmatter or section additions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)