### PR TITLE
Add /assist:wrap Skill and UserPromptSubmit Hook

### DIFF
--- a/.claude/hooks/wrap-reminder.sh
+++ b/.claude/hooks/wrap-reminder.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# wrap-reminder.sh
+#
+# UserPromptSubmit hook. When Forni signals that the session is ending,
+# inject a brief reminder for Claude to propose /assist:wrap before exit.
+#
+# Wrap is the bookend to /assist:mise. It catches loose ends so nothing
+# leaves the session "in your head."
+#
+# Input: hook JSON on stdin with .prompt set to the user's message.
+# Output: JSON on stdout with hookSpecificOutput.additionalContext when
+#         a signoff signal is detected. Empty output otherwise.
+
+set -euo pipefail
+
+# Read hook payload from stdin.
+HOOK_INPUT=$(cat)
+
+# Extract the user's prompt. Fall back to empty string if jq missing
+# or the field is absent.
+USER_PROMPT=$(printf '%s' "$HOOK_INPUT" | jq -r '.prompt // empty' 2>/dev/null || true)
+
+if [[ -z "$USER_PROMPT" ]]; then
+  exit 0
+fi
+
+# Signoff patterns. Matches case-insensitive against the user's prompt.
+# Tuned to fire on genuine end-of-session signals, not casual mentions
+# of the word "exit" or "done" mid-task.
+SIGNOFF_REGEX='(^|[[:space:]])(/?exit\b|wrap (it |this )?(up|session)|wrapping up|signing off|done for (the )?(day|night)|good for (the )?(day|night)|i.m (out|done) (for|here)|that.?s a wrap|end of (the )?session|call it (a day|here))'
+
+if printf '%s' "$USER_PROMPT" | grep -qiE "$SIGNOFF_REGEX"; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext: "The user appears to be winding down the session. Before they exit, propose /assist:wrap to surface any loose ends (git/PR state, external commitments, codify candidates) and offload anything pending into Todoist. Wrap is the bookend to /assist:mise."
+    }
+  }'
+fi
+
+exit 0

--- a/.claude/local-skills/.claude-plugin/marketplace.json
+++ b/.claude/local-skills/.claude-plugin/marketplace.json
@@ -32,7 +32,8 @@
         "./skills/mise/SKILL.md",
         "./skills/permissions/SKILL.md",
         "./skills/present/SKILL.md",
-        "./skills/sharpen/SKILL.md"
+        "./skills/sharpen/SKILL.md",
+        "./skills/wrap/SKILL.md"
       ]
     }
   ]

--- a/.claude/local-skills/plugins/assist/skills/wrap/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/wrap/SKILL.md
@@ -27,7 +27,7 @@ The skill exists because Forni was running the same end-of-session sweep manuall
 
 ### Step 1: Build the Repo List
 
-The repos to scan are exactly the repos touched in this session. Do not maintain a fixed allowlist. Walk the conversation and any tool history for absolute paths used in Read, Edit, Write, or Bash calls. Resolve each path back to its containing git repo (`git -C <path> rev-parse --show-toplevel`). Deduplicate.
+The repos to scan are the repos touched in this session, no more and no less. Do not maintain a fixed allowlist. Walk the conversation and any tool history for absolute paths used in Read, Edit, Write, or Bash calls. Resolve each path back to its containing git repo (`git -C <path> rev-parse --show-toplevel`). Deduplicate.
 
 If the inference produces nothing (rare), fall back to the current working directory's repo only.
 
@@ -38,8 +38,21 @@ For each repo in the list:
 ```bash
 git -C "$REPO" status --porcelain
 git -C "$REPO" rev-parse --abbrev-ref HEAD
-git -C "$REPO" log @{u}..HEAD --oneline 2>&1
-gh --repo "$OWNER/$REPO" pr list --author @me --state open --json number,title,headRefName,reviewDecision 2>&1
+
+# Unpushed commits, only when an upstream is configured. A new local
+# branch has no @{u}; running the log against it would error.
+if git -C "$REPO" rev-parse --abbrev-ref --symbolic-full-name @{u} >/dev/null 2>&1; then
+  git -C "$REPO" log @{u}..HEAD --oneline
+else
+  echo "NO_UPSTREAM"
+fi
+
+# Open PRs, only when the repo has a GitHub remote. Derive the
+# owner/name slug from gh itself rather than threading $OWNER through.
+REPO_SLUG=$(gh -R "$REPO" repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
+if [ -n "$REPO_SLUG" ]; then
+  gh --repo "$REPO_SLUG" pr list --author @me --state open --json number,title,headRefName,reviewDecision
+fi
 ```
 
 Categorize per repo:
