### PR TITLE
Use $HOME and ~ in Place of Hard Coded Usernames

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -69,7 +69,7 @@ When building a workflow skill, do the work by hand once with real data before w
 
 ### Levels shorthand
 
-`L{N}` is shorthand for "Level N" of Bassi Eledath's 8 levels of agentic engineering (tracked in `/Users/mattforni/Eudaimonia/LEVELS.md`). E.g., L7 = Level 7 (background agents), L8 = Level 8 (agent teams). Use the shorthand freely in sharpen sessions and related discussion.
+`L{N}` is shorthand for "Level N" of Bassi Eledath's 8 levels of agentic engineering (tracked in `~/Eudaimonia/LEVELS.md`). E.g., L7 = Level 7 (background agents), L8 = Level 8 (agent teams). Use the shorthand freely in sharpen sessions and related discussion.
 
 ## External App Integration
 

--- a/.claude/local-skills/plugins/assist/skills/bd-email/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/bd-email/SKILL.md
@@ -160,15 +160,15 @@ Matthew Fornaciari
 
 All templates available in:
 
-- `/Users/forni/Craft/vocation/templates/`
+- `~/Craft/vocation/templates/`
 
 Contact database:
 
-- `/Users/forni/Craft/vocation/network/contacts.md`
+- `~/Craft/vocation/network/contacts.md`
 
 Project guidelines:
 
-- `/Users/forni/Craft/vocation/CLAUDE.md`
+- `~/Craft/vocation/CLAUDE.md`
 
 ## Gmail Integration
 

--- a/.claude/local-skills/plugins/assist/skills/job-apply/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/job-apply/SKILL.md
@@ -274,7 +274,7 @@ Filter by:
 
 ## Follow-Up Email Generation
 
-Use template: `/Users/forni/Craft/vocation/templates/07-job-posting-cold-outreach.md`
+Use template: `~/Craft/vocation/templates/07-job-posting-cold-outreach.md`
 
 ### Key Elements
 
@@ -399,16 +399,16 @@ When skill is invoked with job posting URL:
 
 **Email template:**
 
-- `/Users/forni/Craft/vocation/templates/07-job-posting-cold-outreach.md`
+- `~/Craft/vocation/templates/07-job-posting-cold-outreach.md`
 
 **Project guidelines:**
 
-- `/Users/forni/Craft/vocation/CLAUDE.md`
+- `~/Craft/vocation/CLAUDE.md`
 
 **Contact tracking:**
 
-- `/Users/forni/Craft/vocation/network/contacts.md`
+- `~/Craft/vocation/network/contacts.md`
 
 **Company profiles:**
 
-- `/Users/forni/Craft/vocation/companies/`
+- `~/Craft/vocation/companies/`

--- a/.claude/local-skills/plugins/assist/skills/mise/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/mise/SKILL.md
@@ -25,8 +25,8 @@ Two repos, one setup script. The skill exists because Forni was running the same
 
 | Shorthand | Absolute path |
 |---|---|
-| Eudy | `/Users/forni/Eudaimonia` |
-| Homebase | `/Users/forni/Eudaimonia/Craft/Development/personal/homebase` |
+| Eudy | `$HOME/Eudaimonia` |
+| Homebase | `$HOME/Eudaimonia/Craft/Development/personal/homebase` |
 
 Both are git repos. Homebase contains the authoritative `setup.sh` that deploys configs and refreshes tooling.
 
@@ -46,13 +46,13 @@ If the two paths differ for either repo, that repo is a linked worktree. Abort w
 
 ### Step 1: Sync Eudy
 
