### PR TITLE
Block Wrap Exit on Open PRs Forni Authored This Session

### DIFF
--- a/.claude/local-skills/plugins/assist/skills/wrap/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/wrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assist:wrap
-description: Session wrap. Don't lose the thread, clean everything up, don't leave loose ends in your head. Scans every git repo touched this session for uncommitted or unpushed state, surfaces external commitments (pending replies, calendar holds, contract deadlines) from the recent conversation, prompts for codification of durable learnings, logs anything not handled into Todoist (today if pressing, next Monday otherwise), summarizes the session, and leaves Forni ready to /exit cleanly. Use this skill whenever Forni says "wrap", "wrap up", "wrap the session", "wrap this up", "wrapping up", "clean up before I exit", "signing off", "done for the day", or invokes /assist:wrap. Pairs with /assist:mise as the bookend. Mise opens the kitchen for service. Wrap closes it cleanly after.
+description: Session wrap. Don't lose the thread, clean everything up, don't leave loose ends in your head. Scans every git repo touched this session for uncommitted or unpushed state, surfaces external commitments (pending replies, calendar holds, contract deadlines) from the recent conversation, prompts for codification of durable learnings, logs anything not handled into Todoist (today if pressing, next Monday otherwise), summarizes the session, and leaves the user ready to /exit cleanly. Use this skill whenever the user says "wrap", "wrap up", "wrap the session", "wrap this up", "wrapping up", "clean up before I exit", "signing off", "done for the day", or invokes /assist:wrap. Pairs with /assist:mise as the bookend. Mise opens the kitchen for service. Wrap closes it cleanly after.
 allowed-tools:
   - Bash
   - Read
@@ -18,7 +18,7 @@ allowed-tools:
 
 End of session bookend. Don't lose the thread. Don't leave loose ends in your head.
 
-The skill exists because Forni was running the same end-of-session sweep manually: check git and PR state, scan recent work for unhandled commitments, decide what to codify, decide what to log to Todoist, exit. That is a routine. Routines should be automations.
+The skill exists because the user was running the same end-of-session sweep manually: check git and PR state, scan recent work for unhandled commitments, decide what to codify, decide what to log to Todoist, exit. That is a routine. Routines should be automations.
 
 ## Before Every Invocation
 
@@ -59,10 +59,10 @@ fi
 
 Categorize per repo:
 
-- **Clean.** Working tree clean, in sync with origin, no open PRs needing Forni. Nothing to do.
+- **Clean.** Working tree clean, in sync with origin, no open PRs needing the user. Nothing to do.
 - **Uncommitted changes.** Surface and ask: commit (via `/sdlc:checkpoint`), stash, or discard.
 - **Unpushed commits.** Push, or leave intentionally with a note.
-- **Open PR awaiting Forni.** Blocks exit (see Step 9). Surface review comments and chain to `/sdlc:iterate`.
+- **Open PR awaiting the user.** Blocks exit (see Step 9). Surface review comments and chain to `/sdlc:iterate`.
 - **Open PR awaiting reviewer.** Blocks exit (see Step 9). Watch for review to land, then chain to `/sdlc:iterate` or `/sdlc:complete` as appropriate.
 - **Merged PR with the branch still local.** Chain to `/sdlc:complete` via the Skill tool.
 
@@ -70,23 +70,23 @@ When the session already ran `/sdlc:complete`, this step is usually fast and ret
 
 ### Step 3: Surface External Commitments
 
