### PR TITLE
Register atelic MCP at user scope + codify two assist triage rules

### DIFF
--- a/.claude/local-skills/plugins/assist/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/learned-rules.md
@@ -12,7 +12,7 @@ Rules added from triage corrections. Read on every invocation. These override de
 - `UHC@benefits.unitedhealthcare.com` with "UHC Rewards" subject -> 🍏 Constitution/🏥 Benefits + GREEN_STAR. Action: enroll in rewards program ($1000 potential). Keep in inbox until enrolled.
 - `prime@amazon.com` membership change confirmations (renewal, cancellation) -> 📑 Admin/🛒 Purchases. Mark read, archive.
 - `support@email.mill.com` (Mill food waste device) -> 📑 Admin/🛒 Purchases. Mark read, archive.
-- `*@coestatematters.com` (Colorado Estate Matters, estate planning attorney) -> 🍏 Constitution/💰 Financial/📜 Trust (NOT Financial parent). Appointment reminders and confirmations get archived; only surface if there is an action item or document to review.
+- `*@coestatematters.com` (Colorado Estate Matters, estate planning attorney) -> 🍏 Constitution/💰 Financial/📜 Trust (NOT Financial parent). Route to Phase 4 for manual review; auto-archive patterns will codify once enough subject lines are observed.
 
 ## Topic Rules
 

--- a/.claude/local-skills/plugins/assist/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/learned-rules.md
@@ -12,6 +12,11 @@ Rules added from triage corrections. Read on every invocation. These override de
 - `UHC@benefits.unitedhealthcare.com` with "UHC Rewards" subject -> 🍏 Constitution/🏥 Benefits + GREEN_STAR. Action: enroll in rewards program ($1000 potential). Keep in inbox until enrolled.
 - `prime@amazon.com` membership change confirmations (renewal, cancellation) -> 📑 Admin/🛒 Purchases. Mark read, archive.
 - `support@email.mill.com` (Mill food waste device) -> 📑 Admin/🛒 Purchases. Mark read, archive.
+- `*@coestatematters.com` (Colorado Estate Matters, estate planning attorney) -> 🍏 Constitution/💰 Financial/📜 Trust (NOT Financial parent). Appointment reminders and confirmations get archived; only surface if there is an action item or document to review.
+
+## Topic Rules
+
+- **Home buying (purchase, mortgage, title, closing) is NOT Home Improvement.** Home purchase correspondence goes under 🍏 Constitution/💰 Financial + 🤝 Community/🏙️ Cities/🌇 Denver. The 🛠️ Craft/🏡 Home Improvement label is for actual improvement work (renovations, fixtures, tools), not the transaction of buying the home. Senders this applies to: NEO Home Loans, Trelora (greg@trelora.com), CTM eContracts, Land Title Guarantee Company, seller (Matt Bigelow), inspection vendors, HO6 insurance for the unit.
 
 ## Subject Rules
 

--- a/setup.sh
+++ b/setup.sh
@@ -502,6 +502,14 @@ install_mcp_servers() {
     local transport="${rest%%|*}"
     local target_and_extra="${rest#*|}"
 
+    # Skip atelic when its bearer token is missing. Registering with an empty
+    # token bakes a broken entry that the `Already registered` short circuit
+    # below would silently preserve on future runs.
+    if [[ "$name" == "atelic" && -z "${ATELIC_API_TOKEN:-}" ]]; then
+      warn "Skipping atelic: ATELIC_API_TOKEN not set in environment"
+      continue
+    fi
+
     if claude mcp get "$name" &>/dev/null; then
       info "Already registered: $name"
       continue

--- a/setup.sh
+++ b/setup.sh
@@ -482,20 +482,25 @@ install_mcp_servers() {
   fi
 
   # Desired MCP servers at user scope (persist across project entries).
-  # Format: name|transport|command_and_args
+  # Format depends on transport:
+  #   stdio: name|stdio|command_and_args
+  #   http:  name|http|url|optional_header  (single header, eg. "Authorization: Bearer $TOKEN")
   # First time auth on a new machine: each MCP may require its own credentials
   # (e.g., strava needs STRAVA_CLIENT_ID/SECRET in ~/.env.local before running
-  # mcp__strava__connect-strava from Claude). Subsequent runs are idempotent.
+  # mcp__strava__connect-strava from Claude; atelic needs ATELIC_API_TOKEN exported
+  # in the shell before this script runs so the Bearer header registers populated).
+  # Subsequent runs are idempotent.
   local desired=(
     "strava|stdio|npx -y @r-huijts/strava-mcp-server"
     "playwright|stdio|npx -y @playwright/mcp@latest"
+    "atelic|http|https://api.atelic.me/mcp|Authorization: Bearer ${ATELIC_API_TOKEN:-}"
   )
 
   for entry in "${desired[@]}"; do
     local name="${entry%%|*}"
     local rest="${entry#*|}"
     local transport="${rest%%|*}"
-    local cmd="${rest#*|}"
+    local target_and_extra="${rest#*|}"
 
     if claude mcp get "$name" &>/dev/null; then
       info "Already registered: $name"
@@ -503,8 +508,30 @@ install_mcp_servers() {
     fi
 
     info "Registering MCP server: $name"
-    # shellcheck disable=SC2086
-    if claude mcp add --scope user --transport "$transport" "$name" -- $cmd; then
+    local add_status=1
+    if [[ "$transport" == "http" ]]; then
+      local url="${target_and_extra%%|*}"
+      local header=""
+      if [[ "$target_and_extra" == *"|"* ]]; then
+        header="${target_and_extra#*|}"
+      fi
+
+      # `--header` is a varargs flag in claude mcp add; positionals must precede
+      # it or they get consumed as additional header values.
+      if [[ -n "$header" ]]; then
+        claude mcp add "$name" "$url" --scope user --transport http --header "$header"
+        add_status=$?
+      else
+        claude mcp add "$name" "$url" --scope user --transport http
+        add_status=$?
+      fi
+    else
+      # shellcheck disable=SC2086
+      claude mcp add --scope user --transport "$transport" "$name" -- $target_and_extra
+      add_status=$?
+    fi
+
+    if [[ $add_status -eq 0 ]]; then
       SUMMARY+=("MCP server registered: $name")
     else
       warn "Failed to register MCP server: $name"


### PR DESCRIPTION
## Summary

- Adds the atelic Rails-hosted MCP (`https://api.atelic.me/mcp`) to `install_mcp_servers` alongside strava and playwright. Extends the desired array format to support HTTP transport with an optional Authorization header, pulling `ATELIC_API_TOKEN` from the shell at registration time.
- Fixes a CLI ordering gotcha caught during smoke testing: `claude mcp add --header` is variadic, so positionals must precede option flags or they get consumed as additional header values. Both http branches now pass name/url before flags.
- Codifies two assist skill triage rules surfaced during the 3033 Blake purchase flow: a sender rule for `*@coestatematters.com` and a topic rule clarifying that home buying correspondence is Financial / Cities / Denver, not Craft / Home Improvement.

## Test plan

- [x] Smoke tested `claude mcp add atelic ... --header "Authorization: Bearer ..."` form (works after positional fix)
- [x] `claude mcp list` shows `atelic: https://api.atelic.me/mcp (HTTP) - ✓ Connected`
- [x] End-to-end MCP smoke against deployed api: tools/list returns three tools, add_shopping_item creates a row with created_via:"mcp", check_off_shopping_item flips checked_off
- [ ] Optional: re-run `./setup.sh` on this machine to confirm idempotent (already-registered short circuit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)