### PR TITLE
Add sdlc:groom Skill, Validated Against Atelic Backlog Groom

### DIFF
--- a/plugins/sdlc/skills/groom/SKILL.md
+++ b/plugins/sdlc/skills/groom/SKILL.md
@@ -80,16 +80,22 @@ Hierarchy. Fall through if the prior is absent:
 8. **Apply** via the CLI (or MCP) after approval.
 9. **Audit** every kept ticket for project + label attribution.
 
-### Backlog Mode (Draft)
+### Backlog Mode
 
-1. **Scope** the backlog. Capture total open issue count, distribution by status, priority, label, and last updated date.
-2. **Identify** clear stale candidates: items with no priority AND no recent activity (heuristic: 9+ months untouched) AND no assignee AND no project.
-3. **Cluster** the rest of the backlog by label or theme. The largest labels usually carry the most signal.
-4. **Walk** clusters one at a time. For each issue: keep at current priority, set priority, defer with `Later` (or equivalent label), or cancel. Use AskUserQuestion per ticket in the gray zone; reserve batch tables for structurally uniform clusters (e.g., the obvious stale sweep).
-5. **Archive Done items** as a final pass. Linear's archive moves them out of active views without losing the record.
-6. **Capture learnings** as rules in [learned-rules.md](learned-rules.md) for the next groom.
+Calibrated against the Atelic 2026-05-10 run (118 backlog items, solo, no roadmap doc).
 
-The above is a sketch. Calibrate against the Atelic 2026-05 run and replace this section with the specifics.
+1. **Scope** the backlog. Total count, distribution by status, priority, label, last-updated date. Use the CLI `linear issue query --state backlog --json --limit 250` piped to a file; on large teams the output may exceed inline token limits.
+2. **Identify the team's deferral label** (e.g., `👋 Later`). Detection heuristic: a single non-priority label appearing on 30 percent or more of older Backlog items. This label is sacred; items carrying it are working as designed. See [conventions.md](reference/conventions.md).
+3. **Surface stale sweep candidates** that do NOT carry the deferral label, have no priority, and have not been updated in 9+ months. These are the truly orphaned items.
+4. **Cluster the rest by topic** (Pantry, Meal Planning, Recipes, Strava, Auth, etc.) using title-keyword grep. Topic clustering surfaces real signal in solo backlogs where labels are mostly the deferral label.
+5. **Ask the meta-question first.** Before walking each cluster, ask: what is the policy on the deferral label? "Universal walk-past" is the most common answer and shrinks the decision space dramatically (Atelic: 118 items down to 46).
+6. **Verify shipped work against the actual code** for any cluster of implementation tickets that look stale (e.g., the feature is described as working in CLAUDE.md but tickets remain Backlog). Decide: mark Done, or demote to Low for follow-up.
+7. **Cluster batch decisions** via AskUserQuestion (up to four batched questions per round). Each option includes a label and one-sentence rationale. Common cluster outcomes: keep parked, demote to Low, cancel cluster, pull subset into next cycle.
+8. **Walk the gray zone individually** with per-ticket AskUserQuestion. Reserve batch tables for structurally uniform clusters; the gray zone is where the skill earns its keep.
+9. **Apply via CLI** (preferred) or MCP. Hard deletes require the CLI: `linear issue delete <ID> --confirm`. Loop singles, never `--bulk`.
+10. **Verify** the new priority distribution via `linear issue query --state backlog | jq '.nodes | group_by(.priorityLabel)'`. The High items should now read as actual shipping work.
+
+The Done archive is a separate pass. Linear's archive is UI-only as of CLI v2.0.0; multi-select Status=Done in the UI and bulk archive.
 
 ## Hard Rules
 
@@ -141,11 +147,11 @@ The MCP `list_issues` response can exceed token limits on large teams. Pipe to a
 
 ## Conventions
 
-See [reference/conventions.md](reference/conventions.md) for classification heuristics, capacity math, and priority normalization. (Stub for cycle mode lifted from `zero:linear-groom`; backlog mode rules to be filled after the first real run.)
+See [reference/conventions.md](reference/conventions.md) for classification heuristics, capacity math, and priority normalization. Backlog mode rules calibrated against the Atelic 2026-05-10 run.
 
 ## Walkthroughs
 
-See [reference/examples.md](reference/examples.md) for step by step flows: cycle grooming (mid cycle, end of cycle, start of cycle) and backlog grooming. (Cycle examples lifted; backlog example to be written after the Atelic 2026-05 run.)
+See [reference/examples.md](reference/examples.md) for step-by-step flows: backlog walkthrough (the most common case for solo/small-team projects without active cycles), and the three cycle-mode walkthroughs (mid-cycle, end-of-cycle, start-of-cycle).
 
 ## Learned Rules
 