-Walk the recent session conversation for items that imply someone is waiting on Forni, or Forni is waiting on someone:
+Walk the recent session conversation for items that imply someone is waiting on the user, or the user is waiting on someone:
 
 - Emails sent today (ball is in the counterparty's court — flag for tracking)
 - Calendar holds placed but unconfirmed
-- Tasks Forni said he would do "today" or "this morning"
+- Tasks the user said they would do "today" or "this morning"
 - Contract deadlines or external due dates touched in the session
 - Drafts saved but not sent
 
 Categorize each in three tiers:
 
-- ⚠️ **Today.** Action required before end of day. Forni is the blocker.
-- 🟡 **Sliding.** Soft target, no external party blocked. Forni's own commitment to himself.
+- ⚠️ **Today.** Action required before end of day. The user is the blocker.
+- 🟡 **Sliding.** Soft target, no external party blocked. The user's own commitment to themselves.
 - ✅ **Awaiting counterparty.** Tracked, no action.
 
 ### Step 4: Dedupe Against Todoist
 
-Before triaging anything, query Todoist for tasks that already cover the candidate loose ends. Surfacing items that are already scheduled is noise and forces Forni to triage the same thing twice.
+Before triaging anything, query Todoist for tasks that already cover the candidate loose ends. Surfacing items that are already scheduled is noise and forces the user to triage the same thing twice.
 
 ```text
 mcp__claude_ai_Todoist__find-tasks-by-date(
@@ -100,13 +100,13 @@ mcp__claude_ai_Todoist__find-tasks-by-date(
 Match each candidate against scheduled tasks by content keyword (lender name, attorney name, deadline phrase, task type). For each match:
 
 - **On track (due today or in the future):** drop from the triage list entirely; the task is already covered
-- **Overdue:** surface separately under a 🔴 **Overdue, already in Todoist** tier so Forni can reschedule rather than treat them as new
+- **Overdue:** surface separately under a 🔴 **Overdue, already in Todoist** tier so the user can reschedule rather than treat them as new
 
 Only the unmatched ⚠️ and 🟡 items proceed to Step 5 triage.
 
 ### Step 5: Triage Each Loose End
 
-For each ⚠️ and 🟡 item, ask Forni via AskUserQuestion with these options:
+For each ⚠️ and 🟡 item, ask the user via AskUserQuestion with these options:
 
 1. **Do now.** Handle in this session before exiting.
 2. **Todoist today.** Log a task due today with duration 30m.
@@ -123,16 +123,16 @@ Walk the session for codifiable durables:
 - Patterns or conventions that became clear
 - Workflow improvements worth saving
 
-If candidates exist, ask Forni whether to invoke `/assist:codify` via the Skill tool for each candidate. If nothing is codifiable, say so explicitly and skip. Most sessions skip. Forcing codify creates documentation bloat.
+If candidates exist, ask the user whether to invoke `/assist:codify` via the Skill tool for each candidate. If nothing is codifiable, say so explicitly and skip. Most sessions skip. Forcing codify creates documentation bloat.
 
 ### Step 7: Todoist Logging
 
-For each loose end Forni triaged to "today" or "Monday", create a Todoist task:
+For each loose end the user triaged to "today" or "Monday", create a Todoist task:
 
 - **Today:** `dueString: "today"`, `duration: "30m"`
 - **Monday:** `dueString: "next Monday"`, `duration: "30m"`
 
-For each 🔴 overdue item Forni triaged to reschedule, use `mcp__claude_ai_Todoist__reschedule-tasks` rather than creating a new task. Preserves recurring patterns and existing context.
+For each 🔴 overdue item the user triaged to reschedule, use `mcp__claude_ai_Todoist__reschedule-tasks` rather than creating a new task. Preserves recurring patterns and existing context.
 
 Task title conventions from global memory:
 
@@ -151,7 +151,7 @@ One paragraph. Three beats:
 2. What artifacts shipped? (PRs merged, files filed, decisions made, drafts sent)
 3. What is queued for next time? (loose ends now in Todoist)
 
-This is the breadcrumb for re-entry. Future Forni picks the thread back up from this paragraph.
+This is the breadcrumb for re-entry. The user's future self picks the thread back up from this paragraph.
 
 ### Step 9: Exit Readiness
 
@@ -159,24 +159,24 @@ The session is exit-ready only when every condition below holds:
 
 - No uncommitted changes remain in any session-touched repo
 - No unpushed commits remain, or any that do are intentional with a note
-- **No PR Forni authored this session is still open.** An open PR is not exit-ready state. Watch the PR through review (CodeRabbit, Gemini, human reviewers), chain to `/sdlc:iterate` when feedback lands, and to `/sdlc:complete` once merged.
+- **No PR the user authored this session is still open.** An open PR is not exit-ready state. Watch the PR through review (CodeRabbit, Gemini, human reviewers), chain to `/sdlc:iterate` when feedback lands, and to `/sdlc:complete` once merged.
 
 When all conditions are met, end with one line: "Ready to /exit when you are."
 
-When a PR is still open, end instead with the current state of the PR and the next action you are taking on it (waiting for review, addressing feedback, merging, etc.). Do not declare exit readiness.
+When a PR is still open, end instead with the current state of the PR and the next action being taken on it (waiting for review, addressing feedback, merging, etc.). Do not declare exit readiness.
 
-Do not invoke /exit automatically. Forni controls the exit. The skill prepares the ground; Forni walks off it.
+Do not invoke /exit automatically. The user controls the exit. The skill prepares the ground; the user walks off it.
 
 ## Why Each Step Matters
 
-- **Session-touched repos, not a fixed allowlist.** Forni works across Eudaimonia, homebase, skillset, zero repos, and ad-hoc clones. A fixed list either misses repos or scans noise. Inferring from session activity matches the actual blast radius.
+- **Session-touched repos, not a fixed allowlist.** The user works across many repos (Eudaimonia, homebase, skillset, zero repos, and ad-hoc clones). A fixed list either misses repos or scans noise. Inferring from session activity matches the actual blast radius.
 - **Git scan first.** Highest-signal check. After `/sdlc:complete` this is usually fast and clean.
 - **Three-tier categorization over flat list.** ⚠️/🟡/✅ separates "act now" from "track" from "ignore". A flat list of "follow-ups" is noise.
-- **Dedupe against Todoist before triage.** Forni already runs Todoist as the system of record for follow-ups. Surfacing tasks that are already scheduled there is noise and forces him to triage the same thing twice. The Step 4 query is the cheapest check available and removes the noisiest failure mode.
+- **Dedupe against Todoist before triage.** The user already runs Todoist as the system of record for follow-ups. Surfacing tasks that are already scheduled there is noise and forces them to triage the same thing twice. The Step 4 query is the cheapest check available and removes the noisiest failure mode.
 - **Triage one item at a time.** Bulk decisions hide bad triage. AskUserQuestion forces real choice per item.
 - **Codify is opt-in, never mandatory.** Most sessions have no new durable rules. Prompt only when candidates exist; skip cleanly otherwise.
 - **Todoist offload.** Anything not handled in-session goes to Todoist. Working memory should not carry loose ends across sessions. The Monday default channels non-urgent items into the existing Monday planning ritual.
-- **Don't auto-exit.** Wrap prepares the exit; Forni triggers it. Auto-exit would risk closing a session that still needs attention.
+- **Don't auto-exit.** Wrap prepares the exit; the user triggers it. Auto-exit would risk closing a session that still needs attention.
 - **Open PRs block exit.** A PR sitting open after exit risks losing context for review-comment handling, drifts further from main, and breaks the rhythm of finishing what you start. Wrap is responsible for shepherding the PR through review and merge, not just opening it.
 
 ## Output Shape
@@ -207,13 +207,13 @@ Ready to /exit when you are.
 ## Anti-patterns
 
 - Do not scan systems beyond git/PRs and recent-session implications. Slack, every inbox folder, Todoist contents, calendar week ahead, none of those. Comprehensive scans create noise that obscures real loose ends.
-- Do not log to Todoist without Forni's explicit triage for that item. No automatic bulk-dump to Monday.
-- Do not invoke /exit yourself. Wrap prepares; Forni exits.
+- Do not log to Todoist without the user's explicit triage for that item. No automatic bulk-dump to Monday.
+- Do not invoke /exit yourself. Wrap prepares; the user exits.
 - Do not skip the summary even when there is "nothing to summarize." It is the re-entry breadcrumb.
 - Do not force codify. If the session did not produce a durable rule, say so and move on.
 - Do not maintain a fixed allowlist of repos. Repos to scan = repos touched in this session.
-- Do not declare exit readiness while a PR Forni authored this session is still open. Watch it through review and merge before saying "Ready to /exit when you are."
+- Do not declare exit readiness while a PR the user authored this session is still open. Watch it through review and merge before saying "Ready to /exit when you are."
 
 ## Learned Rules
 
-_(Empty. Populated as Forni corrects wrap's judgment over time.)_
+_(Empty. Populated as corrections accumulate over time.)_

--- a/.claude/local-skills/plugins/assist/skills/wrap/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/wrap/SKILL.md
@@ -62,8 +62,8 @@ Categorize per repo:
 - **Clean.** Working tree clean, in sync with origin, no open PRs needing Forni. Nothing to do.
 - **Uncommitted changes.** Surface and ask: commit (via `/sdlc:checkpoint`), stash, or discard.
 - **Unpushed commits.** Push, or leave intentionally with a note.
-- **Open PR awaiting Forni.** Surface review comments. Suggest `/sdlc:iterate`.
-- **Open PR awaiting reviewer.** Just flag for visibility.
+- **Open PR awaiting Forni.** Blocks exit (see Step 9). Surface review comments and chain to `/sdlc:iterate`.
+- **Open PR awaiting reviewer.** Blocks exit (see Step 9). Watch for review to land, then chain to `/sdlc:iterate` or `/sdlc:complete` as appropriate.
 - **Merged PR with the branch still local.** Chain to `/sdlc:complete` via the Skill tool.
 
 When the session already ran `/sdlc:complete`, this step is usually fast and returns clean for the main repo.
@@ -155,7 +155,15 @@ This is the breadcrumb for re-entry. Future Forni picks the thread back up from 
 
 ### Step 9: Exit Readiness
 
-End with one line: "Ready to /exit when you are."
+The session is exit-ready only when every condition below holds:
+
+- No uncommitted changes remain in any session-touched repo
+- No unpushed commits remain, or any that do are intentional with a note
+- **No PR Forni authored this session is still open.** An open PR is not exit-ready state. Watch the PR through review (CodeRabbit, Gemini, human reviewers), chain to `/sdlc:iterate` when feedback lands, and to `/sdlc:complete` once merged.
+
+When all conditions are met, end with one line: "Ready to /exit when you are."
+
+When a PR is still open, end instead with the current state of the PR and the next action you are taking on it (waiting for review, addressing feedback, merging, etc.). Do not declare exit readiness.
 
 Do not invoke /exit automatically. Forni controls the exit. The skill prepares the ground; Forni walks off it.
 
@@ -169,6 +177,7 @@ Do not invoke /exit automatically. Forni controls the exit. The skill prepares t
 - **Codify is opt-in, never mandatory.** Most sessions have no new durable rules. Prompt only when candidates exist; skip cleanly otherwise.
 - **Todoist offload.** Anything not handled in-session goes to Todoist. Working memory should not carry loose ends across sessions. The Monday default channels non-urgent items into the existing Monday planning ritual.
 - **Don't auto-exit.** Wrap prepares the exit; Forni triggers it. Auto-exit would risk closing a session that still needs attention.
+- **Open PRs block exit.** A PR sitting open after exit risks losing context for review-comment handling, drifts further from main, and breaks the rhythm of finishing what you start. Wrap is responsible for shepherding the PR through review and merge, not just opening it.
 
 ## Output Shape
 
@@ -203,6 +212,7 @@ Ready to /exit when you are.
 - Do not skip the summary even when there is "nothing to summarize." It is the re-entry breadcrumb.
 - Do not force codify. If the session did not produce a durable rule, say so and move on.
 - Do not maintain a fixed allowlist of repos. Repos to scan = repos touched in this session.
+- Do not declare exit readiness while a PR Forni authored this session is still open. Watch it through review and merge before saying "Ready to /exit when you are."
 
 ## Learned Rules
 


### PR DESCRIPTION
## Summary
- Bake the "open PR blocks exit" rule directly into `assist:wrap` Step 9 instead of carrying it as a learned rule. Exit readiness is now conditional on no uncommitted changes, no unpushed commits, and no open PRs Forni authored this session.
- Update the Step 2 PR categorization so both "awaiting Forni" and "awaiting reviewer" states are explicitly marked as exit blockers, with a pointer to Step 9.
- Add matching entries under "Why Each Step Matters" and "Anti-patterns" so the rule is reinforced where the skill is most likely to be read.

## Why
Captured today after wrap declared the session ready to exit while PR #47 on Eudaimonia was still mid-review. The skill should shepherd PRs through merge, not just opening.

## Test plan
- [ ] Re-read SKILL.md end to end to confirm Step 9, Step 2, the Why section, and Anti-patterns all carry the rule consistently
- [ ] Next wrap invocation with an open PR should not say "Ready to /exit"

🤖 Generated with [Claude Code](https://claude.com/claude-code)