### PR TITLE
Bump sdlc to 2.2.0 and register land in the marketplace manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -35,7 +35,7 @@
     {
       "name": "sdlc",
       "source": "./plugins/sdlc",
-      "version": "2.0.0",
+      "version": "2.2.0",
       "license": "MIT",
       "description": "Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.",
       "homepage": "https://github.com/mattforni/homebase",
@@ -53,7 +53,8 @@
         "./skills/checkpoint/SKILL.md",
         "./skills/review/SKILL.md",
         "./skills/iterate/SKILL.md",
-        "./skills/complete/SKILL.md"
+        "./skills/complete/SKILL.md",
+        "./skills/land/SKILL.md"
       ]
     }
   ]

--- a/plugins/sdlc/plugin.json
+++ b/plugins/sdlc/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"


### PR DESCRIPTION
## Summary

Follow-up to #85. The new `land` skill wasn't picked up by `claude plugin update` because:

1. The marketplace entry's version was still `2.0.0` (drift from `plugin.json` which had already advanced to `2.1.1`), so the updater short-circuited as "already at latest".
2. The marketplace entry's explicit `skills` array didn't include `land`, so `install` ignored the new directory.

Realigning both manifests on `2.2.0` (minor bump per semver for the new skill) and adding `./skills/land/SKILL.md` to the `skills` array makes `update` pull the new code.

## Test plan

- [x] `claude plugin validate .claude-plugin/marketplace.json` passes
- [ ] After merge: `claude plugin marketplace update skillset` → `claude plugin update sdlc@skillset` shows version 2.2.0 and the 8th skill (`land`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>