--- a/plugins/sdlc/skills/groom/SKILL.md
+++ b/plugins/sdlc/skills/groom/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: sdlc:groom
+description: Groom a Linear team's queue. Two modes — cycle grooming (when the team runs Linear cycles, trim the active cycle to a realistic slate) and backlog grooming (when the team has a backlog without active cycles, triage by priority, staleness, and intent). Use whenever the user mentions Linear grooming, triaging issues, pruning a backlog, sprint grooming, "the cycle is overstuffed", "let's clean up the queue", "groom the backlog", or wants to make decisions across many issues at once. Use the Linear CLI when available; fall back to the Linear MCP otherwise.
+allowed-tools:
+  - Bash(linear *)
+  - mcp__claude_ai_Linear__list_issues
+  - mcp__claude_ai_Linear__get_issue
+  - mcp__claude_ai_Linear__save_issue
+  - mcp__claude_ai_Linear__list_issue_statuses
+  - mcp__claude_ai_Linear__list_issue_labels
+  - mcp__claude_ai_Linear__list_cycles
+  - mcp__claude_ai_Linear__get_team
+  - AskUserQuestion
+  - Read
+  - Grep
+---
+
+# SDLC Groom
+
+Keep a Linear team's queue honest. Two modes; same workflow shape: scope, partition, present, apply.
+
+Adapted from `zero:linear-groom` (cycle mode) with backlog mode added for teams that do not run cycles.
+
+## When to Use
+
+Trigger on:
+
+- The cycle is "overstuffed", "bloated", "needs trimming", or scope drifted from plan
+- The backlog has accumulated and needs triage ("groom the backlog", "prune the queue")
+- "Sprint grooming" (Linear calls them cycles, same concept)
+- Mid cycle review when remaining days do not match remaining work
+- Quarterly or stand still backlog cleanup
+- The user says "groom Linear", "triage the queue", "clean up Linear"
+
+Do NOT use for:
+
+- Single ticket CRUD (create, comment, status update). Use `linear-lifecycle:linear-lifecycle`.
+- Cross team structural work (initiatives, projects spanning quarters). Use a roadmap doc.
+
+## Modes
+
+The skill auto detects mode from the team's state. The user may force a mode by saying "groom the backlog" (forces backlog mode) or "groom the cycle" (forces cycle mode).
+
+### Cycle Mode
+
+The team has an active cycle with issues in it. Goal: trim/keep/move/reprioritize to a realistic slate for the remaining days. Mostly lifted from `zero:linear-groom`.
+
+### Backlog Mode
+
+No active cycle, just a backlog (potentially with hundreds of issues). Goal: triage by priority, staleness, label, and user intent. The skill clusters issues by label or theme and walks them with the user.
+
+**This mode is a draft.** The first real backlog groom (Atelic team, 2026-05) will surface concrete heuristics that turn into hard rules. After that run, this section gets calibrated and the loose edges become learned rules.
+
+## Prerequisites
+
+- **Linear access.** Linear CLI preferred (`linear --version` ≥ 2.0.0, `linear issue mine` succeeds). Falls back to Linear MCP if CLI is missing. The CLI is faster, supports hard delete, and avoids the MCP token overhead.
+- **Team key.** The user names the team. The skill resolves to the Linear team ID. If unclear, ask.
+- **Optional roadmap or vision doc.** Pointer to a markdown file describing strategic focus. The skill reads it for guidance and falls back to user judgment when absent.
+
+## Source of Truth
+
+Hierarchy. Fall through if the prior is absent:
+
+1. **Active cycle plan** in a roadmap doc (cycle mode only).
+2. **Project descriptions** in Linear (pillar matching, see conventions.md).
+3. **Issue priority + staleness + label** (heuristic baseline, primary signal in backlog mode).
+4. **User judgment** via AskUserQuestion. The gray zone is where this skill earns its keep.
+
+## Core Loop
+
+### Cycle Mode
+
+1. **Scope** the active and next cycle. Capture cycle number, date range, business days remaining, and issue count (open / done / total).
+2. **Sync** roadmap terminology to Linear's taxonomy (Initiative → Project → Issue + Cycle) before partitioning. If the doc collapses layers, fix the doc first as a one shot commit, then proceed.
+3. **Read** the cycle plan from the roadmap doc (if present) and project descriptions for pillars.
+4. **List** open issues in the active cycle.
+5. **Partition** into Keep / Move / Backlog / Reprioritize / Cancel buckets per [conventions.md](reference/conventions.md).
+6. **Present** the diff as a table grouped by action. Auto process only the Keep bucket.
+7. **Resolve ambiguity** in a Phase 2 pass, grouped by category. Use AskUserQuestion per ticket in the gray zone.
+8. **Apply** via the CLI (or MCP) after approval.
+9. **Audit** every kept ticket for project + label attribution.
+
+### Backlog Mode (Draft)
+
+1. **Scope** the backlog. Capture total open issue count, distribution by status, priority, label, and last updated date.
+2. **Identify** clear stale candidates: items with no priority AND no recent activity (heuristic: 9+ months untouched) AND no assignee AND no project.
+3. **Cluster** the rest of the backlog by label or theme. The largest labels usually carry the most signal.
+4. **Walk** clusters one at a time. For each issue: keep at current priority, set priority, defer with `Later` (or equivalent label), or cancel. Use AskUserQuestion per ticket in the gray zone; reserve batch tables for structurally uniform clusters (e.g., the obvious stale sweep).
+5. **Archive Done items** as a final pass. Linear's archive moves them out of active views without losing the record.
+6. **Capture learnings** as rules in [learned-rules.md](learned-rules.md) for the next groom.
+
+The above is a sketch. Calibrate against the Atelic 2026-05 run and replace this section with the specifics.
+
+## Hard Rules
+
+- **Non destructive by default.** Prefer move, reprioritize, or backlog over cancel/delete. Never silently destroy.
+- **Diff before apply.** Always present the proposed slate as a table and wait for explicit approval. Auto apply is reserved for the Keep bucket (which by definition changes nothing).
+- **Preserve history.** Touch only `cycle`, `priority`, `state`, `project`, `parent`, `labels`. Do not edit descriptions, titles, comments, or assignees unless explicitly asked.
+- **One team at a time.** Default scope is whatever the user names. Do not silently widen.
+- **Capacity check (cycle mode).** Keep bucket must fit `business_days × active_owners × multiplier` (start at 0.9, calibrate). If over, push back before approving.
+- **Walk the gray zone individually.** Per ticket AskUserQuestion with three to four labeled options. Reserve batch tables for the auto keep cluster and structurally uniform clusters.
+- **Explain every move.** Each proposed change gets a one line rationale. "Move, owner on vacation" beats "Move".
+
+## Quick Reference
+
+### Linear CLI (preferred where installed)
+
+| Operation | Command |
+|---|---|
+| List cycles for team | `linear cycle list --team $LINEAR_TEAM` |
+| View cycle details | `linear cycle view <cycleRef>` |
+| List open in active cycle | `linear issue query --team $LINEAR_TEAM --cycle active --state unstarted --state started --json` |
+| List backlog | `linear issue query --team $LINEAR_TEAM --state backlog --json --limit 250` |
+| Move issue to cycle N | `linear issue update <ID> --cycle <N>` |
+| Return to backlog | `linear issue update <ID> --state Backlog` (auto clears cycle) |
+| Reprioritize | `linear issue update <ID> --priority <1-4>` |
+| Cancel | `linear issue update <ID> --state Canceled` |
+| Hard delete | `linear issue delete <ID> --confirm` |
+| View a single issue | `linear issue view <ID>` |
+
+Priority integers: 1 = Urgent, 2 = High, 3 = Normal, 4 = Low.
+
+**State and cycle interaction.** Setting `--state Backlog` clears the ticket's `cycleId` automatically. Setting `--state Canceled` keeps the `cycleId` but flips `statusType` to canceled, dropping the ticket from active views.
+
+**Bulk delete gotcha.** `linear issue delete --bulk <ids> --confirm` still prompts interactively in CLI v2.0.0. Loop single deletes. Bulk also pulls in child issues automatically.
+
+### Linear MCP (fallback)
+
+| Operation | Tool |
+|---|---|
+| List issues by team and state | `mcp__claude_ai_Linear__list_issues(team, state, limit)` |
+| Get issue detail | `mcp__claude_ai_Linear__get_issue(id)` |
+| Update issue (state, priority, cycle, labels) | `mcp__claude_ai_Linear__save_issue(id, ...)` |
+| List cycles | `mcp__claude_ai_Linear__list_cycles(team)` |
+| List statuses | `mcp__claude_ai_Linear__list_issue_statuses(team)` |
+| List labels | `mcp__claude_ai_Linear__list_issue_labels(team)` |
+
+The MCP does not expose hard delete. When deletion is required, use the CLI or the Linear UI.
+
+The MCP `list_issues` response can exceed token limits on large teams. Pipe to a file via the harness and `jq` rather than loading inline.
+
+## Conventions
+
+See [reference/conventions.md](reference/conventions.md) for classification heuristics, capacity math, and priority normalization. (Stub for cycle mode lifted from `zero:linear-groom`; backlog mode rules to be filled after the first real run.)
+
+## Walkthroughs
+
+See [reference/examples.md](reference/examples.md) for step by step flows: cycle grooming (mid cycle, end of cycle, start of cycle) and backlog grooming. (Cycle examples lifted; backlog example to be written after the Atelic 2026-05 run.)
+
+## Learned Rules
+
+Real grooming runs surface gotchas, calibration numbers, and edge cases the generic rules miss. Those land in [learned-rules.md](learned-rules.md). Read that file before each groom; a learned rule overrides the generic guidance when they conflict.

