### PR TITLE
sdlc:plan v2.2.5 — auto hand off to design on readiness

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
     {
       "name": "sdlc",
       "source": "./plugins/sdlc",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "license": "MIT",
       "description": "Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.",
       "homepage": "https://github.com/mattforni/homebase",

--- a/plugins/sdlc/plugin.json
+++ b/plugins/sdlc/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/plugins/sdlc/skills/plan/SKILL.md
+++ b/plugins/sdlc/skills/plan/SKILL.md
@@ -89,22 +89,15 @@ linear issue update ISSUE_ID -d "UPDATED_DESCRIPTION"
 
 Do not wait until the end to update. Update after each meaningful exchange so the ticket stays current. The user should be able to read the ticket at any point and see an accurate picture of where planning stands.
 
-## Step 5: Confirm Readiness
+## Step 5: Confirm Readiness and Hand Off to Design
 
 When all sections are filled in and open questions are resolved (or explicitly deferred), summarize the final state of the ticket to the user.
 
 Use AskUserQuestion to confirm:
 
-- **Ready for design** — The ticket is in good shape. Proceed to `/sdlc:design ISSUE_ID`.
-- **Keep refining** — There are still gaps to address. Continue the dialogue.
+- **Ready for design** — Planning is in good shape. Move into design now.
+- **Keep refining** — There are still gaps to address. Stay in dialogue.
 
-## Output
+**On "Ready for design":** Acknowledge in one sentence that planning is complete, then **immediately invoke the `sdlc:design` skill** via the Skill tool with the issue ID as the argument. Do not narrate "Next step: /sdlc:design" and stop — the user has already authorized the transition by selecting "Ready for design," and asking them to type the next command is redundant friction.
 
-When the user confirms readiness:
-
-```text
-Planning complete for ISSUE_ID.
-Ticket updated with overview, requirements, options, and recommendation.
-
-Next step: /sdlc:design ISSUE_ID
-```
+**On "Keep refining":** Return to Step 3 and continue the dialogue.

--- a/plugins/sdlc/skills/plan/SKILL.md
+++ b/plugins/sdlc/skills/plan/SKILL.md
@@ -9,6 +9,7 @@ allowed-tools:
   - Grep
   - Glob
   - AskUserQuestion
+  - Skill
 ---
 
 # Plan
@@ -89,7 +90,7 @@ linear issue update ISSUE_ID -d "UPDATED_DESCRIPTION"
 
 Do not wait until the end to update. Update after each meaningful exchange so the ticket stays current. The user should be able to read the ticket at any point and see an accurate picture of where planning stands.
 
-## Step 5: Confirm Readiness and Hand Off to Design
+## Step 5: Confirm Readiness and Hand off to Design
 
 When all sections are filled in and open questions are resolved (or explicitly deferred), summarize the final state of the ticket to the user.
 

--- a/plugins/sdlc/skills/plan/SKILL.md
+++ b/plugins/sdlc/skills/plan/SKILL.md
@@ -99,6 +99,6 @@ Use AskUserQuestion to confirm:
 - **Ready for design** — Planning is in good shape. Move into design now.
 - **Keep refining** — There are still gaps to address. Stay in dialogue.
 
-**On "Ready for design":** Acknowledge in one sentence that planning is complete, then **immediately invoke the `sdlc:design` skill** via the Skill tool with the issue ID as the argument. Do not narrate "Next step: /sdlc:design" and stop — the user has already authorized the transition by selecting "Ready for design," and asking them to type the next command is redundant friction.
+**On "Ready for design":** Acknowledge in one sentence that planning is complete, then **immediately invoke the `sdlc:design` skill** via the Skill tool with `ISSUE_ID` as the argument. Do not narrate "Next step: /sdlc:design" and stop — the user has already authorized the transition by selecting "Ready for design," and asking them to type the next command is redundant friction.
 
 **On "Keep refining":** Return to Step 3 and continue the dialogue.


### PR DESCRIPTION
## Summary

- Step 5 of `sdlc:plan` used to end with "Next step: /sdlc:design ISSUE_ID" and stop. The user had already authorized the transition by selecting "Ready for design" in the AskUserQuestion prompt; making them retype the next slash command was redundant friction.
- Now the plan skill immediately invokes the `sdlc:design` skill via the Skill tool with the issue ID when readiness is confirmed. The "Keep refining" branch is unchanged (returns to Step 3).
- Patch bump 2.2.4 → 2.2.5 in `plugins/sdlc/plugin.json` and the sdlc entry in `.claude-plugin/marketplace.json` per the plugin versioning rule.

## Test plan

- [ ] In a fresh session, run `/sdlc:plan <issue-id>` end to end and confirm that selecting "Ready for design" auto-invokes `sdlc:design` without a manual `/sdlc:design` re-invocation
- [ ] Confirm "Keep refining" still loops back into dialogue
- [ ] Confirm version 2.2.5 surfaces in the loaded skill header on next session

🤖 Generated with [Claude Code](https://claude.com/claude-code)