### PR TITLE
Rename assist:schedule to assist:planning, Restructure assist:training

### DIFF
--- a/.claude/local-skills/.claude-plugin/marketplace.json
+++ b/.claude/local-skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "assist",
       "source": "./plugins/assist",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "MIT",
       "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, and job applications.",
       "author": {

--- a/.claude/local-skills/.claude-plugin/marketplace.json
+++ b/.claude/local-skills/.claude-plugin/marketplace.json
@@ -14,17 +14,17 @@
       "source": "./plugins/assist",
       "version": "1.0.0",
       "license": "MIT",
-      "description": "Personal productivity skills: email triage, schedule planning, knowledge capture, BD outreach, and job applications.",
+      "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, and job applications.",
       "author": {
         "name": "Matthew Fornaciari",
         "url": "https://github.com/mattforni"
       },
       "category": "productivity",
-      "keywords": ["assist", "email", "schedule", "learn", "bd", "job-apply", "present", "productivity"],
+      "keywords": ["assist", "email", "planning", "learn", "bd", "job-apply", "present", "productivity"],
       "strict": false,
       "skills": [
         "./skills/emails/SKILL.md",
-        "./skills/schedule/SKILL.md",
+        "./skills/planning/SKILL.md",
         "./skills/codify/SKILL.md",
         "./skills/bd-email/SKILL.md",
         "./skills/job-apply/SKILL.md",

--- a/.claude/local-skills/plugins/assist/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/learned-rules.md
@@ -43,4 +43,20 @@ Rules added from triage corrections. Read on every invocation. These override de
 - Events booked via Reclaim.ai scheduling links were scheduled by other people. Extra caution required.
 - Deleting or moving adjacent events can cause Reclaim to auto-reschedule nearby flexible events as a side effect. Warn about this.
 
+## Slotting Rules
+
+- **Personal admin tasks slot to morning windows, not afternoon.** Afternoons fill with Zero work and meetings; admin only reliably lands in the morning. Default to slotting Todoist personal tasks (admin, errands, paperwork, follow ups, calls) before the workday starts. Use afternoon slots only when the task explicitly requires business hours (e.g., calling an office that opens at 09:00) or when no morning slot exists.
+
+  **Why:** Codified 2026-05-18 (Wk 3 planning session). Initial slot for 📝 Clio Intake and 🏥 Establish Primary Care landed at 15:00–16:00. Forni redirected: "I just don't tend to have time later in the day with work. It just doesn't really work that way." Afternoon slots in practice get displaced by work even when calendar shows them open.
+
+  **How to apply:** When triaging Schedule filter tasks, default to morning slots. Strong morning windows: Mon 7:00–10:00 (deep AM at office), Tue/Wed 7:00–10:30 (Heads Down container), Thu 7:30–8:00 (post SPRC pre meetings), Fri 7:00–11:30 (large WFH block). Use afternoon only as a fallback.
+
+## Codification Rules
+
+- **No half step phase numbering.** When inserting a new phase into an existing skill or document, renumber subsequent phases rather than creating `Phase 4.5` or `Phase 3.5`. Half steps look like patches; integer sequences look like deliberate structure.
+
+  **Why:** Surfaced 2026-05-18 when adding an interrogation phase to `assist:training` retro mode. Initial draft used `Phase 4.5` for the new step. Forni redirected: "let's not codify things in general as half steps. So phase four and a half or phase three and a half, let's just go with moving the other phases backwards."
+
+  **How to apply:** New phase goes at its integer position. Every phase after it shifts up by one. Update body cross references (e.g., "continue to Phase 5") and any references in learned-rules.md or other skills that point at numbered phases. Worth a final grep for `Phase [0-9]\.[0-9]` to catch stragglers.
+
 ## Created Filters

--- a/.claude/local-skills/plugins/assist/plugin.json
+++ b/.claude/local-skills/plugins/assist/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "assist",
   "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, job applications, and meal planning.",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/.claude/local-skills/plugins/assist/plugin.json
+++ b/.claude/local-skills/plugins/assist/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "assist",
-  "description": "Personal productivity skills: email triage, schedule planning, knowledge capture, BD outreach, job applications, and meal planning.",
+  "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, job applications, and meal planning.",
   "version": "1.0.0",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"
   },
   "license": "MIT",
-  "keywords": ["assist", "email", "schedule", "codify", "sharpen", "bd", "job-apply", "meals", "productivity"]
+  "keywords": ["assist", "email", "planning", "codify", "sharpen", "bd", "job-apply", "meals", "productivity"]
 }

