### PR TITLE
Drop Dead Token Injection From Claude Wrapper

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -85,7 +85,7 @@ Choose the highest available option. Native connectors are smoother and require 
 
 The `gws` CLI uses `$GOOGLE_WORKSPACE_CLI_CONFIG_DIR` for per-account isolation. Forni's shell auto-loads either `~/.config/gws-zero/` or `~/.config/gws-home/` based on `~/.config/gws-current`. A zsh chpwd hook also walks up from `$PWD` looking for `.account` marker files (a cross-tool convention; the `~/bin/claude` wrapper reads the same marker) and silently switches when one is found, so cd'ing into a home subtree flips you to home for that shell. Use `gws-whoami` to confirm which account is active before sending mail or modifying calendars. When ambiguous, ask which account Forni wants the action against. Per-command override: `GOOGLE_WORKSPACE_CLI_CONFIG_DIR=~/.config/gws-home gws ...`.
 
-The `~/bin/claude` wrapper picks a Claude Code config dir (`~/.claude-zero/` or `~/.claude-home/`) at launch from the same `.account` marker, reads the matching `claude-code-oauth-<profile>` Keychain entry, and exec's the real binary. New sessions started in a directory subtree automatically use the right Anthropic account.
+The `~/bin/claude` wrapper picks a Claude Code config dir (`~/.claude-zero/` or `~/.claude-home/`) at launch from the same `.account` marker and exec's the real binary. Claude Code's OAuth credential storage is per CLAUDE_CONFIG_DIR natively (Keychain service `Claude Code-credentials-<hash>`), so the right Anthropic account is selected automatically. New sessions in a directory subtree use the right account.
 
 ### Google Workspace links (Docs, Sheets, Slides, Drive)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Both the `gws` CLI and Claude Code switch identity per directory subtree via a s
 | `gws-whoami` | Show profile, config dir, and `gws auth status` |
 | `GOOGLE_WORKSPACE_CLI_CONFIG_DIR=~/.config/gws-home gws ...` | One shot override |
 
-**Claude Code:** `~/bin/claude` is a wrapper that exports `CLAUDE_CONFIG_DIR=~/.claude-<profile>/` and reads the matching `claude-code-oauth-<profile>` entry from macOS Keychain before exec'ing the real binary. Per-profile dirs are bootstrapped by `bin/claude-profiles-init.sh` (invoked from setup.sh).
+**Claude Code:** `~/bin/claude` is a wrapper that exports `CLAUDE_CONFIG_DIR=~/.claude-<profile>/` and exec's the real binary. Claude Code stores OAuth credentials per CLAUDE_CONFIG_DIR natively in a `Claude Code-credentials-<hash>` Keychain entry, so the wrapper doesn't need to inject a token; setting the config dir is enough. Per-profile dirs are bootstrapped by `bin/claude-profiles-init.sh` (invoked from setup.sh); each profile needs a one time `claude` login from inside its directory to seed its Keychain credential.
 
 OAuth `client_secret.json` files for gws sync across machines via GCP Secret Manager (bootstrap project: `gws-forni`, override via `GWS_BOOTSTRAP_PROJECT`). `setup.sh` fetches automatically when a profile dir is missing one. Use `bin/gws-secrets-push.sh` once on the source machine to seed the secrets. Encrypted tokens stay per-machine by design.
 

--- a/bin/claude
+++ b/bin/claude
@@ -3,12 +3,19 @@
 #
 # Walks up from $PWD finding the nearest .account marker (shared with the gws
 # resolver in .functions). Falls back to the ambient profile in
-# ~/.config/gws-current. Reads the matching claude-code-oauth-<profile> entry
-# from macOS Keychain, exports CLAUDE_CONFIG_DIR + CLAUDE_CODE_OAUTH_TOKEN,
-# and exec's the real binary.
+# ~/.config/gws-current. Sets CLAUDE_CONFIG_DIR for the matching profile and
+# exec's the real binary.
+#
+# Auth note: Claude Code stores OAuth tokens per CLAUDE_CONFIG_DIR natively
+# (in a `Claude Code-credentials-<hash>` Keychain entry where the hash is
+# derived from the config dir path). Setting CLAUDE_CONFIG_DIR is enough to
+# pick the right account; no token injection needed.
 #
 # Profile dirs at ~/.claude-zero/ and ~/.claude-home/ are populated by
