### PR TITLE
Detect Legacy gws Account Before Migration

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -545,16 +545,43 @@ setup_auth() {
 
   # Google Workspace CLI (multi-profile)
   if command -v gws &>/dev/null; then
-    # Migrate legacy single-profile layout into the "zero" profile.
-    if [[ -d "$HOME/.config/gws" ]] && [[ ! -d "$HOME/.config/gws-zero" ]]; then
-      info "Migrating ~/.config/gws -> ~/.config/gws-zero"
-      mv "$HOME/.config/gws" "$HOME/.config/gws-zero" || return 1
-      SUMMARY+=("gws: migrated legacy config to zero profile")
-    elif [[ -d "$HOME/.config/gws" ]] && [[ -d "$HOME/.config/gws-zero" ]]; then
-      warn "Both ~/.config/gws and ~/.config/gws-zero exist. Inspect and remove the stale one manually."
+    # Migrate legacy single-profile layout. Detect which profile the legacy
+    # config belongs to by peeking at the authenticated account; map
+    # @zerohomes.io domain to "zero" and anything else to "personal".
+    local migrated_profile=""
+    if [[ -d "$HOME/.config/gws" ]]; then
+      local legacy_user=""
+      legacy_user=$(GOOGLE_WORKSPACE_CLI_CONFIG_DIR="$HOME/.config/gws" gws auth status 2>/dev/null \
+        | python3 -c "import json,sys; print(json.load(sys.stdin).get('user',''))" 2>/dev/null \
+        || true)
+
+      local legacy_profile=""
+      case "$legacy_user" in
+        *@zerohomes.io) legacy_profile=zero ;;
+        "") legacy_profile="" ;;
+        *) legacy_profile=personal ;;
+      esac
+
+      if [[ -z "$legacy_profile" ]]; then
+        warn "Could not detect account in ~/.config/gws (no auth state to inspect)."
+        warn "Rename it manually before re-running setup:"
+        warn "  mv ~/.config/gws ~/.config/gws-<zero|personal>"
+      else
+        local migration_target="$HOME/.config/gws-$legacy_profile"
+        if [[ -d "$migration_target" ]]; then
+          warn "Both ~/.config/gws (account: $legacy_user) and $migration_target exist. Inspect and remove the stale one manually."
+        else
+          info "Migrating ~/.config/gws -> $migration_target (detected account: $legacy_user)"
+          mv "$HOME/.config/gws" "$migration_target" || return 1
+          SUMMARY+=("gws: migrated legacy config to $legacy_profile profile ($legacy_user)")
+          migrated_profile="$legacy_profile"
+        fi
+      fi
     fi
 
-    [[ -f "$HOME/.config/gws-current" ]] || printf 'zero\n' > "$HOME/.config/gws-current"
+    # Seed the active-profile pointer. Prefer the just-migrated profile so a
+    # fresh personal-only machine doesn't default to zero ambient.
+    [[ -f "$HOME/.config/gws-current" ]] || printf '%s\n' "${migrated_profile:-zero}" > "$HOME/.config/gws-current"
 
     local gws_bootstrap_project="${GWS_BOOTSTRAP_PROJECT:-gws-forni}"
     local gws_profile gws_dir

--- a/setup.sh
+++ b/setup.sh
@@ -552,7 +552,7 @@ setup_auth() {
     if [[ -d "$HOME/.config/gws" ]]; then
       local legacy_user=""
       legacy_user=$(GOOGLE_WORKSPACE_CLI_CONFIG_DIR="$HOME/.config/gws" gws auth status \
-        | python3 -c "import json,sys; print(json.load(sys.stdin).get('user',''))" \
+        | jq -r '.user // empty' \
         || true)
 
       local legacy_profile=""

--- a/setup.sh
+++ b/setup.sh
@@ -568,7 +568,7 @@ setup_auth() {
         warn "  mv ~/.config/gws ~/.config/gws-<zero|personal>"
       else
         local migration_target="$HOME/.config/gws-$legacy_profile"
-        if [[ -d "$migration_target" ]]; then
+        if [[ -e "$migration_target" ]]; then
           warn "Both ~/.config/gws (account: $legacy_user) and $migration_target exist. Inspect and remove the stale one manually."
         else
           info "Migrating ~/.config/gws -> $migration_target (detected account: $legacy_user)"

--- a/setup.sh
+++ b/setup.sh
@@ -551,8 +551,8 @@ setup_auth() {
     local migrated_profile=""
     if [[ -d "$HOME/.config/gws" ]]; then
       local legacy_user=""
-      legacy_user=$(GOOGLE_WORKSPACE_CLI_CONFIG_DIR="$HOME/.config/gws" gws auth status 2>/dev/null \
-        | python3 -c "import json,sys; print(json.load(sys.stdin).get('user',''))" 2>/dev/null \
+      legacy_user=$(GOOGLE_WORKSPACE_CLI_CONFIG_DIR="$HOME/.config/gws" gws auth status \
+        | python3 -c "import json,sys; print(json.load(sys.stdin).get('user',''))" \
         || true)
 
       local legacy_profile=""

--- a/setup.sh
+++ b/setup.sh
@@ -556,7 +556,7 @@ setup_auth() {
         || true)
 
       local legacy_profile=""
-      case "$legacy_user" in
+      case "${legacy_user,,}" in
         *@zerohomes.io) legacy_profile=zero ;;
         "") legacy_profile="" ;;
         *) legacy_profile=personal ;;


### PR DESCRIPTION
## Summary

- `setup.sh` previously assumed any legacy `~/.config/gws/` was the zero account and migrated it to `~/.config/gws-zero`. That worked on the first machine but mislabels personal auth on any subsequent machine.
- Now peek at the authenticated user via `gws auth status`, map `@zerohomes.io` → `zero` and anything else → `personal`, and migrate accordingly. If no auth state is present, surface a manual rename prompt rather than guessing.
- Also seed `~/.config/gws-current` with the detected profile so a freshly-migrated personal-only machine does not silently default its ambient to zero.

## Test plan

- [x] Bash syntax check passes (`bash -n setup.sh`)
- [ ] Dry-run on a fresh machine with `~/.config/gws` authenticated as personal: confirm it migrates to `~/.config/gws-personal` and seeds `gws-current` with `personal`
- [ ] Dry-run on a machine with `~/.config/gws` authenticated as zero: confirm it migrates to `~/.config/gws-zero`
- [ ] Dry-run on a machine where the legacy dir already has a target sibling (e.g., both `~/.config/gws` and `~/.config/gws-personal` exist): confirm the warn fires and nothing is moved
- [ ] No-op verification: on a machine without `~/.config/gws`, setup.sh skips the migration block cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)