### PR TITLE
Codify Claude Code Auth and setup.sh Phase Conventions

### DIFF
--- a/.claude/references/claude-code-auth.md
+++ b/.claude/references/claude-code-auth.md
@@ -1,0 +1,51 @@
+# Claude Code OAuth Storage
+
+Reference for how the `claude` binary stores credentials and how to isolate identities across accounts. Load when touching the `~/bin/claude` wrapper, `bin/claude-profiles-init.sh`, the Claude Code setup phase in `setup.sh`, or any future tooling that wants to read or supply Claude Code auth.
+
+## Where Claude Code Stores OAuth Credentials
+
+Current Claude Code binaries (verified as of May 2026 on the build shipping with `@anthropic-ai/claude-code` installed under `~/.local/bin/`) store OAuth credentials in macOS Keychain under a **per-CLAUDE_CONFIG_DIR service name**:
+
+```
+Claude Code-credentials-<hash>
+```
+
+The `<hash>` is derived from the `CLAUDE_CONFIG_DIR` path. Different config dirs get different hashed entries. There is also an unhashed `Claude Code-credentials` entry that newer Claude Code versions populate as a default; treat it as version-dependent and do not depend on it.
+
+**There is no longer a single `claude-code-oauth` Keychain entry.** Older binaries and `~/.claude/references/headless-claude.md` mention that service name; on current builds it is not used by interactive logins. The `bin/run-mise` headless flow still references it for its own reasons (launchd-managed periodic runs read a token from there); that is independent of the interactive flow.
+
+## Implications for Per-Account Isolation
+
+Setting `CLAUDE_CONFIG_DIR` is sufficient to isolate accounts. Claude Code's native Keychain lookup uses the hashed service name derived from that config dir. No env-var token injection is needed.
+
+The `~/bin/claude` wrapper accordingly does only one thing for auth: it sets `CLAUDE_CONFIG_DIR` based on the `.account` marker and exec's the real binary. An earlier draft (PRs #93 and #94) injected `CLAUDE_CODE_OAUTH_TOKEN` from a per-profile Keychain entry (`claude-code-oauth-<profile>`); PR #95 ripped that out as dead code after discovering the native isolation works.
+
+## Bootstrap Idiom
+
+To seed credentials for a new profile dir (e.g., `~/.claude-ryllc/`):
+
+1. `cd` into a directory whose `.account` marker (or ambient profile) resolves to that profile.
+2. Run `claude`. Since the hashed Keychain entry doesn't exist yet, Claude Code triggers a browser OAuth flow.
+3. Sign in as the Anthropic account that should own this profile.
+4. Claude Code writes the credential to `Claude Code-credentials-<hash>` for the active `CLAUDE_CONFIG_DIR`. Exit the session — the bootstrap is done.
+
+No `security add-generic-password` step is needed.
+
+## Debugging Cheat Sheet
+
+| Question | Command |
+|---|---|
+| Which Claude credentials are in Keychain? | `security dump-keychain 2>/dev/null \| awk '/^keychain:/{kc=$0} /"svce"<blob>/{print}' \| grep -i 'claude\|anthropic' \| sort -u` |
+| Which credential file is on disk (fallback path)? | `ls -la "$CLAUDE_CONFIG_DIR/.oauth-token" 2>&1` |
+| What is the wrapper resolving to right now? | `claude` runs the wrapper at `~/bin/claude`; check `which -a claude` to confirm wrapper ordering, then read `~/bin/claude` to trace logic. |
+
+## Related Files
+
+- `~/Eudaimonia/Craft/Development/personal/homebase/bin/claude` — the wrapper
+- `~/Eudaimonia/Craft/Development/personal/homebase/bin/claude-profiles-init.sh` — profile dir bootstrap (no auth)
+- `~/Eudaimonia/Craft/Development/personal/homebase/setup.sh` — Claude Code phase that calls the bootstrap
+- `~/Eudaimonia/Craft/Development/personal/homebase/bin/run-mise` — headless launchd-managed Claude (separate auth path via `claude-code-oauth` service)
+
+## When This Note Goes Stale
+
+If Anthropic changes Claude Code's credential storage scheme again (e.g., moves to a different Keychain service name, or to a file under `~/.claude/`), update this note. Quickest signal: a fresh `claude` login on a fresh profile dir creates a Keychain entry not matching `Claude Code-credentials-<hash>`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,20 @@ OAuth `client_secret.json` files for gws sync across machines via GCP Secret Man
 
 Applies to: `.claude/settings.json` permissions and marketplace paths, skill SKILL.md files, shell rc files, any markdown that references a path. If a tool reads the value literally and does not expand `$HOME` or `~`, surface that as a setup.sh templating gap rather than working around it with a hard-coded username.
 
+## setup.sh Phase Conventions
+
+`setup.sh` is split into phases like `setup_prerequisites`, `install_brew_packages`, `deploy_homebase`, and `setup_auth`. The `setup_auth` phase short circuits early when `INTERACTIVE != true`, because OAuth flows and `read -rp` prompts require a TTY.
+
+**Bootstrap operations must NOT live inside `setup_auth`.** File moves, directory creation, marker file seeding, and other no-TTY-required scaffolding belong in their own phases that run regardless of interactivity. If they sit inside `setup_auth`, a non-interactive run (Claude Code background session, headless launchd, CI) will silently skip them along with the auth prompts.
+
+**Pattern to follow when adding new tooling to setup.sh:**
+
+- Split the work into a bootstrap step (file ops, idempotent, runs always) and an auth step (interactive prompts, runs only when `INTERACTIVE == true`).
+- The bootstrap step goes in its own phase function (e.g., `bootstrap_claude_profiles`) or inside an existing non-auth phase.
+- The auth step goes inside `setup_auth`, gated by the existing `INTERACTIVE` check.
+
+**Why it matters:** Codified 2026-05-19. The Claude Code profile-dir bootstrap initially shipped inside `setup_auth`, which meant a non-interactive `./setup.sh` invocation (the way it runs from inside a Claude Code background session) skipped the entire block. The profile dirs never got created until manually invoking `bin/claude-profiles-init.sh` by hand.
+
 ## Development Workflow
 
 1. Edit files in this repository


### PR DESCRIPTION
## Summary

Two learnings from today's multi profile migration, captured for next time:

1. **`.claude/references/claude-code-auth.md`** (new): Claude Code stores OAuth credentials per `CLAUDE_CONFIG_DIR` in a Keychain entry named `Claude Code-credentials-<hash>`, not the older `claude-code-oauth` service. Setting `CLAUDE_CONFIG_DIR` is enough to isolate accounts; no env-var token injection needed. Captures the discovery that led to PR #95, the bootstrap idiom, and a debugging cheat sheet.

2. **`CLAUDE.md` setup.sh Phase Conventions**: bootstrap operations (file moves, dir creation, marker seeding) must not live inside `setup_auth`, which short circuits in non-interactive sessions. Today's Claude Code profile-dir bootstrap initially sat inside `setup_auth` and silently skipped on every non-TTY invocation. The new section codifies the split-bootstrap-from-auth pattern.

Documentation only; no behavior changes.

## Test plan

- [x] No code changes — nothing to syntax check
- [ ] Future agent loading `~/.claude/references/claude-code-auth.md` gets the right model for Claude Code's keychain isolation
- [ ] Future homebase contributor adding tooling to `setup.sh` sees the phase conventions section before nesting bootstrap inside `setup_auth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)