-# bin/claude-profiles-init.sh (invoked from setup.sh).
+# bin/claude-profiles-init.sh (invoked from setup.sh). The first time you
+# launch into a freshly-bootstrapped profile dir, Claude Code triggers an
+# OAuth browser flow and stores the resulting credential under the hashed
+# Keychain entry for that dir.
 
 set -euo pipefail
 
@@ -60,9 +67,4 @@ if [[ ! -d "$cfg_dir" ]]; then
     exec "$real_claude" "$@"
 fi
 
-token=$(security find-generic-password -s "claude-code-oauth-$profile" -w 2>/dev/null || true)
-
-env_args=(CLAUDE_CONFIG_DIR="$cfg_dir")
-[[ -n "$token" ]] && env_args+=(CLAUDE_CODE_OAUTH_TOKEN="$token")
-
-exec env "${env_args[@]}" "$real_claude" "$@"
+exec env CLAUDE_CONFIG_DIR="$cfg_dir" "$real_claude" "$@"

--- a/bin/claude-profiles-init.sh
+++ b/bin/claude-profiles-init.sh
@@ -73,6 +73,7 @@ if [[ -d "$LEGACY/sessions" ]] && [[ ! -e "$ZERO/sessions/.migrated" ]]; then
 fi
 
 echo "Done. ~/.claude-zero/ and ~/.claude-home/ ready."
-echo "Next: populate Keychain entries if missing:"
-echo "  security add-generic-password -a \$USER -s claude-code-oauth-zero -w '<token>' -U"
-echo "  security add-generic-password -a \$USER -s claude-code-oauth-home -w '<token>' -U"
+echo "Next: cd into each profile's territory and run \`claude\` once."
+echo "Claude Code will open an OAuth browser flow and store the resulting"
+echo "credential under a per-CLAUDE_CONFIG_DIR Keychain entry. Each profile"
+echo "needs its own login (sign in as the right Anthropic account)."

--- a/setup.sh
+++ b/setup.sh
@@ -643,12 +643,9 @@ setup_auth() {
     else
       info "Claude Code profile dirs already present (~/.claude-zero, ~/.claude-home)"
     fi
-    for cc_profile in zero home; do
-      if ! security find-generic-password -s "claude-code-oauth-$cc_profile" >/dev/null 2>&1; then
-        warn "Missing Keychain entry: claude-code-oauth-$cc_profile"
-        warn "  security add-generic-password -a \$USER -s claude-code-oauth-$cc_profile -w '<token>' -U"
-      fi
-    done
+    info "Per-profile auth: cd into each profile's territory and run \`claude\` once."
+    info "Claude Code stores credentials per CLAUDE_CONFIG_DIR natively (Keychain"
+    info "service \"Claude Code-credentials-<hash>\"). Sign in as the right account."
   fi
 }
 


### PR DESCRIPTION
## Summary

Claude Code stores OAuth credentials per `CLAUDE_CONFIG_DIR` natively in a `Claude Code-credentials-<hash>` Keychain entry. The wrapper's `CLAUDE_CODE_OAUTH_TOKEN` env-var injection (reading from `claude-code-oauth-<profile>` Keychain entries) was based on a stale auth model from the binary we string-dumped during planning — that path never fires on a current Claude Code build.

Discovered when bootstrapping #93's wrapper on this machine: the first OAuth flow stored its token under `Claude Code-credentials-b87bbb34` (hashed for `~/.claude-home/`), not under `claude-code-oauth`, so the wrapper's env-var lookup found nothing and Claude Code's native lookup did the right thing anyway.

This PR removes the dead weight:
- `bin/claude`: drop the `security find-generic-password` lookup and the `env_args` array; exec straight through with just `CLAUDE_CONFIG_DIR` set.
- `bin/claude-profiles-init.sh`: stop telling the user to populate `claude-code-oauth-<profile>` Keychain entries; instruct them to cd in and run `claude` once instead.
- `setup.sh`: drop the warning loop that checked for the per-profile Keychain entries.
- `CLAUDE.md` and `.claude/CLAUDE.md`: update the wrapper description to reflect the simpler model.

## Test plan

- [x] Bash syntax checks pass for `bin/claude`, `bin/claude-profiles-init.sh`, `setup.sh`
- [ ] After merge: `cd ~/Eudaimonia && claude` resolves to the home account; `cd ~/Eudaimonia/Craft/Development/zero && claude` resolves to zero; `cd ~ && claude` resolves to ambient (zero) — same behavior as before, fewer moving parts in the wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)