### PR TITLE
Add Per-Account Claude Code Profiles and Cascade gws Rename

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -83,7 +83,9 @@ Choose the highest available option. Native connectors are smoother and require 
 
 ### gws Profiles
 
-The `gws` CLI uses `$GOOGLE_WORKSPACE_CLI_CONFIG_DIR` for per-account isolation. Forni's shell auto-loads either `~/.config/gws-zero/` or `~/.config/gws-personal/` based on `~/.config/gws-current`. A zsh chpwd hook also walks up from `$PWD` looking for `.gws-profile` marker files and silently switches when one is found, so cd'ing into a personal subtree flips you to personal for that shell. Use `gws-whoami` to confirm which account is active before sending mail or modifying calendars. When ambiguous, ask which account Forni wants the action against. Per-command override: `GOOGLE_WORKSPACE_CLI_CONFIG_DIR=~/.config/gws-personal gws ...`.
+The `gws` CLI uses `$GOOGLE_WORKSPACE_CLI_CONFIG_DIR` for per-account isolation. Forni's shell auto-loads either `~/.config/gws-zero/` or `~/.config/gws-home/` based on `~/.config/gws-current`. A zsh chpwd hook also walks up from `$PWD` looking for `.account` marker files (a cross-tool convention; the `~/bin/claude` wrapper reads the same marker) and silently switches when one is found, so cd'ing into a home subtree flips you to home for that shell. Use `gws-whoami` to confirm which account is active before sending mail or modifying calendars. When ambiguous, ask which account Forni wants the action against. Per-command override: `GOOGLE_WORKSPACE_CLI_CONFIG_DIR=~/.config/gws-home gws ...`.
+
+The `~/bin/claude` wrapper picks a Claude Code config dir (`~/.claude-zero/` or `~/.claude-home/`) at launch from the same `.account` marker, reads the matching `claude-code-oauth-<profile>` Keychain entry, and exec's the real binary. New sessions started in a directory subtree automatically use the right Anthropic account.
 
 ### Google Workspace links (Docs, Sheets, Slides, Drive)
 

--- a/.claude/skills/gws-shared/SKILL.md
+++ b/.claude/skills/gws-shared/SKILL.md
@@ -2,7 +2,7 @@
 name: gws-shared
 description: "gws CLI: Shared patterns for authentication, global flags, and output formatting."
 metadata:
-  version: 0.22.5
+  version: 0.22.6
   openclaw:
     category: "productivity"
     requires:
@@ -33,22 +33,24 @@ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
 | Profile | Config dir | Account |
 |---------|-----------|---------|
 | `zero` | `~/.config/gws-zero/` | `mattf@zerohomes.io` (Zero Homes) |
-| `personal` | `~/.config/gws-personal/` | personal Gmail |
+| `home` | `~/.config/gws-home/` | personal Gmail |
 
 The active profile is layered:
 
 1. **Ambient** — recorded in `~/.config/gws-current` and exported as `GOOGLE_WORKSPACE_CLI_CONFIG_DIR` at shell startup by `.functions`. Persists across shells.
-2. **Directory override** — a zsh `chpwd` hook walks up from `$PWD` on every `cd`, finds the nearest `.gws-profile` marker file (one line text containing the profile name), and silently swaps the env var. `cd` out, snap back to ambient.
+2. **Directory override** — a zsh `chpwd` hook walks up from `$PWD` on every `cd`, finds the nearest `.account` marker file (one line text containing the profile name), and silently swaps the env var. `cd` out, snap back to ambient.
 3. **Pin** — `gws-pin` disables the chpwd hook in the current shell.
+
+The `.account` marker is a cross-tool convention; the `~/bin/claude` wrapper reads the same file to pick the Claude Code profile.
 
 | Command | Effect |
 |---------|--------|
 | `gws-use` | List profiles; show current |
-| `gws-use personal` | Set ambient profile (persists across shells; also unpins) |
+| `gws-use home` | Set ambient profile (persists across shells; also unpins) |
 | `gws-pin` | Lock to current profile in this shell (disables chpwd hook) |
 | `gws-unpin` | Resume chpwd hook |
 | `gws-whoami` | Show profile, config dir, and `gws auth status` |