-Run the sync routine below against `/Users/forni/Eudaimonia`. See [Sync Routine](#sync-routine).
+Run the sync routine below against `$HOME/Eudaimonia`. See [Sync Routine](#sync-routine).
 
 If sync produces a merge conflict, stop mise. Do not continue to homebase or setup.sh. Report the conflict so Forni can resolve it.
 
 ### Step 2: Sync Homebase
 
-Run the same sync routine against `/Users/forni/Eudaimonia/Craft/Development/personal/homebase`.
+Run the same sync routine against `$HOME/Eudaimonia/Craft/Development/personal/homebase`.
 
 Same conflict handling: stop on conflict, do not proceed to setup.sh.
 

--- a/.claude/local-skills/plugins/assist/skills/present/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/present/learned-rules.md
@@ -2,11 +2,11 @@
 
 ## macOS Screenshot filenames contain narrow no-break spaces
 
-`/Users/mattforni/Screenshots/Screenshot YYYY-MM-DD at H.MM.SS PM.png` looks like it has regular spaces, but the byte between the seconds and `AM`/`PM` is U+202F (NARROW NO-BREAK SPACE), not U+0020.
+`~/Screenshots/Screenshot YYYY-MM-DD at H.MM.SS PM.png` looks like it has regular spaces, but the byte between the seconds and `AM`/`PM` is U+202F (NARROW NO-BREAK SPACE), not U+0020.
 
 **Why:** A literal `cp "Screenshot 2026-04-30 at 2.02.02 PM.png"` will fail with "No such file or directory" even though the file appears in `ls`. Burned ~2 minutes during the 2026-04-30 demo build trying to copy a dashboard screenshot.
 
-**How to apply:** Reference these files via glob, not literal path. `cp /Users/mattforni/Screenshots/*"2.02.02"*"PM.png" <dest>` works because the glob matches the actual byte sequence.
+**How to apply:** Reference these files via glob, not literal path. `cp ~/Screenshots/*"2.02.02"*"PM.png" <dest>` works because the glob matches the actual byte sequence.
 
 ## Forni cuts hard during planning — trust the cuts
 

--- a/.claude/local-skills/plugins/assist/skills/schedule/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/schedule/SKILL.md
@@ -21,12 +21,12 @@ Help Forni manage his weekly schedule: review the week, slot Todoist tasks into 
 ## Before Every Invocation
 
 1. Read [learned-rules.md](../../learned-rules.md) for any schedule-specific corrections
-2. Read the weekly template: `/Users/forni/Eudaimonia/schedule.md`
+2. Read the weekly template: `~/Eudaimonia/schedule.md`
 3. Determine the current week (Monday through Sunday) based on today's date
 
 ## Source of Truth
 
-The weekly template lives at `/Users/forni/Eudaimonia/schedule.md`. It defines the recurring skeleton: work hours, training sessions, transitions, recovery, and community commitments. The Google Calendar holds the live reality, including one-off events and Reclaim work blocks.
+The weekly template lives at `~/Eudaimonia/schedule.md`. It defines the recurring skeleton: work hours, training sessions, transitions, recovery, and community commitments. The Google Calendar holds the live reality, including one-off events and Reclaim work blocks.
 
 When there is a conflict between the template and the calendar, the calendar is the current truth. The template describes what a "normal" week should look like.
 
@@ -237,5 +237,5 @@ Use the `gws` CLI tool (via Bash) for Gmail operations during planning. Common u
 - When slotting a task, always set: date/time via reschedule-tasks, then duration + Scheduled label via update-tasks.
 - Todoist deadlineDate is Premium-only. Note deadlines in the task description instead.
 - Transition and travel conventions are in GC `Calendar Preferences`. Both Basil. Transition is *holding space* (context shift, destination in description). Travel is *explicit* (drive / transit, destination in title).
-- When a Todoist bookmark is really an open question rather than an action (description phrased as a question, "Investigate" prefix, no clear next step), capture it as a koan under `/Users/forni/Eudaimonia/koans/<topic>.md` and delete the Todoist task. Don't punt to next Monday — questions don't get less true with time.
+- When a Todoist bookmark is really an open question rather than an action (description phrased as a question, "Investigate" prefix, no clear next step), capture it as a koan under `~/Eudaimonia/koans/<topic>.md` and delete the Todoist task. Don't punt to next Monday — questions don't get less true with time.
 - EnterWorktree at the start of plan mode if any Eudaimonia repo edits are anticipated (schedule.md changes, koan creation, file moves). Don't wait until mid session — relocating uncommitted edits to a worktree later requires stash/pop and is avoidable. Use a date stamped name like `schedule-YYYY-MM-DD` and rename the branch to drop the `worktree-` prefix per global GC instructions.

--- a/.claude/local-skills/plugins/assist/skills/sharpen/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/sharpen/SKILL.md
@@ -20,7 +20,7 @@ Move our collaboration one rung at a time toward Level 7 (background agents) and
 ## Before Every Invocation
 
 1. Read [learned-rules.md](../../learned-rules.md) for any prior corrections about how Forni wants sharpen to run.
-2. Read [LEVELS.md](../../../../../../Eudaimonia/LEVELS.md) (absolute path: `/Users/mattforni/Eudaimonia/LEVELS.md`) to anchor on current state and recent log entries.
+2. Read [LEVELS.md](../../../../../../Eudaimonia/LEVELS.md) (absolute path: `~/Eudaimonia/LEVELS.md`) to anchor on current state and recent log entries.
 3. Check this skill's directory for a local `learned-rules.md` and read it if present.
 
 ## Principles
@@ -37,9 +37,9 @@ Move our collaboration one rung at a time toward Level 7 (background agents) and
 
 Pull recent activity to ground the session. Run these in parallel when possible.
 
-- **Recent git activity in Eudaimonia**: `git -C /Users/mattforni/Eudaimonia log --since="7 days ago" --oneline`
-- **Recent auto memory entries**: Read `/Users/mattforni/.claude/projects/-Users-mattforni-Eudaimonia/memory/MEMORY.md` and skim the most recently added feedback_*.md files
-- **Recent plan files**: `ls -lt /Users/mattforni/.claude/plans/ | head -10` and read titles
+- **Recent git activity in Eudaimonia**: `git -C ~/Eudaimonia log --since="7 days ago" --oneline`
+- **Recent auto memory entries**: Read `~/.claude/projects/-Users-mattforni-Eudaimonia/memory/MEMORY.md` and skim the most recently added feedback_*.md files
+- **Recent plan files**: `ls -lt ~/.claude/plans/ | head -10` and read titles
 - **Optional focus area**: If the user gave a focus in arguments (e.g., "zero code review"), narrow the scan to commits, memories, and plans relating to that area
 
 ### Step 2: Find patterns
@@ -76,7 +76,7 @@ Small enough to finish in session. If the chosen move is larger than session siz
 
 ### Step 6: Log
 
-Append a new entry to `/Users/mattforni/Eudaimonia/LEVELS.md` under `## Log` with:
+Append a new entry to `~/Eudaimonia/LEVELS.md` under `## Log` with:
 
 ```markdown
 ### YYYY-MM-DD — [one line title]
@@ -94,7 +94,7 @@ If the session altered the Current State table (a dimension's level genuinely ch
 
 If the session surfaced a rule, preference, or insight worth preserving:
 
-- **Cross-skill correction** → append to `/Users/mattforni/.claude/local-skills/plugins/assist/learned-rules.md`
+- **Cross-skill correction** → append to `~/.claude/local-skills/plugins/assist/learned-rules.md`
 - **Sharpen-specific rule** → append to this skill's `learned-rules.md` (create if missing)
 - **Broader Eudaimonia convention** → invoke `assist:codify` for the full three-layer write up
 

--- a/.claude/local-skills/plugins/assist/skills/training/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/training/SKILL.md
@@ -22,9 +22,9 @@ Help Forni schedule the week's training events from the active block plan, valid
 
 1. Read [learned-rules.md](learned-rules.md) in this directory
 2. Read the canonical training context:
-   - `/Users/forni/Eudaimonia/Constitution/Fitness/2026-training-plan.md` — current block plan with weekly Long mi, Vert ft, Fri shape
-   - `/Users/forni/Eudaimonia/Constitution/Fitness/CLAUDE.md` — training conventions
-   - `/Users/forni/Eudaimonia/schedule.md` — recurring weekly anchors (yoga, lifts, climbs, SPRC, sauna)
+   - `~/Eudaimonia/Constitution/Fitness/2026-training-plan.md` — current block plan with weekly Long mi, Vert ft, Fri shape
+   - `~/Eudaimonia/Constitution/Fitness/CLAUDE.md` — training conventions
+   - `~/Eudaimonia/schedule.md` — recurring weekly anchors (yoga, lifts, climbs, SPRC, sauna)
 3. Determine the target week. Default to the current ISO week. Use `date +"%G-W%V"` for the week identifier.
 
 ## Source of Truth

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -80,8 +80,7 @@
       "Bash(while:*)",
       "Bash(xargs:*)",
       "Bash(~/.zshrc)",
-      "Read(//Users/forni/**)",
-      "Read(//Users/mattforni/**)",
+      "Read(//$HOME/**)",
       "Skill(assist:*)",
       "Skill(linear-lifecycle:*)",
       "Skill(sdlc:*)",
@@ -185,7 +184,7 @@
     "local-skills": {
       "source": {
         "source": "directory",
-        "path": "/Users/mattforni/.claude/local-skills"
+        "path": "$HOME/.claude/local-skills"
       }
     },
     "skillset": {

--- a/.claude/skills/bd-email/SKILL.md
+++ b/.claude/skills/bd-email/SKILL.md
@@ -160,15 +160,15 @@ Matthew Fornaciari
 
 All templates available in:
 
-- `/Users/forni/Craft/vocation/templates/`
+- `~/Craft/vocation/templates/`
 
 Contact database:
 
-- `/Users/forni/Craft/vocation/network/contacts.md`
+- `~/Craft/vocation/network/contacts.md`
 
 Project guidelines:
 
-- `/Users/forni/Craft/vocation/CLAUDE.md`
+- `~/Craft/vocation/CLAUDE.md`
 
 ## Gmail Integration
 

--- a/.claude/skills/job-apply/SKILL.md
+++ b/.claude/skills/job-apply/SKILL.md
@@ -274,7 +274,7 @@ Filter by:
 
 ## Follow-Up Email Generation
 
-Use template: `/Users/forni/Craft/vocation/templates/07-job-posting-cold-outreach.md`
+Use template: `~/Craft/vocation/templates/07-job-posting-cold-outreach.md`
 
 ### Key Elements
 
@@ -399,16 +399,16 @@ When skill is invoked with job posting URL:
 
 **Email template:**
 
-- `/Users/forni/Craft/vocation/templates/07-job-posting-cold-outreach.md`
+- `~/Craft/vocation/templates/07-job-posting-cold-outreach.md`
 
 **Project guidelines:**
 
-- `/Users/forni/Craft/vocation/CLAUDE.md`
+- `~/Craft/vocation/CLAUDE.md`
 
 **Contact tracking:**
 
-- `/Users/forni/Craft/vocation/network/contacts.md`
+- `~/Craft/vocation/network/contacts.md`
 
 **Company profiles:**
 
-- `/Users/forni/Craft/vocation/companies/`
+- `~/Craft/vocation/companies/`

--- a/.zshrc
+++ b/.zshrc
@@ -47,7 +47,7 @@ cd . # Trigger RVM auto-switch on shell start
 export PATH="$HOME/.local/bin:$PATH"
 
 # bun completions
-[ -s "/Users/forni/.bun/_bun" ] && source "/Users/forni/.bun/_bun"
+[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
 
 # bun
 export BUN_INSTALL="$HOME/.bun"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,12 @@ Run `./setup.sh` to install homebase to the home directory. The script will:
 └── setup.sh         # Installation and setup script
 ```
 
+## Path Conventions
+
+**Never hard-code a username in tracked config or documentation.** Homebase deploys to multiple machines, and absolute paths like `/Users/mattforni/...` or `/Users/forni/...` break on every machine that does not match. Use `$HOME` (preferred for shell scripts and JSON config) or `~` (preferred for markdown documentation and shell aliases) so the same content works everywhere.
+
+Applies to: `.claude/settings.json` permissions and marketplace paths, skill SKILL.md files, shell rc files, any markdown that references a path. If a tool reads the value literally and does not expand `$HOME` or `~`, surface that as a setup.sh templating gap rather than working around it with a hard-coded username.
+
 ## Development Workflow
 
 1. Edit files in this repository


### PR DESCRIPTION
## Summary

- Replace `/Users/forni/...` and `/Users/mattforni/...` with `$HOME` (shell, JSON) or `~` (markdown docs) across 12 files
- Collapse two `Read(//Users/.../**)` permission entries into one `Read(//$HOME/**)`
- Add Path Conventions section to `CLAUDE.md` documenting the rule for future contributions

## Test plan

- [ ] Restart Claude Code; verify the `local-skills` marketplace loads (validates that the marketplace `path` field accepts `$HOME` expansion). If it does not, this is a setup.sh templating gap rather than a workaround opportunity.
- [ ] Verify `Read(//$HOME/**)` permission still grants the expected reads
- [ ] Spot check skill invocations (assist:mise, assist:bd-email, assist:sharpen) for any path resolution issues
- [ ] Run `./setup.sh` and confirm deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)