### PR TITLE
Codify /gemini review trigger and DIRTY rebase in sdlc:land

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
     {
       "name": "sdlc",
       "source": "./plugins/sdlc",
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "MIT",
       "description": "Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.",
       "homepage": "https://github.com/mattforni/homebase",

--- a/plugins/sdlc/plugin.json
+++ b/plugins/sdlc/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/plugins/sdlc/skills/land/SKILL.md
+++ b/plugins/sdlc/skills/land/SKILL.md
@@ -99,7 +99,13 @@ Calibration: 60s poll interval and 45 min cap fit atelic-style repos (CI 1–2 m
     - No comments / "no feedback" / all advisory you'd decline → **merge** (Step 5)
     - Actionable items → **iterate** (next bullet)
     - Mixed → address actionable, decline advisory with reasoning, push, then loop back to Step 3
-- **Iterate**: invoke `sdlc:iterate` with PR_NUMBER. It addresses comments, pushes, and posts the re-review trigger (push alone usually re-triggers Gemini; CodeRabbit may need an explicit `@coderabbitai review` per the repo's `sdlc.review-command` config). Loop back to Step 3.
+- **Iterate**: invoke `sdlc:iterate` with PR_NUMBER. It addresses comments and pushes. **Pushing alone does NOT re-trigger either Gemini Code Assist or CodeRabbit.** After each iterate push you must explicitly post the re-review comment for the configured bot — `/gemini review` for Gemini, `@coderabbitai review` for CodeRabbit (consult the repo's `sdlc.review-command` config). Then check `mergeStateStatus` and rebase if the PR went `DIRTY` while you were iterating (main can move under you, especially in active repos):
+
+  ```bash
+  gh pr view PR_NUMBER --json mergeStateStatus --jq '.mergeStateStatus'
+  ```
+
+  If `DIRTY`, fetch main, rebase, resolve conflicts, force-push with `--force-with-lease`, then post the re-review trigger. Loop back to Step 3.
 - **`CHECKS_FAILED`**: fetch failing job logs. If the failure is something you introduced and can fix in place, fix and push; loop back to Step 3. Otherwise bail to the user with the failing job link.
 - **`HUMAN_REVIEW`**: bail to the user with the review body. Humans get the final word — never auto-merge over a human comment even if it looks like a nit.
 - **`TIMEOUT`**: bail to the user with the current state summary.


### PR DESCRIPTION
## Summary

Two lessons surfaced while landing GROW-111 PR #14 (zero-decarb/dev-tools):

1. **Pushing alone does NOT re-trigger Gemini Code Assist.** After every iterate push you must post the bot's explicit re-review comment (`/gemini review` for Gemini, `@coderabbitai review` for CodeRabbit). The skill previously implied push was enough, which silently stranded review cycles.
2. **`mergeStateStatus` can flip to `DIRTY` mid iterate** when main moves while you're iterating. The skill needed a check + rebase step before re-requesting review; previously it only checked merge state at final-merge time.

Bumps `sdlc` plugin version 2.2.2 → 2.2.3 (patch; behavioral tweak to a skill).

## Test plan

- [x] Lesson came from a real run today
- [ ] Next /sdlc:land invocation respects the updated guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)