@@ -100,7 +113,7 @@ For each loose end Forni triaged to "today" or "Monday", create a Todoist task:
 Task title conventions from global memory:
 
 - Emoji prefix indicating task type (📧 email, 📞 call, 📝 form/doc, 🏠 home buying, 💼 vocation, etc.)
-- Short title with a link to the source in markdown format where available
+- Short title with a link to the source in Markdown format where available
 - No parenthetical clarification
 - Details go in a comment on the task, not in the description field
 

--- a/.claude/local-skills/plugins/assist/skills/wrap/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/wrap/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: assist:wrap
+description: Session wrap. Don't lose the thread, clean everything up, don't leave loose ends in your head. Scans every git repo touched this session for uncommitted or unpushed state, surfaces external commitments (pending replies, calendar holds, contract deadlines) from the recent conversation, prompts for codification of durable learnings, logs anything not handled into Todoist (today if pressing, next Monday otherwise), summarizes the session, and leaves Forni ready to /exit cleanly. Use this skill whenever Forni says "wrap", "wrap up", "wrap the session", "wrap this up", "wrapping up", "clean up before I exit", "signing off", "done for the day", or invokes /assist:wrap. Pairs with /assist:mise as the bookend. Mise opens the kitchen for service. Wrap closes it cleanly after.
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - AskUserQuestion
+  - Skill
+  - mcp__claude_ai_Todoist__add-tasks
+  - mcp__claude_ai_Todoist__find-projects
+---
+
+# Wrap
+
+End of session bookend. Don't lose the thread. Don't leave loose ends in your head.
+
+The skill exists because Forni was running the same end-of-session sweep manually: check git and PR state, scan recent work for unhandled commitments, decide what to codify, decide what to log to Todoist, exit. That is a routine. Routines should be automations.
+
+## Before Every Invocation
+
+1. Read this skill's local [learned-rules.md](learned-rules.md) for prior corrections.
+2. Read the plugin-wide [../../learned-rules.md](../../learned-rules.md) for cross-skill corrections that also apply.
+
+## Workflow
+
+### Step 1: Build the Repo List
+
+The repos to scan are exactly the repos touched in this session. Do not maintain a fixed allowlist. Walk the conversation and any tool history for absolute paths used in Read, Edit, Write, or Bash calls. Resolve each path back to its containing git repo (`git -C <path> rev-parse --show-toplevel`). Deduplicate.
+
+If the inference produces nothing (rare), fall back to the current working directory's repo only.
+
+### Step 2: Git and PR State
+
+For each repo in the list:
+
+```bash
+git -C "$REPO" status --porcelain
+git -C "$REPO" rev-parse --abbrev-ref HEAD
+git -C "$REPO" log @{u}..HEAD --oneline 2>&1
+gh --repo "$OWNER/$REPO" pr list --author @me --state open --json number,title,headRefName,reviewDecision 2>&1
+```
+
+Categorize per repo:
+
+- **Clean.** Working tree clean, in sync with origin, no open PRs needing Forni. Nothing to do.
+- **Uncommitted changes.** Surface and ask: commit (via `/sdlc:checkpoint`), stash, or discard.
+- **Unpushed commits.** Push, or leave intentionally with a note.
+- **Open PR awaiting Forni.** Surface review comments. Suggest `/sdlc:iterate`.
+- **Open PR awaiting reviewer.** Just flag for visibility.
+- **Merged PR with the branch still local.** Chain to `/sdlc:complete` via the Skill tool.
+
+When the session already ran `/sdlc:complete`, this step is usually fast and returns clean for the main repo.
+
+### Step 3: Surface External Commitments
+
+Walk the recent session conversation for items that imply someone is waiting on Forni, or Forni is waiting on someone:
+
+- Emails sent today (ball is in the counterparty's court — flag for tracking)
+- Calendar holds placed but unconfirmed
+- Tasks Forni said he would do "today" or "this morning"
+- Contract deadlines or external due dates touched in the session
+- Drafts saved but not sent
+
+Categorize each in three tiers:
+
+- ⚠️ **Today.** Action required before end of day. Forni is the blocker.
+- 🟡 **Sliding.** Soft target, no external party blocked. Forni's own commitment to himself.
+- ✅ **Awaiting counterparty.** Tracked, no action.
+
+### Step 4: Triage Each Loose End
+
+For each ⚠️ and 🟡 item, ask Forni via AskUserQuestion with these options:
+
+1. **Do now.** Handle in this session before exiting.
+2. **Todoist today.** Log a task due today with duration 30m.
+3. **Todoist Monday.** Log a task due next Monday for the Monday planning session, duration 30m.
+4. **Drop.** Item is no longer relevant. Acknowledge and move on.
+
+One question per item. Bulk decisions hide bad triage. Stick to ⚠️ and 🟡; ✅ items are tracking-only and don't need triage.
+
+### Step 5: Codify Check
+
+Walk the session for codifiable durables:
+
+- New rules, preferences, or gotchas surfaced
+- Patterns or conventions that became clear
+- Workflow improvements worth saving
+
+If candidates exist, ask Forni whether to invoke `/assist:codify` via the Skill tool for each candidate. If nothing is codifiable, say so explicitly and skip. Most sessions skip. Forcing codify creates documentation bloat.
+
+### Step 6: Todoist Logging
+
+For each loose end Forni triaged to "today" or "Monday", create a Todoist task:
+
+- **Today:** `dueString: "today"`, `duration: "30m"`
+- **Monday:** `dueString: "next Monday"`, `duration: "30m"`
+
+Task title conventions from global memory:
+
+- Emoji prefix indicating task type (📧 email, 📞 call, 📝 form/doc, 🏠 home buying, 💼 vocation, etc.)
+- Short title with a link to the source in markdown format where available
+- No parenthetical clarification
+- Details go in a comment on the task, not in the description field
+
+Use the project and section that best matches the loose-end's domain. Infer from context. Home buying tasks go under the home buying project; vocation tasks under 🛠️ Craft / 💼 Vocation; etc. Ask if the right project is genuinely ambiguous; otherwise infer and proceed.
+
+### Step 7: Session Summary
+
+One paragraph. Three beats:
+
+1. What was the work? (one phrase)
+2. What artifacts shipped? (PRs merged, files filed, decisions made, drafts sent)
+3. What is queued for next time? (loose ends now in Todoist)
+
+This is the breadcrumb for re-entry. Future Forni picks the thread back up from this paragraph.
+
+### Step 8: Exit Readiness
+
+End with one line: "Ready to /exit when you are."
+
+Do not invoke /exit automatically. Forni controls the exit. The skill prepares the ground; Forni walks off it.
+
+## Why Each Step Matters
+
+- **Session-touched repos, not a fixed allowlist.** Forni works across Eudaimonia, homebase, skillset, zero repos, and ad-hoc clones. A fixed list either misses repos or scans noise. Inferring from session activity matches the actual blast radius.
+- **Git scan first.** Highest-signal check. After `/sdlc:complete` this is usually fast and clean.
+- **Three-tier categorization over flat list.** ⚠️/🟡/✅ separates "act now" from "track" from "ignore". A flat list of "follow-ups" is noise.
+- **Triage one item at a time.** Bulk decisions hide bad triage. AskUserQuestion forces real choice per item.
+- **Codify is opt-in, never mandatory.** Most sessions have no new durable rules. Prompt only when candidates exist; skip cleanly otherwise.
+- **Todoist offload.** Anything not handled in-session goes to Todoist. Working memory should not carry loose ends across sessions. The Monday default channels non-urgent items into the existing Monday planning ritual.
+- **Don't auto-exit.** Wrap prepares the exit; Forni triggers it. Auto-exit would risk closing a session that still needs attention.
+
+## Output Shape
+
+```
+Wrap complete ✓
+
+Git / PRs:
+  Eudaimonia (main): clean
+  homebase (assist-wrap): 3 unpushed commits → pushed
+
+External commitments:
+  ⚠️ LBP waive form (sign today, due Monday)
+  🟡 Jeff CPA follow-up (slid from 5/14)
+  ✅ Bethany (Land Title) — awaiting her reply
+
+Codify: nothing new this session
+
+Logged to Todoist:
+  📝 Sign LBP form (today, 30m)
+  📞 Call Jeff re RYLLC 2024 (next Monday, 30m)
+
+Summary: Locked the NEO loan at 6.375%, filed HOA Status Letter and Loan Estimate, shipped PRs #43 and #44. Two follow-ups in Todoist for Monday planning.
+
+Ready to /exit when you are.
+```
+
+## Anti-patterns
+
+- Do not scan systems beyond git/PRs and recent-session implications. Slack, every inbox folder, Todoist contents, calendar week ahead, none of those. Comprehensive scans create noise that obscures real loose ends.
+- Do not log to Todoist without Forni's explicit triage for that item. No automatic bulk-dump to Monday.
+- Do not invoke /exit yourself. Wrap prepares; Forni exits.
+- Do not skip the summary even when there is "nothing to summarize." It is the re-entry breadcrumb.
+- Do not force codify. If the session did not produce a durable rule, say so and move on.
+- Do not maintain a fixed allowlist of repos. Repos to scan = repos touched in this session.
+
+## Learned Rules
+
+_(Empty. Populated as Forni corrects wrap's judgment over time.)_

--- a/.claude/local-skills/plugins/assist/skills/wrap/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/wrap/learned-rules.md
@@ -1,0 +1,5 @@
+# Wrap Learned Rules
+
+Skill-specific corrections that override SKILL.md. Populate as Forni corrects wrap's judgment over time.
+
+_(Empty.)_

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -197,5 +197,17 @@
   },
   "outputStyle": "Concise",
   "alwaysThinkingEnabled": true,
-  "skipAutoPermissionPrompt": true
+  "skipAutoPermissionPrompt": true,
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/wrap-reminder.sh"
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

Adds `/assist:wrap`, the bookend to `/assist:mise`. Mise opens the kitchen at the start of the day. Wrap closes it cleanly at the end of a session so nothing leaves the session "in your head."

Codifies the recurring end-of-session sweep that was already happening by hand: check git and PR state across every repo touched in the session, surface external commitments in three tiers (⚠️ today / 🟡 sliding / ✅ awaiting counterparty), triage each loose end (do now / Todoist today / Todoist Monday / drop), prompt for codification of any durable learnings, log items into Todoist with the existing conventions (emoji prefix, 30m duration, `dueString` of "today" or "next Monday"), and finish with a session summary plus "Ready to /exit when you are."

Three pieces:

- **Skill file** at `.claude/local-skills/plugins/assist/skills/wrap/SKILL.md`. Structure mirrors `/assist:mise`: before-every-invocation, numbered workflow steps, why-each-step-matters, output shape, anti-patterns, learned rules placeholder. Trigger phrases include "wrap", "wrap up", "signing off", "done for the day", "/assist:wrap"
- **Empty `learned-rules.md`** for the standard skill-correction pattern
- **Harness hook** at `.claude/hooks/wrap-reminder.sh` registered as a `UserPromptSubmit` hook in `settings.json`. Pattern-matches signoff signals in the user's input (`/exit`, "wrapping up", "signing off", "done for the day", "that's a wrap", "call it a day", etc.) and emits an `additionalContext` JSON object reminding Claude to propose `/assist:wrap` before the user exits. Stays silent when the prompt does not match a signoff signal, so it does not pollute the normal flow

Also adds `wrap` to the local-skills marketplace manifest so the plugin loader picks it up.

## Design notes

Followed the "manual first, then codify" rule from GC. This session ran a wrap manually before the skill was authored, and the learnings from that real run shaped the workflow steps and the anti-patterns list. Specifically:

- Three-tier commitment categorization (⚠️ / 🟡 / ✅) over a flat list, because a flat list of "follow-ups" is noise
- Per-item triage via AskUserQuestion rather than bulk decision, because bulk hides bad triage
- Codify as opt-in with explicit skip path, because most sessions have no new durable rule
- Repos to scan = repos touched this session (inferred from tool history), not a fixed allowlist
- Todoist dueString defaults to "next Monday" for non-urgent items so they channel into the existing Monday planning ritual

Hook tested locally against three prompts before commit:

- "wrapping up for the day" -> additionalContext emitted
- "let me check my email" -> silent (no match)
- "/exit" -> additionalContext emitted

## Test plan

- [ ] Run ./setup.sh (or /assist:mise) to deploy settings.json and .claude/hooks/wrap-reminder.sh to $HOME/.claude/
- [ ] Verify the hook fires on a signoff phrase in a fresh session ("ok wrapping up") and stays silent on a normal prompt
- [ ] Invoke /assist:wrap directly and walk through a session to validate the workflow against a real end-of-session state
- [ ] Confirm Todoist tasks created by the skill use the right project, section, emoji prefix, and 30m duration