### PR TITLE
Codify Plugin Versioning Rule and Bump sdlc to 2.2.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
     {
       "name": "sdlc",
       "source": "./plugins/sdlc",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "MIT",
       "description": "Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.",
       "homepage": "https://github.com/mattforni/homebase",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,23 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Homebase is a personal development environment repository for managing shell configurations, aliases, functions, Claude Code skills/plugins, and development tooling across different systems.
 
+## Plugin Versioning
+
+**Every change to anything inside `plugins/<plugin>/...` requires a version bump in two places before the change merges.** Skill prose, scripts, configs, hooks, command definitions, the plugin.json itself, anything inside a plugin directory. Without a version bump, the marketplace cannot tell "you have the old skill" from "you have the new skill," and updates silently fail to propagate.
+
+Bump both, and keep them in sync:
+
+- `plugins/<plugin>/plugin.json`: `version` field
+- `.claude-plugin/marketplace.json`: `version` field for the matching plugin entry (must equal the plugin.json value)
+
+Use semver:
+
+- **Patch** (`2.2.1` to `2.2.2`): behavioral tweaks, bug fixes, prose updates, hardening, rule additions inside a skill body.
+- **Minor** (`2.2.1` to `2.3.0`): new skill, new command, new hook, new public surface area.
+- **Major** (`2.2.1` to `3.0.0`): breaking change to a skill's contract, argument shape, or removed surface.
+
+Top-level repo files (`CLAUDE.md`, `README.md`, `.gitconfig`, `.aliases`, etc.) do **not** trigger a plugin version bump because they live outside any plugin directory.
+
 ## Installation
 
 Run `./setup.sh` to install homebase to the home directory. The script will:

--- a/plugins/sdlc/plugin.json
+++ b/plugins/sdlc/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"


### PR DESCRIPTION
## Summary

Previous PR #89 updated `plugins/sdlc/skills/plan/SKILL.md` without bumping the plugin version. Without a version bump, the marketplace cannot distinguish "you have the old skill" from "you have the new skill" and updates silently fail to propagate. Two changes here:

- **Elevate Plugin Versioning rule in `CLAUDE.md`** as the second top-level section so future sessions see it before touching any plugin. Rule requires bumping both `plugins/<plugin>/plugin.json` and `.claude-plugin/marketplace.json` on any change inside a plugin directory, with semver guidance (patch for prose/hardening, minor for new surface, major for breaks). Top-level repo files do not trigger a plugin bump.
- **Bump sdlc to 2.2.2** to retroactively version the plan skill changes that already landed in #89.

## Test plan

- [ ] Confirm `plugin.json` and `marketplace.json` show `2.2.2` for sdlc.
- [ ] Confirm `CLAUDE.md` Plugin Versioning section is the second top-level header (right after Repository Overview).
- [ ] Next plugin change in this repo bumps both manifests without prompting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)