--- a/plugins/sdlc/skills/groom/learned-rules.md
+++ b/plugins/sdlc/skills/groom/learned-rules.md
@@ -10,7 +10,31 @@ Each rule states the rule, the reason, and how to apply it. Keep them tight; the
 
 ## Rules
 
-(empty — to be populated as the skill is used)
+### CLI is the default tool, not MCP. Auth per workspace before grooming.
+
+When a user has both Linear MCP and Linear CLI available, default to the CLI for grooming actions. The MCP gets used only for read-only inspection when the CLI is not auth'd to the target workspace. Reasons: MCP cannot hard-delete, MCP fuzzy-maps state names imprecisely (the "Canceled" gotcha below), and the user may have explicitly requested CLI.
+
+**Why:** Atelic groom 2026-05-10. Forni said "Let's default to using the CLI instead of the MCP" mid-session after observing MCP's `state: "Canceled"` mapping to "Duplicate" status (Linear has both as canceled-type). The CLI-first default avoids that surprise.
+
+**How to apply:** Before starting a groom, check `linear auth list` and confirm the target workspace is configured. If not, prompt the user to run `linear auth login` and pick the workspace. Once auth'd, prefer CLI commands (`linear issue update`, `linear issue delete --confirm`) over MCP `save_issue`.
+
+### MCP `save_issue` with `state: "Canceled"` may map to "Duplicate" status.
+
+The Linear MCP fuzzy-matches state names. Passing `state: "Canceled"` can land the issue in the "Duplicate" status (also a canceled-type, but semantically different — implies superseded by another issue). If you want literal "Canceled" via MCP, pass the explicit state ID for Canceled (visible from `list_issue_statuses`), not the name string.
+
+**Why:** Surfaced on the first Atelic groom run when ATE-349 came back with `status: "Duplicate"` after a `state: "Canceled"` update.
+
+**How to apply:** When canceling via MCP, either (a) accept the Duplicate-vs-Canceled imprecision since both hide the issue from active views, (b) pass the explicit Canceled state UUID, or (c) use the CLI: `linear issue update ATE-NNN --state Canceled`.
+
+### A team's deferral label is sacred. Do not include it in the stale sweep.
+
+The naive backlog stale-sweep heuristic (no priority + no recent activity + no assignee + no project) misfires on any team that uses a label like `👋 Later` to mean "intentionally deferred, save the intent." Items carrying that label are working as designed; bulk canceling them erases real intent.
+
+**Why:** Surfaced on the first Atelic groom run (2026-05-10). Of 37 candidates that matched the naive stale heuristic, 32 carried `👋 Later`. Mass canceling would have lost 32 deliberately-parked aspirations.
+
+**How to apply:** Detect the team's deferral convention before sweeping. Look at label distribution on Backlog issues; if a single non-priority label is on a large fraction of older items, treat it as the deferral signal and exclude it from the sweep. Stale candidates are then `(no priority + stale + no project + does not carry the deferral label)`. For Atelic, the label is `👋 Later`. For other teams, find the equivalent.
+
+
 
 ### Lifted from `zero:linear-groom`
 