--- a/.claude/local-skills/plugins/assist/skills/planning/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: assist:schedule
-description: Weekly schedule planning, calendar management, and Monday morning task slotting. Use this skill whenever the user mentions their schedule, weekly planning, Monday planning session, slotting tasks, finding free time, checking what their week looks like, moving or swapping calendar events, or wants help fitting something into their week. Also trigger when the user asks about V2MOM measure coverage. Training plan scheduling lives in `assist:training`; this skill calls into it during Monday planning.
+name: assist:planning
+description: Weekly planning, calendar management, and Monday morning task slotting. Use this skill whenever the user mentions weekly planning, the Monday planning session, slotting tasks, finding free time, checking what their week looks like, moving or swapping calendar events, or wants help fitting something into their week. Also trigger when the user asks about V2MOM measure coverage. Training plan scheduling lives in `assist:training`; this skill calls into it during Monday planning.
 argument-hint: "[plan | week | slot | move]"
 allowed-tools:
   - Skill
@@ -14,9 +14,9 @@ allowed-tools:
   - AskUserQuestion
 ---
 
-# Schedule Assist
+# Planning Assist
 
-Help Forni manage his weekly schedule: review the week, slot Todoist tasks into open time, and make calendar adjustments while respecting training and recovery constraints.
+Help Forni plan his week: review the calendar, slot Todoist tasks into open time, and make calendar adjustments while respecting training and recovery constraints.
 
 ## Before Every Invocation
 
@@ -34,15 +34,13 @@ When there is a conflict between the template and the calendar, the calendar is 
 
 These constraints exist for real physiological and practical reasons. They are not suggestions.
 
-**Transitions**: Every movement between locations gets a 30-minute buffer. This is not travel time alone; it includes the mental shift between contexts. Do not schedule events back-to-back without a transition unless they are at the same location.
-
-**Fasting window**: Last meal at 18:30, first meal at 07:30 (13:11 intermittent fasting). Do not schedule dinner events after 18:30 without flagging the fasting impact.
+**Transitions**: Every movement between locations gets a 30-minute buffer. This is not travel time alone; it includes the mental shift between contexts. Do not schedule events back-to-back without a transition unless they are at the same location. Transitions are placeholders — when a scheduled meeting claims part of a transition's time slot, shrink the transition to fit the remaining gap rather than flagging it as a conflict.
 
 **Work hours**: 8:00-16:00 is the target. Mon/Tue/Thu in office at Zero Homes, Wed/Fri from home. Lunch breaks on Mon (yoga 12:15) and Tue (lift 11:00) are already spoken for.
 
-**Lights out**: 21:30. Events that push past 21:00 should be flagged.
-
 **Training adjacent constraints**: Cold plunge sequencing (4 to 6 hour gap after strength), sauna timing post strength, and Thursday SPRC morning protection live in the `assist:training` skill. Defer to that skill when validating moves of training, sauna, contrast, or Thursday morning events.
+
+**Personal anchors (not conflicts)**: Forni's last meal cutoff (currently 19:30) and lights out (currently 22:00) live in `~/Eudaimonia/schedule.md` Daily Anchors. These are personal constraints Forni manages himself — do not flag events that push past them as conflicts.
 
 ## Mode: plan (default)
 
@@ -72,11 +70,11 @@ Present all conflicts to the user, one at a time or in small batches. For each c
 
 Execute only the agreed changes before moving on. The calendar should be clean and conflict-free before the overview.
 
-### Phase 1.5: Training Scheduling
+### Phase 2: Training Scheduling
 
 Before the week overview and triage, ensure the week's training events are scheduled. Invoke the `assist:training` skill in `week` mode via the Skill tool. It will detect existing recurring placeholders (Mon yoga, Tue lift, Thu SPRC, Wed climb, etc.), surface what's missing, and create the variable one offs (Friday long run + paired drive blocks) following its own constraint logic. Return here once training scheduling is complete.
 
