### PR TITLE
Drop explicit skills arrays so plugins load under current loader

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "linear-lifecycle",
       "source": "./plugins/linear-lifecycle",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "description": "Manage Linear issues via the Linear CLI with zero-context overhead.",
       "homepage": "https://github.com/mattforni/homebase",
@@ -24,10 +24,6 @@
       },
       "category": "development",
       "keywords": ["linear", "issue-tracking", "cli", "workflow", "context-budget", "project-management"],
-      "strict": false,
-      "skills": [
-        "./skills/linear-lifecycle/SKILL.md"
-      ],
       "commands": [
         "./commands/linear-setup.md"
       ]
@@ -35,7 +31,7 @@
     {
       "name": "sdlc",
       "source": "./plugins/sdlc",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "description": "Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.",
       "homepage": "https://github.com/mattforni/homebase",
@@ -45,17 +41,7 @@
         "url": "https://github.com/mattforni"
       },
       "category": "development",
-      "keywords": ["sdlc", "workflow", "git", "pr", "review", "development", "lifecycle"],
-      "strict": false,
-      "skills": [
-        "./skills/plan/SKILL.md",
-        "./skills/design/SKILL.md",
-        "./skills/checkpoint/SKILL.md",
-        "./skills/review/SKILL.md",
-        "./skills/iterate/SKILL.md",
-        "./skills/complete/SKILL.md",
-        "./skills/land/SKILL.md"
-      ]
+      "keywords": ["sdlc", "workflow", "git", "pr", "review", "development", "lifecycle"]
     }
   ]
 }

--- a/plugins/linear-lifecycle/plugin.json
+++ b/plugins/linear-lifecycle/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "linear-lifecycle",
   "description": "Manage Linear issues via the Linear CLI with zero-context overhead.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/plugins/sdlc/plugin.json
+++ b/plugins/sdlc/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"


### PR DESCRIPTION
## Summary

`/doctor` (effectively `claude plugin list`) surfaced 19 plugin load errors, all of the form `path is a file; expected a directory`. Cause: Claude Code's loader rejects explicit `skills: ["./skills/X/SKILL.md"]` entries. Working plugins in the marketplace (feature-dev, code-review, etc.) omit the array and rely on auto-discovery of the `skills/` subdirectory.

This PR drops the explicit `skills` arrays from `sdlc` and `linear-lifecycle` (plus the unused `strict: false` flag) and patch-bumps both plugins (`sdlc` 2.2.0 → 2.2.1, `linear-lifecycle` 1.2.0 → 1.2.1) so `claude plugin update` actually pulls the fix. Without a version bump the updater short-circuits as "already at latest" — same gotcha that delayed land's first appearance.

Removes 8 of the 19 errors. The remaining 11 were on a local-only `assist` manifest (not in this repo) and have been fixed in place.

## Test plan

- [x] `claude plugin validate .claude-plugin/marketplace.json` passes
- [ ] After merge: `claude plugin marketplace update skillset` → `claude plugin update sdlc@skillset` → both sdlc and linear-lifecycle show `✔ enabled` and no skill-load errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>