--- a/plugins/sdlc/skills/groom/learned-rules.md
+++ b/plugins/sdlc/skills/groom/learned-rules.md
@@ -1,0 +1,29 @@
+# SDLC Groom: Learned Rules
+
+Session specific gotchas and calibration captured from real grooming runs. These override the generic guidance in SKILL.md and reference/ when they conflict.
+
+Read this file before each groom. Add to it after.
+
+## Format
+
+Each rule states the rule, the reason, and how to apply it. Keep them tight; the value is in the specifics.
+
+## Rules
+
+(empty — to be populated as the skill is used)
+
+### Lifted from `zero:linear-groom`
+
+The following rules came from real Growth team groom runs and are likely to apply to most cycle grooming work. Validate during cycle mode runs; promote into the rules above if they hold.
+
+- **Pillar first matching trumps keyword matching.** A project's description lists its pillars. An issue that maps to a pillar belongs with that project in whichever cycle that project is in focus, regardless of surface level keyword matches to other cycles' bullets.
+- **In Progress beats alignment.** When a ticket is In Progress or In Review, leave it in its current cycle even if the plan does not call for it. Disrupting flowing work is worse than temporary misalignment.
+- **Default to next cycle and defer, not multi cycle projection.** When unsure whether work belongs in C5 vs C6, push to the next cycle and plan to re groom at its start.
+- **Bulk delete is broken.** `linear issue delete --bulk <ids> --confirm` still prompts interactively in CLI v2.0.0. Loop single deletes. Bulk also pulls in child issues automatically.
+- **`--state Backlog` clears the cycle field automatically.** Don't chain a separate cycle reset; the state change is sufficient.
+- **Walk the gray zone individually with AskUserQuestion.** Forni's preferred UX: per ticket question with three to four labeled options (Keep / Move / Backlog / Cancel + recommended). Reserve batch tables for auto keep and structurally uniform clusters.
+- **Course correction cascade.** When a directional decision lands mid groom (e.g., "kill X wholesale"), revisit earlier decisions in the same session that depended on the now stale assumption.
+- **Bulk cross project moves trip the safety gate.** A loop of more than ~10 project reassignments via Bash gets denied as mass modification. Surface the explicit target list via AskUserQuestion before re attempting.
+- **Effort matters in classification.** A title that sounds campaign shaped might be a 30 minute audit. Ask about effort when the cycle plan match is fuzzy. A low effort high value ticket can stay even if it does not perfectly match.
+- **Capacity multiplier starts at 0.9.** First C3 run predicted 10 Keep but reality was 16; multiplier was too conservative at 0.6. Recalibrate per team.
+- **Project deletion needs `--force`.** `linear project delete <id>` errors with "Interactive confirmation required." Issue delete uses `--confirm` instead. Different flag names for similar gates.