-### Phase 2: Week Overview
+### Phase 3: Week Overview
 
 Present the rectified week at a glance, day by day. For each day show:
 
@@ -87,7 +85,7 @@ Present the rectified week at a glance, day by day. For each day show:
 
 This is a clean view of what the week actually looks like after conflicts are resolved.
 
-### Phase 2.5: Triage
+### Phase 4: Triage
 
 Before slotting, triage the Todoist tasks from the Schedule filter. This is a collaborative pass through all tasks to:
 
@@ -96,7 +94,7 @@ Before slotting, triage the Todoist tasks from the Schedule filter. This is a co
 3. **Reprioritize**: Review priorities and flag anything that looks off. Use best judgment, then confirm with the user.
 4. **Clear p4**: All p4 tasks either get bumped to a real priority or punted to the following Monday. p4 items do not get slotted into the current week.
 
-### Phase 3: Task Slotting
+### Phase 5: Task Slotting
 
 Present the remaining tasks that need scheduling. For each task, suggest a time slot based on:
 
@@ -131,7 +129,7 @@ Google Calendar is still used directly for non-task events: meetings, transition
 
 **Deferred tasks land on Monday**: When deferring tasks to next week or further out, always schedule them for the Monday of the target week. Monday is the landing zone where tasks get triaged during the planning session.
 
-### Phase 4: Summary
+### Phase 6: Summary
 
 After slotting is complete, present:
 
@@ -190,7 +188,7 @@ Include the location when the event is at a specific place.
 
 ## Training Plan Scheduling
 
-Training event creation lives in the `assist:training` skill. See that skill for the recurring placeholder table, Friday long run workflow, special weeks (cutback, altitude, race), Mon flex, and training adjacent constraints. Phase 1.5 above invokes it during Monday planning.
+Training event creation lives in the `assist:training` skill. See that skill for the recurring placeholder table, Friday long run workflow, special weeks (cutback, altitude, race), Mon flex, and training adjacent constraints. Phase 2 above invokes it during Monday planning.
 
 ## Key Locations
 

--- a/.claude/local-skills/plugins/assist/skills/sharpen/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/sharpen/learned-rules.md
@@ -20,7 +20,7 @@ Sharpen sessions are branched as `sharpen-YYYY-MM-DD` in every repo touched by t
 
 Before proposing a new headless routine, audit the feedback channels on existing ones. If notifications are the only path for success/failure, that is a gap and the next move should harden it, not add another agent.
 
-**Why:** 2026-05-07 sharpen session. Proposed extending the headless pattern from one routine (mise) to a second (Monday `/assist:schedule`). Forni redirected: "Before we move on to automation another routine, we first need to get better at the feedback and backpressure mechanisms for mise. Right now, it fails silently sometimes (because my notifications are silenced) and even when it succeeds, it tries to tell me some things, but they get cut off in the notification and when I click through, I get nothing else." macOS notifications are best effort and load-bear too much when used as the source of truth.
+**Why:** 2026-05-07 sharpen session. Proposed extending the headless pattern from one routine (mise) to a second (Monday `/assist:planning`). Forni redirected: "Before we move on to automation another routine, we first need to get better at the feedback and backpressure mechanisms for mise. Right now, it fails silently sometimes (because my notifications are silenced) and even when it succeeds, it tries to tell me some things, but they get cut off in the notification and when I click through, I get nothing else." macOS notifications are best effort and load-bear too much when used as the source of truth.
 
 **How to apply:**
 - For each live headless routine, ask: "If this fails silently, how would Forni find out?" If the answer is "macOS notification" alone, that is insufficient.