-| `GOOGLE_WORKSPACE_CLI_CONFIG_DIR=~/.config/gws-personal gws ...` | One shot override |
+| `GOOGLE_WORKSPACE_CLI_CONFIG_DIR=~/.config/gws-home gws ...` | One shot override |
 
 When writing tooling that should always run against a specific account, prefer the per-command override over relying on the ambient profile. When in doubt about which account is active, run `gws-whoami` before any action that sends mail or modifies a calendar.
 

--- a/.functions
+++ b/.functions
@@ -425,18 +425,19 @@ find_and_source_env() {
 # Multi-profile support for the gws (Google Workspace) CLI.
 # Layered model:
 #   1. Ambient profile from ~/.config/gws-current (persists across shells)
-#   2. Directory override via .gws-profile markers + chpwd hook (zsh)
+#   2. Directory override via .account markers + chpwd hook (zsh)
 #   3. Pin via gws-pin to disable the hook in the current shell
 # Per-command override stays available: GOOGLE_WORKSPACE_CLI_CONFIG_DIR=... gws ...
+# The .account marker is shared across tools (also read by ~/bin/claude).
 __gws_resolve_profile() {
     [[ "${GWS_AUTO_SWITCH:-1}" == "0" ]] && return 0
 
-    # Walk up from PWD looking for the nearest .gws-profile marker.
+    # Walk up from PWD looking for the nearest .account marker.
     local dir="$PWD"
     local target=""
     while :; do
-        if [[ -f "$dir/.gws-profile" ]]; then
-            target="$(cat "$dir/.gws-profile" 2>/dev/null)"
+        if [[ -f "$dir/.account" ]]; then
+            target="$(cat "$dir/.account" 2>/dev/null)"
             target="${target//[$'\t\r\n ']/}"
             break
         fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,12 +78,12 @@ Run `./setup.sh` to install homebase to the home directory. The script will:
 - `log [-p] <executable>` - Run executable and log output with timestamp
 - `numf [-a] [directory]` - Count files in directory
 
-### Google Workspace CLI Profiles
+### Account Profiles (gws + Claude Code)
 
-The `gws` CLI supports multiple Google accounts via per-profile config dirs. Active profile is layered:
+Both the `gws` CLI and Claude Code switch identity per directory subtree via a shared `.account` marker file (one-line text containing the profile name). Profiles today: `zero` (Zero Homes work) and `home` (personal). Active profile is layered:
 
-1. **Ambient** — recorded in `~/.config/gws-current`, exported as `GOOGLE_WORKSPACE_CLI_CONFIG_DIR` at shell startup. Persists across shells.
-2. **Directory override** — a zsh `chpwd` hook walks up from `$PWD` looking for the nearest `.gws-profile` marker file and silently swaps the env var for that shell.
+1. **Ambient** — recorded in `~/.config/gws-current` and exported as `GOOGLE_WORKSPACE_CLI_CONFIG_DIR` at shell startup. Persists across shells.
+2. **Directory override** — a zsh `chpwd` hook walks up from `$PWD` looking for the nearest `.account` marker file and silently swaps the env var for that shell. The `~/bin/claude` wrapper reads the same marker at launch time to pick the Claude Code config dir.
 3. **Pin** — `gws-pin` disables the chpwd hook in the current shell.
 
 | Command | Effect |
@@ -93,9 +93,11 @@ The `gws` CLI supports multiple Google accounts via per-profile config dirs. Act
 | `gws-pin` | Lock to current profile in this shell |
 | `gws-unpin` | Resume chpwd hook |
 | `gws-whoami` | Show profile, config dir, and `gws auth status` |
-| `GOOGLE_WORKSPACE_CLI_CONFIG_DIR=~/.config/gws-personal gws ...` | One shot override |
+| `GOOGLE_WORKSPACE_CLI_CONFIG_DIR=~/.config/gws-home gws ...` | One shot override |
 
-OAuth `client_secret.json` files sync across machines via GCP Secret Manager (bootstrap project: `gws-forni`, override via `GWS_BOOTSTRAP_PROJECT`). `setup.sh` fetches automatically when a profile dir is missing one. Use `bin/gws-secrets-push.sh` once on the source machine to seed the secrets. Encrypted tokens stay per-machine by design.
+**Claude Code:** `~/bin/claude` is a wrapper that exports `CLAUDE_CONFIG_DIR=~/.claude-<profile>/` and reads the matching `claude-code-oauth-<profile>` entry from macOS Keychain before exec'ing the real binary. Per-profile dirs are bootstrapped by `bin/claude-profiles-init.sh` (invoked from setup.sh).
+
+OAuth `client_secret.json` files for gws sync across machines via GCP Secret Manager (bootstrap project: `gws-forni`, override via `GWS_BOOTSTRAP_PROJECT`). `setup.sh` fetches automatically when a profile dir is missing one. Use `bin/gws-secrets-push.sh` once on the source machine to seed the secrets. Encrypted tokens stay per-machine by design.
 
 ## Project Structure
 

--- a/bin/claude
+++ b/bin/claude
@@ -10,7 +10,7 @@
 # Profile dirs at ~/.claude-zero/ and ~/.claude-home/ are populated by
 # bin/claude-profiles-init.sh (invoked from setup.sh).
 
-set -uo pipefail
+set -euo pipefail
 
 resolve_profile() {
     local dir="$PWD"
@@ -34,17 +34,17 @@ profile=$(resolve_profile)
 cfg_dir="$HOME/.claude-$profile"
 
 # Find the next `claude` on PATH that isn't this wrapper.
+# Bash's `-ef` test compares files by device+inode, so it correctly handles
+# the case where this script is reached via a symlink in PATH (e.g.
+# ~/bin/claude -> .../homebase/bin/claude) and the same physical file appears
+# under a different PATH entry.
 real_claude=""
-self_real=$(/usr/bin/python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$0" 2>/dev/null || echo "$0")
 IFS=':' read -ra path_parts <<< "$PATH"
 for p in "${path_parts[@]}"; do
     candidate="$p/claude"
-    if [[ -x "$candidate" ]]; then
-        candidate_real=$(/usr/bin/python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$candidate" 2>/dev/null || echo "$candidate")
-        if [[ "$candidate_real" != "$self_real" ]]; then
-            real_claude="$candidate"
-            break
-        fi
+    if [[ -x "$candidate" && ! "$candidate" -ef "$0" ]]; then
+        real_claude="$candidate"
+        break
     fi
 done
 if [[ -z "$real_claude" ]]; then

--- a/bin/claude
+++ b/bin/claude
@@ -24,7 +24,9 @@ resolve_profile() {
         dir="$(dirname "$dir")"
     done
     if [[ -z "$target" ]]; then
-        target="$(cat "$HOME/.config/gws-current" 2>/dev/null | tr -d '[:space:]')"
+        if [[ -f "$HOME/.config/gws-current" ]]; then
+            target="$(cat "$HOME/.config/gws-current" | tr -d '[:space:]')"
+        fi
         [[ -z "$target" ]] && target="zero"
     fi
     printf '%s' "$target"

--- a/bin/claude
+++ b/bin/claude
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Per-profile wrapper around the real `claude` binary.
+#
+# Walks up from $PWD finding the nearest .account marker (shared with the gws
+# resolver in .functions). Falls back to the ambient profile in
+# ~/.config/gws-current. Reads the matching claude-code-oauth-<profile> entry
+# from macOS Keychain, exports CLAUDE_CONFIG_DIR + CLAUDE_CODE_OAUTH_TOKEN,
+# and exec's the real binary.
+#
+# Profile dirs at ~/.claude-zero/ and ~/.claude-home/ are populated by
+# bin/claude-profiles-init.sh (invoked from setup.sh).
+
+set -uo pipefail
+
+resolve_profile() {
+    local dir="$PWD"
+    local target=""
+    while :; do
+        if [[ -f "$dir/.account" ]]; then
+            target="$(cat "$dir/.account" 2>/dev/null | tr -d '[:space:]')"
+            break
+        fi
+        [[ "$dir" == "$HOME" || "$dir" == "/" ]] && break
+        dir="$(dirname "$dir")"
+    done
+    if [[ -z "$target" ]]; then
+        target="$(cat "$HOME/.config/gws-current" 2>/dev/null | tr -d '[:space:]')"
+        [[ -z "$target" ]] && target="zero"
+    fi
+    printf '%s' "$target"
+}
+
+profile=$(resolve_profile)
+cfg_dir="$HOME/.claude-$profile"
+
+# Find the next `claude` on PATH that isn't this wrapper.
+real_claude=""
+self_real=$(/usr/bin/python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$0" 2>/dev/null || echo "$0")
+IFS=':' read -ra path_parts <<< "$PATH"
+for p in "${path_parts[@]}"; do
+    candidate="$p/claude"
+    if [[ -x "$candidate" ]]; then
+        candidate_real=$(/usr/bin/python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$candidate" 2>/dev/null || echo "$candidate")
+        if [[ "$candidate_real" != "$self_real" ]]; then
+            real_claude="$candidate"
+            break
+        fi
+    fi
+done
+if [[ -z "$real_claude" ]]; then
+    echo "claude wrapper: cannot find real claude binary on PATH" >&2
+    exit 127
+fi
+
+# Fall back to default config root if the profile dir does not exist.
+if [[ ! -d "$cfg_dir" ]]; then
+    echo "claude wrapper: $cfg_dir not found, using default config" >&2
+    exec "$real_claude" "$@"
+fi
+
+token=$(security find-generic-password -s "claude-code-oauth-$profile" -w 2>/dev/null || true)
+
+env_args=(CLAUDE_CONFIG_DIR="$cfg_dir")
+[[ -n "$token" ]] && env_args+=(CLAUDE_CODE_OAUTH_TOKEN="$token")
+
+exec env "${env_args[@]}" "$real_claude" "$@"

--- a/bin/claude-profiles-init.sh
+++ b/bin/claude-profiles-init.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Bootstrap ~/.claude-zero/ and ~/.claude-home/ from the legacy ~/.claude/.
+#
+# Splits sessions/memory by project path: entries under Eudaimonia/Craft/
+# Development/zero go to zero; other Eudaimonia entries go to home; everything
+# else goes to zero (ambient on this machine). Copies user-level settings into
+# both profiles. Symlinks the shared homebase surface (skills, commands,
+# references, local-skills, statusline, project CLAUDE.md) into both.
+#
+# Idempotent: re-running on already-split dirs is a no-op for the parts that
+# survive (it never overwrites an existing entry).
+
+set -euo pipefail
+
+LEGACY="$HOME/.claude"
+ZERO="$HOME/.claude-zero"
+HOME_PROFILE="$HOME/.claude-home"
+HOMEBASE_CLAUDE="$HOME/Eudaimonia/Craft/Development/personal/homebase/.claude"
+
+for d in "$ZERO" "$HOME_PROFILE"; do
+    mkdir -p "$d"/{projects,sessions,plugins,hooks}
+done
+
+# Per-profile settings: copy from legacy if not already present.
+for d in "$ZERO" "$HOME_PROFILE"; do
+    for f in settings.json settings.local.json; do
+        [[ -f "$d/$f" ]] && continue
+        [[ -f "$LEGACY/$f" ]] && cp -a "$LEGACY/$f" "$d/$f"
+    done
+done
+
+# Symlinks back to homebase (shared surface).
+for d in "$ZERO" "$HOME_PROFILE"; do
+    for item in skills commands references local-skills statusline.sh CLAUDE.md; do
+        target="$HOMEBASE_CLAUDE/$item"
+        link="$d/$item"
+        if [[ -e "$target" ]] && [[ ! -e "$link" ]] && [[ ! -L "$link" ]]; then
+            ln -s "$target" "$link"
+        fi
+    done
+done
+
+# Migrate ~/.claude/projects/ by path.
+if [[ -d "$LEGACY/projects" ]]; then
+    for entry in "$LEGACY/projects"/*; do
+        [[ -d "$entry" ]] || continue
+        name=$(basename "$entry")
+        case "$name" in
+            -Users-mattforni-Eudaimonia-Craft-Development-zero*)
+                dest="$ZERO/projects/$name" ;;
+            -Users-mattforni-Eudaimonia*)
+                dest="$HOME_PROFILE/projects/$name" ;;
+            *)
+                dest="$ZERO/projects/$name" ;;
+        esac
+        if [[ ! -e "$dest" ]]; then
+            mv "$entry" "$dest"
+        fi
+    done
+fi
+
+# Sessions: copy to zero only (short-lived; OK to start fresh on home).
+if [[ -d "$LEGACY/sessions" ]] && [[ ! -e "$ZERO/sessions/.migrated" ]]; then
+    cp -a "$LEGACY/sessions"/. "$ZERO/sessions/" 2>/dev/null || true
+    touch "$ZERO/sessions/.migrated"
+fi
+
+echo "Done. ~/.claude-zero/ and ~/.claude-home/ ready."
+echo "Next: populate Keychain entries if missing:"
+echo "  security add-generic-password -a \$USER -s claude-code-oauth-zero -w '<token>' -U"
+echo "  security add-generic-password -a \$USER -s claude-code-oauth-home -w '<token>' -U"

--- a/bin/claude-profiles-init.sh
+++ b/bin/claude-profiles-init.sh
@@ -15,7 +15,11 @@ set -euo pipefail
 LEGACY="$HOME/.claude"
 ZERO="$HOME/.claude-zero"
 HOME_PROFILE="$HOME/.claude-home"
-HOMEBASE_CLAUDE="$HOME/Eudaimonia/Craft/Development/personal/homebase/.claude"
+# Resolve HOMEBASE_CLAUDE from this script's physical location so the script
+# works whether invoked directly from homebase/bin or via the $HOME/bin
+# symlink. `cd -P` forces physical resolution, following the symlink.
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOMEBASE_CLAUDE="$(dirname "$SCRIPT_DIR")/.claude"
 
 for d in "$ZERO" "$HOME_PROFILE"; do
     mkdir -p "$d"/{projects,sessions,plugins,hooks}
@@ -40,15 +44,18 @@ for d in "$ZERO" "$HOME_PROFILE"; do
     done
 done
 
-# Migrate ~/.claude/projects/ by path.
+# Migrate ~/.claude/projects/ by path. Project entries are named after the
+# absolute path with `/` replaced by `-`, so we derive the same encoding
+# from $HOME rather than hardcoding the username.
+HOME_PATTERN="${HOME//\//-}"
 if [[ -d "$LEGACY/projects" ]]; then
     for entry in "$LEGACY/projects"/*; do
         [[ -d "$entry" ]] || continue
         name=$(basename "$entry")
         case "$name" in
-            -Users-mattforni-Eudaimonia-Craft-Development-zero*)
+            "${HOME_PATTERN}-Eudaimonia-Craft-Development-zero"*)
                 dest="$ZERO/projects/$name" ;;
-            -Users-mattforni-Eudaimonia*)
+            "${HOME_PATTERN}-Eudaimonia"*)
                 dest="$HOME_PROFILE/projects/$name" ;;
             *)
                 dest="$ZERO/projects/$name" ;;

--- a/setup.sh
+++ b/setup.sh
@@ -547,7 +547,7 @@ setup_auth() {
   if command -v gws &>/dev/null; then
     # Migrate legacy single-profile layout. Detect which profile the legacy
     # config belongs to by peeking at the authenticated account; map
-    # @zerohomes.io domain to "zero" and anything else to "personal".
+    # @zerohomes.io domain to "zero" and anything else to "home".
     local migrated_profile=""
     if [[ -d "$HOME/.config/gws" ]]; then
       local legacy_user=""
@@ -559,13 +559,13 @@ setup_auth() {
       case "${legacy_user,,}" in
         *@zerohomes.io) legacy_profile=zero ;;
         "") legacy_profile="" ;;
-        *) legacy_profile=personal ;;
+        *) legacy_profile=home ;;
       esac
 
       if [[ -z "$legacy_profile" ]]; then
         warn "Could not detect account in ~/.config/gws (no auth state to inspect)."
         warn "Rename it manually before re-running setup:"
-        warn "  mv ~/.config/gws ~/.config/gws-<zero|personal>"
+        warn "  mv ~/.config/gws ~/.config/gws-<zero|home>"
       else
         local migration_target="$HOME/.config/gws-$legacy_profile"
         if [[ -e "$migration_target" ]]; then
@@ -580,12 +580,12 @@ setup_auth() {
     fi
 
     # Seed the active-profile pointer. Prefer the just-migrated profile so a
-    # fresh personal-only machine doesn't default to zero ambient.
+    # fresh home-only machine doesn't default to zero ambient.
     [[ -f "$HOME/.config/gws-current" ]] || printf '%s\n' "${migrated_profile:-zero}" > "$HOME/.config/gws-current"
 
     local gws_bootstrap_project="${GWS_BOOTSTRAP_PROJECT:-gws-forni}"
     local gws_profile gws_dir
-    for gws_profile in zero personal; do
+    for gws_profile in zero home; do
       gws_dir="$HOME/.config/gws-$gws_profile"
       if [[ -f "$gws_dir/client_secret.json" ]] && [[ -f "$gws_dir/credentials.enc" ]] && [[ "$FORCE" != true ]]; then
         info "gws $gws_profile profile already configured ($gws_dir)"
@@ -627,6 +627,26 @@ setup_auth() {
         SUMMARY+=("gws: $gws_profile profile authenticated")
       else
         error "gws auth login failed for $gws_profile"
+      fi
+    done
+  fi
+
+  # Claude Code (multi-profile)
+  if command -v claude &>/dev/null; then
+    if [[ ! -d "$HOME/.claude-zero" ]] || [[ ! -d "$HOME/.claude-home" ]]; then
+      info "Bootstrapping Claude Code profile dirs..."
+      if "$DIR/bin/claude-profiles-init.sh"; then
+        SUMMARY+=("Claude Code profile dirs bootstrapped")
+      else
+        warn "claude-profiles-init.sh failed"
+      fi
+    else
+      info "Claude Code profile dirs already present (~/.claude-zero, ~/.claude-home)"
+    fi
+    for cc_profile in zero home; do
+      if ! security find-generic-password -s "claude-code-oauth-$cc_profile" >/dev/null 2>&1; then
+        warn "Missing Keychain entry: claude-code-oauth-$cc_profile"
+        warn "  security add-generic-password -a \$USER -s claude-code-oauth-$cc_profile -w '<token>' -U"
       fi
     done
   fi

--- a/setup.sh
+++ b/setup.sh
@@ -635,7 +635,7 @@ setup_auth() {
   if command -v claude &>/dev/null; then
     if [[ ! -d "$HOME/.claude-zero" ]] || [[ ! -d "$HOME/.claude-home" ]]; then
       info "Bootstrapping Claude Code profile dirs..."
-      if "$DIR/bin/claude-profiles-init.sh"; then
+      if bash "$DIR/bin/claude-profiles-init.sh"; then
         SUMMARY+=("Claude Code profile dirs bootstrapped")
       else
         warn "claude-profiles-init.sh failed"


### PR DESCRIPTION
## Summary

- Abstract the directory marker file from `.gws-profile` to `.account`. The marker is now read by both the gws resolver in `.functions` and the new `~/bin/claude` wrapper, and any future tool can opt in by reading the same file.
- Rename the non-work profile `personal` → `home` throughout: gws config dir convention (`~/.config/gws-home/`), `setup.sh` iteration list, legacy account detection fallback, Secret Manager lookup name (`gws-client-secret-home`), and all docs.
- Add `bin/claude` wrapper that walks up from `$PWD` to find the nearest `.account` marker, falls back to `~/.config/gws-current`, reads the matching `claude-code-oauth-<profile>` Keychain entry, exports `CLAUDE_CONFIG_DIR` + `CLAUDE_CODE_OAUTH_TOKEN`, and exec's the real `claude` binary (located by walking `$PATH` skipping itself).
- Add `bin/claude-profiles-init.sh` bootstrap that seeds `~/.claude-zero/` and `~/.claude-home/` from the legacy `~/.claude/`, splits `projects/` by path (zero subtree to `~/.claude-zero/`, other Eudaimonia entries to `~/.claude-home/`, ambient to zero), copies user-level settings into both, and symlinks the shared homebase surface (skills, commands, references, local-skills, statusline.sh, CLAUDE.md) into both profiles.
- `setup.sh` invokes the bootstrap when either profile dir is missing and warns when Keychain entries are absent.
- Bump `gws-shared` skill version (0.22.5 → 0.22.6).

Companion Eudaimonia PR (mattforni/Eudaimonia#NN) renames the two committed marker files and updates the gitignore exception.

## Test plan

- [x] `bash -n` syntax checks pass for `.functions`, `setup.sh`, `bin/claude`, `bin/claude-profiles-init.sh`
- [ ] After local migration: `cd ~/Eudaimonia && which claude` resolves to `~/bin/claude` (the wrapper)
- [ ] `cd ~/Eudaimonia && claude --version` runs under the home profile env
- [ ] `cd ~/Eudaimonia/Craft/Development/zero && claude --version` runs under the zero profile env
- [ ] `cd ~ && claude --version` runs under ambient (zero)
- [ ] `gws-whoami` continues to work in all three locations (proves the `.account` marker rename didn't break the gws resolver)
- [ ] `security find-generic-password -s claude-code-oauth-home -w` returns the home token after manual setup
- [ ] A new claude session in `~/Eudaimonia` writes memory to `~/.claude-home/projects/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)