--- a/plugins/sdlc/skills/groom/reference/conventions.md
+++ b/plugins/sdlc/skills/groom/reference/conventions.md
@@ -1,0 +1,179 @@
+# SDLC Groom Conventions
+
+Classification heuristics, capacity math, and priority rules. SKILL.md is the workflow; this file is how to make the judgment calls inside that workflow.
+
+## Pre-Groom Checks
+
+Before classification, do two cheap checks. Each saves hours later.
+
+### 1. Identify the team's deferral label
+
+Most teams use a single label to mean "intentionally deferred, save the intent". Common conventions: `👋 Later`, `🔮 Future`, `Someday`, `🏝️ Parked`. The label distribution will give it away — if one non-priority label appears on a large fraction (30 percent or more) of older Backlog items, that is almost certainly the deferral signal.
+
+**Why it matters.** This label is sacred. Items carrying it are working as designed. Bulk canceling them erases real intent. Treat them as walk-past in any stale sweep.
+
+### 2. Sync roadmap taxonomy to Linear (cycle mode only)
+
+If a roadmap doc is in play, confirm it uses Linear's taxonomy: **Initiative → Project → Issue + Cycle**. If the doc collapses layers, classification cascades fail. Fix the doc first as a single commit, then proceed.
+
+## Cycle Mode: Bucket Classification
+
+Apply rules in order. First match wins. Ordering matters: "in progress" beats "pillar match" beats "keyword match."
+
+### Keep
+
+- State is `In Progress` or `In Review` (work is flowing; disrupting is worse than the cycle being overstuffed)
+- OR pillar-matched to an in-focus project this cycle (pillars come from project descriptions, not cycle plan keywords)
+- OR named in the roadmap's cycle plan
+- OR priority is Urgent (override cycle plan; live fires)
+
+### Move to Next Cycle
+
+- Planned in the roadmap for a later cycle that overlaps with this one
+- OR assigned but not started AND `business_days_remaining < estimated_days`
+- OR blocked on external dependency that will not clear this cycle
+- OR owner unavailable for remainder of the cycle
+
+### Return to Backlog
+
+- Unassigned AND not updated in 14+ days AND not in cycle plan
+- OR priority Low AND not in progress
+- OR placeholder/stub body
+- OR superseded by a newer issue
+
+### Reprioritize
+
+In the right cycle but priority drifts from the plan emphasis.
+
+### Cancel/Delete
+
+Duplicate, superseded, or won't do. Deletion only on explicit user direction.
+
+## Backlog Mode: Bucket Classification
+
+Calibrated from the Atelic 2026-05 groom (118 backlog items, solo team, no roadmap doc).
+
+Apply in order. First match wins.
+
+### Walk Past (Sacred Deferral)
+
+- Carries the team's deferral label (see pre-groom check)
+
+This bucket frequently dominates. Atelic: 56 of 118 (47 percent). Treat as walk-past unless the user explicitly opts into walking by cluster.
+
+### Mark Done
+
+- Implementation completed but ticket never closed (verify against the actual code, not the ticket status)
+- OR superseded by shipped work
+
+Atelic: 9 Piper tickets verified against `app/services/ai_scoring_service.rb`, `app/controllers/v1/jobs_controller.rb`, etc. Forni opted to keep them in Backlog at Low priority instead of Done, since they may surface follow-up work. Both are valid; ask.
+
+### Set Low Priority, Leave in Backlog
+
+- Research, competitor investigation, or "go read X" tasks. Not implementation work.
+- OR shipped-but-may-need-polish (Piper case above)
+- OR off-focus relative to the current cycle's domain
+
+The honest signal of "not shipping work right now" is Low priority. Demoting prevents High items from cluttering the queue.
+
+### Hard Delete
+
+- Off-focus aspirational items the user explicitly says do not resonate
+- OR notes that belong in markdown (Eudy, working docs) not as Linear tickets
+- OR subsumed by retitled / expanded work
+
+Use the CLI: `linear issue delete <ID> --confirm`. The MCP cannot hard delete.
+
+### Pull Into Active Cycle
+
+- Aligns with the user's stated focus for the next 1-2 weeks
+- AND has a clear scope (or scope can be defined in 60 seconds)
+- AND fits remaining capacity (see math below)
+
+## Capacity Math
+
+```
+capacity = business_days_remaining × active_owners × multiplier
+```
+
+### Active owners
+
+Count distinct assignees in the bucket being measured. Do not use team headcount.
+
+For solo or part-time projects, owners is often 1 but the owner is fractional. The Atelic groom set Cycle 1 to 10 items for 10 work days × 1 owner × 0.9 = 9 (slightly over). Real-world calibration showed the part-time multiplier is closer to 0.5 to 0.7 when the owner has a day job + other repos.
+
+### Starting multiplier
+
+- Full-time team on cycle work: 0.9
+- Solo project, part-time: 0.5 to 0.7
+- Anything In Review counts as near-zero capacity
+- If the multiplier ever exceeds 1.0, the Keep definition is wrong (likely In-Review items being counted as active work)
+
+### After the groom
+
+Log `predicted_keep` vs `actual_keep` and adjust the multiplier per team. The right number depends on:
+
+- How many In-Review items are in the count
+- Whether assignees are full-time on cycle work
+- Meeting load, context switching, review cycles
+
+## Priority Normalization
+
+| Linear value | Name | Convention |
+|---|---|---|
+| 1 | Urgent | Live fire. Override cycle plan. |
+| 2 | High | Must land. |
+| 3 | Normal / Medium | Expected but slippable. |
+| 4 | Low | Stretch, or research, or shipped-but-followup. |
+| 0 | None | Untriaged. Treat as Low for scheduling. |
+
+When demoting research and competitor tickets to Low, the queue's High items become an honest list of "actually shipping work right now."
+
+Project priority tiers in a roadmap (P0/P1/P2/Parked) map to the issue priorities as follows:
+
+| Project priority | Default issue priority |
+|---|---|
+| P0 | High (2) |
+| P1 | Normal (3) |
+| P2 | Low (4) |
+| Parked | Low (4) |
+
+## Rationale Style
+
+Every proposed move needs a rationale. One line, plain English, names the cause.
+
+Good:
+
+- "Move, blocked on external dep, won't clear this cycle"
+- "Backlog, unassigned, untouched 28 days, not in plan"
+- "Reprioritize High to Normal, project is P1 this cycle, not P0"
+- "Keep, in progress, cycle plan item"
+- "Cancel, superseded by ATE-200"
+- "Demote to Low, research work, not implementation"
+
+Bad:
+
+- "Move, not realistic" (realistic why?)
+- "Backlog, stale" (stale how? for how long?)
+- "Reprioritize, seems wrong" (what does wrong mean here?)
+
+The reader is the user scanning the diff table for items to push back on. If the rationale does not help them decide, rewrite it.
+
+## When the Cycle Plan or Roadmap Is Missing
+
+Some teams (especially solo/personal teams) have no roadmap doc. Backlog mode handles this directly.
+
+In cycle mode without a plan:
+
+1. Report the gap: "No cycle plan found for this cycle."
+2. Fall back to user judgment via AskUserQuestion.
+3. Ask the user for the cycle's focus before proposing moves.
+4. Offer to draft a plan after triage as future-cycle source of truth.
+
+## Tool Selection
+
+Default to the Linear CLI for grooming actions. Use the MCP only for read-only inspection when the CLI is not auth'd to the target workspace.
+
+The CLI is more precise (state names map directly), supports hard delete, and avoids the MCP's fuzzy state mapping (the `state: "Canceled"` to "Duplicate" gotcha). Before grooming, run `linear auth list` and confirm the target workspace is configured.
+
+If `LINEAR_API_KEY` is set in the environment, it shadows the keychain auth and forces a single-workspace mode. Either unset it for grooming sessions or update it to the target workspace's token.