--- a/.claude/local-skills/plugins/assist/skills/training/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/training/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assist:training
-description: Training plan scheduling, weekly retrospectives, and training adjacent constraint validation. Use this skill whenever the user mentions training, lifts, runs, climbs, the Friday long run, sauna timing, cold plunge timing, recovery days, cutback weeks, altitude weeks, race week, training restructure, Fitbod, asking to schedule a training session, or asking to look back / retrospect on a past training week. Also trigger for "/assist:training", "schedule my long run", "what does training look like this week", "how did last week go", "training retro", or any request that touches the training plan in `Constitution/Fitness/`. Independently usable, and also called by `/assist:schedule` during Monday planning.
+description: Training plan scheduling, weekly retrospectives, and training adjacent constraint validation. Use this skill whenever the user mentions training, lifts, runs, climbs, the Friday long run, sauna timing, cold plunge timing, recovery days, cutback weeks, altitude weeks, race week, training restructure, Fitbod, asking to schedule a training session, or asking to look back / retrospect on a past training week. Also trigger for "/assist:training", "schedule my long run", "what does training look like this week", "how did last week go", "training retro", or any request that touches the training plan in `Constitution/Fitness/`. Independently usable, and also called by `/assist:planning` during Monday planning.
 argument-hint: "[week | long-run | move | retro]"
 allowed-tools:
   - Bash
@@ -16,7 +16,7 @@ allowed-tools:
 
 # Training Assist
 
-Help Forni schedule the week's training events from the active block plan, validate training adjacent constraints, and move training sessions safely. The skill is independently invocable, and also gets called by `/assist:schedule` during Monday planning before triage and slotting.
+Help Forni schedule the week's training events from the active block plan, validate training adjacent constraints, and move training sessions safely. The skill is independently invocable, and also gets called by `/assist:planning` during Monday planning before triage and slotting.
 
 ## Before Every Invocation
 
@@ -29,9 +29,11 @@ Help Forni schedule the week's training events from the active block plan, valid
 
 ## Source of Truth
 
-The training plan lives at `Constitution/Fitness/2026-training-plan.md`. The weekly skeleton (recurring anchors) lives at `schedule.md`. Google Calendar holds the live reality, including one off events (Friday long run + paired drives, race weekends, altitude trips).
+The training plan lives at `Constitution/Fitness/2026-training-plan.md`. The weekly skeleton (recurring anchors) lives at `schedule.md`. Google Calendar holds the live scheduled reality, including one off events (Friday long run + paired drives, race weekends, altitude trips).
 