--- a/plugins/sdlc/skills/groom/reference/examples.md
+++ b/plugins/sdlc/skills/groom/reference/examples.md
@@ -1,0 +1,191 @@
+# SDLC Groom Examples
+
+Walkthroughs for the four common grooming situations. Each assumes the Linear CLI is installed and authenticated to the target workspace (`linear auth list` shows it).
+
+Set `$LINEAR_TEAM` to the team key for the session if you have not already.
+
+## Backlog Walkthrough
+
+The most common case for solo or small-team projects with no active cycle. The backlog has accumulated, priorities have drifted, and the user wants strategic focus.
+
+This is calibrated against the Atelic 2026-05 groom (118 backlog items, solo, no roadmap doc).
+
+### 1. Scope
+
+Pull the backlog and characterize the shape:
+
+```bash
+linear issue query --team "$LINEAR_TEAM" --state backlog --json --limit 250 > /tmp/backlog.json
+jq '.nodes | length' /tmp/backlog.json
+```
+
+Distribution by status, priority, label, and last-updated date. The MCP equivalent works but `list_issues` can exceed token limits on large teams; pipe to a file and use `jq` either way.
+
+Report the shape: total count, status breakdown, priority distribution, label frequency, oldest items.
+
+### 2. Identify the deferral label
+
+Per [conventions.md](conventions.md), find the team's "intentionally deferred" label. Atelic uses `👋 Later`. The signal is: a single non-priority label appearing on a large fraction (30 percent or more) of older Backlog items.
+
+Once identified, treat it as walk-past in the stale sweep.
+
+### 3. Stale sweep candidates
+
+```jq
+# Items without the deferral label, no priority, untouched in 9+ months
+.nodes[] | select(.state.name == "Backlog")
+        | select((.labels.nodes | map(.name) | index("👋 Later")) | not)
+        | select(.priority == 0)
+        | select(.updatedAt < "<cutoff>")
+```
+
+Surface these for the user. They are the truly orphaned candidates; the user decides cancel vs keep.
+
+### 4. Cluster by topic
+
+Cluster the rest of the backlog by topic, not by label. Labels in solo backlogs are mostly the deferral label. Topic clustering surfaces real signal.
+
+Topical clusters that came out of Atelic: Pantry, Meal Planning, Recipes, Nutrition Scoring, Training Plan, Strava/Activity, Jobs/Piper, Aspirational off-focus, Auth/Onboarding, Marketing/Pages.
+
+Use simple title keyword grep against the Backlog issue titles to bucket. Not every item lands cleanly; that is fine, the long tail goes into Misc.
+
+### 5. Meta-question first
+
+Before walking each cluster, ask one high-leverage meta-question: what is the policy on the deferral label?
+
+- Universal walk-past: trust the label, skip every item carrying it. Fastest path. The decision space shrinks dramatically.
+- Walk per-cluster: ask cluster by cluster.
+- No shortcut: re-evaluate every Later item.
+
+If the user picks universal walk-past, the remaining decision space is items WITHOUT the label. On Atelic this cut 118 items down to 46 actual decisions.
+
+### 6. Verify shipped work against the actual code
+
+For implementation tickets that look stale (no priority, low recent activity, no obvious blocker), check whether the code already exists. Atelic example: 9 Piper tickets all had corresponding files in `app/services/ai_scoring_service.rb`, `app/controllers/v1/jobs_controller.rb`, etc. They had been implemented without explicit ticket closure.
+
+The decision then becomes: mark Done, or demote to Low priority for any follow-up. Either is valid; ask.
+
+### 7. Cluster batch decisions
+
+For each cluster, propose one of:
+
+- Keep parked (apply deferral label, walk past)
+- Demote to Low priority (research/competitor cluster, shipped-with-followup cluster)
+- Cancel cluster (off-focus aspirational)
+- Pull subset into next cycle (focused cluster aligned with stated direction)
+- Walk individually (gray zone)
+
+Use AskUserQuestion with up to four batched questions per round. Each option has a label and one-sentence rationale.
+
+### 8. Walk the gray zone individually
+
+For items where the cluster decision does not fit, use per-ticket AskUserQuestion with three to four labeled options (Keep at current priority / Set Low priority / Defer with Later label / Cancel / Hard delete + recommended). Include a brief rationale per option.
+
+Reserve batch tables for structurally-uniform clusters; the gray zone is where the skill earns its keep.
+
+### 9. Apply via CLI
+
+```bash
+# Demote to Low
+for ID in <list>; do linear issue update ATE-$ID --priority 4; done
+
+# Cancel
+linear issue update ATE-<ID> --state Canceled
+
+# Hard delete (one at a time; --bulk is broken in CLI v2.0.0)
+for ID in <list>; do linear issue delete ATE-$ID --confirm; done
+
+# Pull into next cycle
+linear issue update ATE-<ID> --cycle <N>
+```
+
+If `LINEAR_API_KEY` is set in the env and shadows the keychain auth, prefix each call with `LINEAR_API_KEY=` to override per-call, or unset it for the session.
+
+### 10. Verify
+
+```bash
+linear issue query --team "$LINEAR_TEAM" --state backlog --json --limit 250 \
+  | jq '.nodes | group_by(.priorityLabel) | map({priority: .[0].priorityLabel, count: length})'
+```
+
+The new priority distribution tells the story: are the High items now the actual shipping work, or did things slip?
+
+## Mid-Cycle Walkthrough
+
+Cycle started clean, scope crept, remaining days do not match remaining work. Trigger phrases: "let us trim the cycle", "we have too much in here", "what should I drop."
+
+### 1. Scope
+
+```bash
+linear cycle list --team "$LINEAR_TEAM"
+```
+
+Capture: current cycle number, dates, business days remaining, issue count.
+
+### 2. Read cycle plan
+
+```bash
+grep -A 30 "^### Cycle Plan" "$ROADMAP_DOC"
+```
+
+Extract the row for the active cycle. Note per-Initiative focus.
+
+For each in-focus project, also read its Linear description for pillars (see conventions.md).
+
+### 3. List open in cycle
+
+```bash
+linear issue query \
+  --team "$LINEAR_TEAM" \
+  --cycle active \
+  --state unstarted --state started \
+  --json > /tmp/cycle-open.json
+```
+
+### 4. Partition
+
+Apply rules from [conventions.md](conventions.md). Bulk lands in Keep; the work is identifying borderline items for Move/Backlog/Reprioritize/Cancel.
+
+### 5. Present the diff
+
+Table format grouped by action. Capacity line at the top: "Keep bucket: 16. Capacity floor: 8 days × 2 owners × 0.9 = 14.4. Mild overcommit, OK if borderline items can slip."
+
+Flag priority mismatches in the Keep bucket so the user can bump if desired.
+
+### 6. Resolve ambiguity
+
+Group ambiguous tickets by category (in-progress-but-off-plan, dependency-adjacent, low-signal, etc.) and walk each group with AskUserQuestion. Do not bulk guess.
+
+### 7. Apply
+
+CLI commands to move, reprioritize, return to backlog, cancel.
+
+## End-of-Cycle Close-Out
+
+The cycle is ending. Decide what spills into the next cycle and what gets reopened as new scope.
+
+1. List open issues in the active cycle, including blocked states
+2. Anything In Progress: move to next cycle, keep priority
+3. Anything Todo with assignee: ask the user (move or backlog)
+4. Anything Todo unassigned: return to backlog by default
+5. Anything Canceled: leave it
+6. Generate close-out summary with counts per bucket
+
+No capacity math at end of cycle. The math happens at the start of the next cycle.
+
+## Start-of-Cycle Scoping
+
+Next cycle just started, plan is written, cycle is empty in Linear. Pulling in, not pushing out.
+
+1. Read the cycle plan row for the new cycle
+2. For each in-focus initiative, list its projects' backlog issues
+3. Cross-reference against cycle plan and project pillars
+4. Propose a slate sized to capacity
+5. Apply by setting `--cycle <N>` on each selected issue
+6. Post the slate as a comment on the cycle if requested
+
+**Do not auto-pull issues that were previously moved out** of the prior cycle without surfacing them. The prior move was a signal; repeating the prior mistake is how cycles stay overstuffed.
+
+## Dry-Run Pattern
+
+If the user asks for a dry run, complete steps 1 through 5 of the relevant walkthrough but stop before Apply. End with the diff table and a note: "No changes applied. Say 'apply' to proceed."


### PR DESCRIPTION
## Summary

Adds `sdlc:groom` skill at `plugins/sdlc/skills/groom/`. Two modes share the same workflow shape (scope, partition, present, apply):

- **Cycle mode** lifted from `zero:linear-groom`, generic-ified to drop Growth-team specifics. Source of truth via roadmap doc + project descriptions.
- **Backlog mode** drafted, then validated against a real run on the Atelic team (118 backlog items, solo, no roadmap doc). The skill now reflects the calibrated ten-step flow that worked.

Strong patterns kept across both modes: diff-before-apply, non-destructive defaults, per-ticket AskUserQuestion in the gray zone, capacity math, "explain every move" rationales, hard rules around what fields the skill is allowed to touch.

## Files

- `SKILL.md` — main skill, both modes
- `reference/conventions.md` — classification heuristics, capacity math, priority normalization, tool selection
- `reference/examples.md` — backlog walkthrough (new) + three cycle-mode walkthroughs (lifted)
- `learned-rules.md` — three rules captured from the Atelic run

## Learned rules captured

1. **The team's deferral label is sacred.** Atelic uses `👋 Later` on 47% of backlog items as intentional deferral. Bulk canceling them would erase real intent. Detect the team's deferral convention before any stale sweep and exclude it.
2. **CLI is the default, not MCP.** MCP fuzzy-mapped `state: "Canceled"` to `"Duplicate"`. CLI is precise and supports hard delete. MCP gets read-only fallback when CLI is not auth'd to the target workspace.
3. **MCP `save_issue` with `state: "Canceled"` may map to "Duplicate".** Both are canceled-type but Duplicate semantically implies superseded. Pass the explicit state UUID via MCP, or use the CLI.

## Real-data validation results from Atelic

- Started: 171 issues, 118 in Backlog, 70 with no priority, 5 Urgent, 39 Done lingering
- Ended: 115 in Backlog with cleaner priority distribution (High 6, Medium 17, Low 44, None 48); zero Urgent
- Cycle 1 populated with 10 nutrition-focused items (8 existing + 2 new MCP/migration tickets)
- 27 ops applied via CLI: 14 research/competitor demoted to Low, 9 Piper demoted to Low, 1 priority normalization (Urgent→Medium), 1 Instacart demote, 2 hard deletes
- Decision space cut from 118 items to 46 by applying the universal "deferral label is sacred" rule

## Test plan

- [x] Use the skill on the Atelic team backlog
- [x] Capture gotchas inline as Learned Rules during the run
- [x] Calibrate `reference/conventions.md` against actual data
- [x] Write `reference/examples.md` backlog walkthrough from the real flow
- [x] Replace SKILL.md draft backlog mode with calibrated ten-step flow