-When there is a conflict between the plan and the calendar, the calendar is the current truth. The plan describes what a "normal" training week should look like.
+**For scheduling decisions** (what's on the calendar this week, what conflicts with what): the calendar is truth.
+
+**For retrospective decisions** (what actually happened last week): Strava is truth for runs; the user is truth for everything else. Calendar events are not evidence of completion — they reflect scheduled intent, nothing more.
 
 ## Training Constraints
 
@@ -41,7 +43,7 @@ These constraints exist for real physiological and practical reasons. They are n
 
 **Thursday mornings**: No prayer, meditation, or journaling on Thursdays. That time is reserved for getting to SPRC at 6:00 AM, which rotates locations.
 
-**Fasting window adjacency**: Last meal at 18:30, first meal at 07:30. Long runs starting at 07:00 begin in the fasted state, ending close to or just after the first meal window. Plan fueling around this. Do not propose long runs that push deep into the fasted window without flagging.
+**Fasting window adjacency**: Last meal at 19:30, first meal at 07:30. Long runs starting at 07:00 begin in the fasted state, ending close to or just after the first meal window. Plan fueling around this.
 
 ## Calendar Event Conventions
 
@@ -56,9 +58,23 @@ Color coding, transition / travel, and title formats live in GC `Calendar Prefer
 
 ## Mode: week (default)
 
-Schedule the week's training events from the active block plan. This is the mode `/assist:schedule` calls during Monday planning.
+The Monday morning training pass. Runs as part of `/assist:planning` plan mode (Phase 2), or standalone for ad hoc training planning.
 
-### Phase 1: Detect Existing Placeholders
+The pass has two stages: **retrospective** on the just-closed week, then **scheduling** the current week. Retro first is non-negotiable — scheduling without knowing what happened last week causes drift to compound.
+
+### Phase 1: Retrospective on the Previous Week
+
+Run the full retro workflow on the just-closed ISO week (see Mode: retro below). The retro produces:
+
+- A new `### Wk N` subsection appended to the training plan
+- An adherence read on what hit, what slipped
+- A plan adjustment check: do the current week's targets still hold, or do they step down?
+
+When the retro reveals drift (long run missed, weekly mileage 30%+ under plan, two consecutive weeks of misses, or weight off trajectory), pause before scheduling. Propose adjustments to the current week's targets and get user confirmation before continuing to Phase 2.
+
+If a `### Wk N` subsection already exists in the plan for the just-closed week, skip Phase 1 and continue to Phase 2.
+
+### Phase 2: Detect Existing Placeholders
 
 Fetch the week's calendar events (Monday through Sunday) and check for already existing recurring or one off events. Do not overwrite or duplicate. Only create what is missing for this specific week.
 
@@ -69,11 +85,11 @@ Fetch the week's calendar events (Monday through Sunday) and check for already e
 
 If a recurring placeholder is missing, surface it to the user rather than silently creating it. The user may have skipped the session this week intentionally.
 
-### Phase 2: Friday Long Run
+### Phase 3: Friday Long Run
 
 Run the Friday long run workflow (see Mode: long-run below). This is the primary one off creation each week.
 
-### Phase 3: Special Week Handling
+### Phase 4: Special Week Handling
 
 Check the current week number against the training plan and apply special week logic:
 
@@ -81,7 +97,7 @@ Check the current week number against the training plan and apply special week l
 - **Altitude weeks (9, 10)**: Front Range altitude (week 9) or Aspen recon (week 10). Week 10 includes a Thu drive out + overnight; surface logistics to the user before creating events.
 - **Race week (13)**: Fri 7/31 is the FPL race itself. Coordinate the race day plan as a separate workflow, not a training long run.
 
-### Phase 4: Mon Flex
+### Phase 5: Mon Flex
 
 Optional easy ~4 mi run on Mon. Energy dependent. Do not auto schedule. Surface as an option, do not create without explicit user confirmation.
 
@@ -129,19 +145,19 @@ Look back on a completed (or in progress) training week. Compare planned vs actu
 
 ### Phase 2: Gather Data
 
-Pull from three sources in parallel:
+Pull from two sources in parallel:
 
 1. **Training plan**: read the row in `2026-training-plan.md` for the target week. Note **Long mi**, **Vert ft**, **Fri shape**, **Weight** target, **Nutrition focus**.
-2. **Google Calendar**: list opaque events for the week. Filter to training relevant (Sage colorId 2, training emojis, or session keywords like SPRC, DRC, lift, climb, sauna, contrast, long run).
-3. **Strava**: pull all activities for the week via `mcp__strava__get-all-activities` with `startDate` and `endDate`. Then call `mcp__strava__get-activity-details` on each run to get **distance** and **elevation gain in meters** (convert to ft: meters * 3.28084).
+2. **Strava**: pull all activities for the week via `mcp__strava__get-all-activities` with `startDate` and `endDate`. Then call `mcp__strava__get-activity-details` on each run to get **distance** and **elevation gain in meters** (convert to ft: meters * 3.28084).
+
+**Strava is the source of truth for what happened.** Do not pull calendar data for retro purposes. The calendar shows scheduled intent, not completion. A calendar event existing is not evidence the session happened.
 
 ### Phase 3: Build the Coverage Table
 
-For every planned session in the week, record actual status. Sources:
+For every planned session in the week, record actual status:
 
-- Yoga, lifts, climb (if any): calendar event present = scheduled. Lifts at Movement RiNo do **not** show in Strava — confirm with the user when a lift's status is unclear, do not assume missed.
-- Runs (DRC, SPRC, long run, Mon flex): match Strava activities by date and approximate distance.
-- Recovery (sauna, contrast): calendar event present is the signal.
+- **Runs (DRC, SPRC, long run, Mon flex)**: match Strava activities by date and approximate distance. No matching Strava activity = miss.
+- **Yoga, lifts, climbing, sauna, contrast therapy**: not captured in Strava. Ask the user explicitly via `AskUserQuestion` whether each happened. Batch the questions when there are several. Do not infer completion from calendar events existing.
 
 Mark each session as `✅` (hit), `❌` (missed), `↪️` (shifted), `❓` (open / status unknown), or `n/a` (not applicable this week).
 
@@ -158,7 +174,22 @@ Compare each against the plan row. Express delta as percentage and direction.
 
 **Vert is co-equal with mileage.** The plan tracks both; the retro evaluates against both. Hitting mileage and missing vert (e.g., long run on flat terrain instead of trail) is a partial hit, not a hit.
 
-### Phase 5: Write the Retro Subsection
+### Phase 5: Interrogate Significant Deltas
+
+When the numbers show significant divergence from plan — mileage 30%+ under, long run missed entirely, two consecutive weeks of misses, or weight off trajectory — interrogate the cause before writing the retro. Numbers alone are not the read; they are the symptom. The cause shapes the adjustment.
+
+Categories worth surfacing via `AskUserQuestion`:
+
+- **Injury or body**: pain, soreness, illness, recovery debt
+- **Schedule / life**: travel, work compression, family obligations, social
+- **Motivation / state**: low energy, emotional load, post hard week dip
+- **Conditions**: weather, gear, route or logistics
+
+Ask one focused question for category, then leave room for the user to fill in detail in chat. When the cause is medical (injury, illness), explicitly prompt for any provider notes, AI consults, or external feedback the user wants captured verbatim or summarized. Capture that context in the retro's "The Read" — it shapes adjustment more than the numbers do.
+
+Skip this phase only when the retro lands at or above plan with no meaningful gap.
+
+### Phase 6: Write the Retro Subsection
 
 Append a new subsection at the bottom of the **Weekly Retrospectives** section in `2026-training-plan.md`. Use this skeleton (note the heading levels: `###` for the week, `####` for the inner sections so the table of contents stays clean):
 
@@ -197,7 +228,21 @@ Append a new subsection at the bottom of the **Weekly Retrospectives** section i
 
 Before writing, present the draft inline and ask the user one question via `AskUserQuestion`: anything to add or correct? Save after they confirm or redirect. Use `Edit` to insert the new subsection at the end of the Weekly Retrospectives section, immediately before the `## References` heading.
 
-### Phase 6: Surface Trends
+### Phase 7: Plan Adjustment Check
+
+Compare the just-written retro to the **current** week's plan row. When the retro shows under-coverage — long run missed, weekly mileage 30%+ under, two weeks in a row of misses, or weight off trajectory — the current week's targets likely need to step down rather than press forward.
+
+Propose adjustment options to the user via `AskUserQuestion`. Typical levers:
+
+- **Long run target**: hold the plan number, drop to last week's actual, or drop further to rebuild rhythm
+- **Vert target**: same logic, often paired with the mileage call
+- **Phase shift**: if drift is severe, treat the current week as a recovery / rebuild rather than continuing the build progression
+
+After the user decides, update the row in `2026-training-plan.md` to reflect the adjusted targets. Annotate inline so both numbers stay visible — e.g., `20 (adjusted from 22)`. The original plan and the adjustment trace together.
+
+Skip this phase only when the retro shows the week landed at or above plan.
+
+### Phase 8: Surface Trends
 
 After saving, briefly scan the prior 1 to 2 retro subsections already in the plan file (if they exist). Surface any pattern: repeated misses, drifting metrics, growing or shrinking adherence. Keep this short — one or two sentences. Do not invent patterns when there is not enough data.
 

--- a/.claude/local-skills/plugins/assist/skills/training/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/training/learned-rules.md
@@ -31,6 +31,30 @@ Training specific rules tied to current life shape. Read on every invocation. St
 
 ## Retro Evaluation
 
+- **Retro precedes scheduling.** The Mon morning training pass starts with the previous week's retro. Never schedule the current week without knowing what happened last week — drift compounds. The week mode (Phase 1) enforces this; standalone scheduling without a prior retro is the wrong shape.
+
+  **Why:** Wk 2 was scheduled forward without a retro on Wk 1's slip; by Wk 3 planning the gap was a full week behind. Codified 2026-05-18 (Wk 3 planning session).
+
+  **How to apply:** Always run retro before scheduling, even when the user invokes the skill mid week or for an ad hoc pass.
+
+- **Strava is the source of truth for completion, not the calendar.** Calendar events represent scheduled intent, not evidence anything happened. For Strava tracked sessions (runs), the activity is the proof. For non Strava sessions (yoga, lifts, sauna, contrast), ask the user directly via `AskUserQuestion`. Do not pull calendar data into retro coverage tables.
+
+  **Why:** Calendar inference produces false positives on adherence. An event sitting on the calendar tells you it was planned, not that it happened. Codified 2026-05-18.
+
+  **How to apply:** Strava query first for runs; user question for non Strava sessions; calendar stays out of retro source data entirely.
+
+- **Use retro findings to adjust the current week.** When the previous week shows significant under coverage, propose stepping down the current week's targets rather than pressing forward on the original plan. Annotate adjustments inline in the plan table (e.g., `20 (adjusted from 22)`) so both the original and adjusted targets stay visible for trend reading.
+
+  **Why:** Pressing forward on a plan that already slipped multiplies the gap. Adjusting in response to reality keeps adherence honest. Codified 2026-05-18.
+
+  **How to apply:** Phase 7 of retro mode does this explicitly. If the retro shows missed long run, mileage 30%+ under, or back to back misses, surface adjustment options before continuing to schedule.
+
+- **Interrogate significant deltas, don't just record them.** When retro numbers diverge sharply from plan, the read is incomplete without knowing the cause. Ask the user via `AskUserQuestion` about category (injury / schedule / motivation / conditions), then prompt for detail in chat. The cause drives the adjustment more than the numbers do. When the cause is medical, ask for any provider notes or AI consults the user wants captured in the retro.
+
+  **Why:** Wk 2 (ISO 2026-W20) came in -51% on mileage and -89% on vert. Numbers alone read as "fell off." Actual cause was a left heel injury (suspected plantar fasciitis). Without interrogating, the adjustment would have been wrong — push harder Wk 3 rather than step back and prioritize healing. Codified 2026-05-18.
+
+  **How to apply:** Phase 5 of retro mode. Always run it when the gap is 30%+ on any tracked metric or when a marquee session (long run, Thu SPRC) is fully missed.
+
 - **Vert is co-equal with mileage.** The training plan tracks both Long mi and Vert ft per week. A retro that only evaluates mileage misses half the point. Always pull elevation gain from Strava activity details and total against the plan's Vert ft target.
 - **Lifts at Movement RiNo do not show in Strava.** When a lift is missing from Strava, the status is **open**, not missed. Confirm with the user before logging it as a miss in the retro. Same applies to climbing at Movement.
 - **Strava run elevation in meters; convert to feet.** `meters * 3.28084`. Worth doing per activity then summing, since the plan's vert target is in feet.


### PR DESCRIPTION
## Summary

**Rename `assist:schedule` → `assist:planning`.** The skill is fundamentally about weekly planning, not schedule viewing alone.

**Restructure `assist:training` based on the W21 retro session:**

- Retro precedes scheduling. Week mode now runs the prior week's retro before scheduling the current week. Drift compounds without it.
- Strava is the source of truth for completion, not the calendar. Non Strava sessions (yoga, lifts, sauna, contrast) get user confirmation, never inferred from calendar events.
- New interrogation phase: when retro numbers diverge sharply from plan, ask why before writing. The cause shapes the adjustment more than the numbers do.
- New plan adjustment phase: use retro findings to step down current week targets when needed. Annotate inline (e.g. `20 (adjusted from 22)`) so both numbers stay visible.
- Integer phase numbering throughout (no Phase 4.5 half steps).

**Planning skill cleanup:**

- Dropped Fasting window and Lights out from Constraints. Personal anchors Forni manages, not scheduling conflicts to flag.
- Codified transition placeholder behavior: scheduled meetings claim time; transitions shrink to fit rather than reading as overlaps.

**Plugin learned rules:**

- Personal admin defaults to morning slots, not afternoon. Afternoons fill with work.
- No half step phase numbering when adding phases to skills or documents. Renumber subsequent phases instead.

Also picked up the latest main (sdlc 2.2.0 + the new sdlc:land skill).

## Test plan

- [ ] Verify the renamed `assist:planning` skill loads and behaves identically to former `assist:schedule`
- [ ] Run `/assist:training week` and confirm retro precedes scheduling
- [ ] Confirm retro mode runs interrogation when there is significant drift
- [ ] Grep for `Phase [0-9]\.[0-9]` to confirm no half step references remain (the codification rule's quoted example is the only allowed match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)