### PR TITLE
sdlc:groom: codify 4 learnings from GROW Cycle 5 (v2.2.8)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
     {
       "name": "sdlc",
       "source": "./plugins/sdlc",
-      "version": "2.2.7",
+      "version": "2.2.8",
       "license": "MIT",
       "description": "Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.",
       "homepage": "https://github.com/mattforni/homebase",

--- a/plugins/sdlc/plugin.json
+++ b/plugins/sdlc/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/plugins/sdlc/skills/groom/SKILL.md
+++ b/plugins/sdlc/skills/groom/SKILL.md
@@ -3,6 +3,7 @@ name: sdlc:groom
 description: Groom a Linear team's queue. Two modes — cycle grooming (when the team runs Linear cycles, trim the active cycle to a realistic slate) and backlog grooming (when the team has a backlog without active cycles, triage by priority, staleness, and intent). Use whenever the user mentions Linear grooming, triaging issues, pruning a backlog, sprint grooming, "the cycle is overstuffed", "let's clean up the queue", "groom the backlog", or wants to make decisions across many issues at once. Use the Linear CLI when available; fall back to the Linear MCP otherwise.
 allowed-tools:
   - Bash(linear *)
+  - Bash(git *)
   - mcp__claude_ai_Linear__list_issues
   - mcp__claude_ai_Linear__get_issue
   - mcp__claude_ai_Linear__save_issue

--- a/plugins/sdlc/skills/groom/learned-rules.md
+++ b/plugins/sdlc/skills/groom/learned-rules.md
@@ -26,6 +26,38 @@ The Linear MCP fuzzy-matches state names. Passing `state: "Canceled"` can land t
 
 **How to apply:** When canceling via MCP, either (a) accept the Duplicate-vs-Canceled imprecision since both hide the issue from active views, (b) pass the explicit Canceled state UUID, or (c) use the CLI: `linear issue update ATE-NNN --state Canceled`.
 
+### Default scope to assignee == requesting user, not the whole cycle.
+
+The skill's scope step should default to filtering cycle issues where `assignee.name == user` unless the user explicitly says "groom the whole cycle." Otherwise you partition other people's tickets, confuse the capacity math, and force the user to redirect mid-walk.
+
+**Why:** GROW Cycle 5 groom 2026-06-01. Initial dump showed 68 cycle tickets; Forni owned 42. Capacity math and the first partition table used the wrong denominator. Forni redirected on a Rich owned admin task with "Is this my ticket? Maybe we need to look at my tickets, please?"
+
+**How to apply:** At scope, query the cycle, then immediately filter to `assignee.name == user` for the working set. Surface the full cycle count plus the per assignee distribution so the user can opt into a broader scope if they want. Default working set is always "your tickets."
+
+### Linear `priority: 0` is "No priority," not Urgent. Always render `priorityLabel`.
+
+Linear priority integers: 1=Urgent, 2=High, 3=Normal, 4=Low, **0=No priority** (untriaged). Rendering the integer as `P0` makes untriaged tickets read as the most urgent thing in the cycle.
+
+**Why:** GROW Cycle 5 groom 2026-06-01. Initial table rendered GROW-292 and GROW-295 as "P0" because of `priority: 0`. Both were untriaged. Wrong framing landed in a recommendation slate before being caught and re-rendered.
+
+**How to apply:** In every table, sort key, and rationale string, use `priorityLabel` (the string Linear computes from the integer), never the integer. When sorting, treat `priority == 0` as Low for scheduling order, not as the top of the list.
+
+### Verify "shipped but Todo" against the team's main repo before partitioning.
+
+For each cycle groom, grep the team's primary code repo for commits matching the ticket key pattern since cycle start. Any ticket key that appears in a merged commit but still sits in Todo is state drift: probably Done in reality, never moved in Linear.
+
+**Why:** GROW Cycle 5 groom 2026-06-01. Three tickets (GROW-280, GROW-289, GROW-292) shipped in PRs #324/#325/#326 but stayed Todo. Without the repo check they would have been classified as overstuffed cycle work. Only caught because Forni said "I think it's wrapped" on GROW-292, prompting the spot check that surfaced the other two.
+
+**How to apply:** During scope, run `git -C <main-repo> log --since="<cycle-start>" --grep="<TEAM>-" -i --oneline`. Cross reference each ticket key against Linear states. For shipped-but-Todo, surface as a batch: "verified shipped in PR #N — mark Done?"
+
+### Re-query the cycle at the end of partitioning to catch newly-added tickets.
+
+Long groom sessions take an hour or more. New tickets land mid session. The final verification should re-pull the cycle and diff against the original working set so nothing slips through unclassified.
+
+**Why:** GROW Cycle 5 groom 2026-06-01. GROW-296 (Aircall AICSR Spec) was created during the AICSR meeting Forni had cued up; landed in Cycle 5 between the initial JSON dump and the final partition. Only surfaced in the closing verification pass.
+
+**How to apply:** After applying all approved changes, re-run the cycle query and diff `current_set - original_working_set`. Surface any newly-added tickets to the user as a final batch decision before declaring the groom complete.
+
 ### A team's deferral label is sacred. Do not include it in the stale sweep.
 
 The naive backlog stale-sweep heuristic (no priority + no recent activity + no assignee + no project) misfires on any team that uses a label like `👋 Later` to mean "intentionally deferred, save the intent." Items carrying that label are working as designed; bulk canceling them erases real intent.

--- a/plugins/sdlc/skills/groom/learned-rules.md
+++ b/plugins/sdlc/skills/groom/learned-rules.md
@@ -26,7 +26,7 @@ The Linear MCP fuzzy-matches state names. Passing `state: "Canceled"` can land t
 
 **How to apply:** When canceling via MCP, either (a) accept the Duplicate-vs-Canceled imprecision since both hide the issue from active views, (b) pass the explicit Canceled state UUID, or (c) use the CLI: `linear issue update ATE-NNN --state Canceled`.
 
-### Default scope to assignee == requesting user, not the whole cycle.
+### Default Scope to Assignee == Requesting User, Not the Whole Cycle.
 
 The skill's scope step should default to filtering cycle issues where `assignee.name == user` unless the user explicitly says "groom the whole cycle." Otherwise you partition other people's tickets, confuse the capacity math, and force the user to redirect mid-walk.
 
@@ -34,7 +34,7 @@ The skill's scope step should default to filtering cycle issues where `assignee.
 
 **How to apply:** At scope, query the cycle, then immediately filter to `assignee.name == user` for the working set. Surface the full cycle count plus the per assignee distribution so the user can opt into a broader scope if they want. Default working set is always "your tickets."
 
-### Linear `priority: 0` is "No priority," not Urgent. Always render `priorityLabel`.
+### Linear `priority: 0` Is "No Priority," Not Urgent. Always Render `priorityLabel`.
 
 Linear priority integers: 1=Urgent, 2=High, 3=Normal, 4=Low, **0=No priority** (untriaged). Rendering the integer as `P0` makes untriaged tickets read as the most urgent thing in the cycle.
 
@@ -42,7 +42,7 @@ Linear priority integers: 1=Urgent, 2=High, 3=Normal, 4=Low, **0=No priority** (
 
 **How to apply:** In every table, sort key, and rationale string, use `priorityLabel` (the string Linear computes from the integer), never the integer. When sorting, treat `priority == 0` as Low for scheduling order, not as the top of the list.
 
-### Verify "shipped but Todo" against the team's main repo before partitioning.
+### Verify "Shipped but Todo" Against the Team's Main Repo Before Partitioning.
 
 For each cycle groom, grep the team's primary code repo for commits matching the ticket key pattern since cycle start. Any ticket key that appears in a merged commit but still sits in Todo is state drift: probably Done in reality, never moved in Linear.
 
@@ -50,7 +50,7 @@ For each cycle groom, grep the team's primary code repo for commits matching the
 
 **How to apply:** During scope, run `git -C <main-repo> log --since="<cycle-start>" --grep="<TEAM>-" -i --oneline`. Cross reference each ticket key against Linear states. For shipped-but-Todo, surface as a batch: "verified shipped in PR #N — mark Done?"
 
-### Re-query the cycle at the end of partitioning to catch newly-added tickets.
+### Re-query the Cycle at the End of Partitioning to Catch Newly Added Tickets.
 
 Long groom sessions take an hour or more. New tickets land mid session. The final verification should re-pull the cycle and diff against the original working set so nothing slips through unclassified.
 

--- a/plugins/sdlc/skills/groom/learned-rules.md
+++ b/plugins/sdlc/skills/groom/learned-rules.md
@@ -48,7 +48,7 @@ For each cycle groom, grep the team's primary code repo for commits matching the
 
 **Why:** GROW Cycle 5 groom 2026-06-01. Three tickets (GROW-280, GROW-289, GROW-292) shipped in PRs #324/#325/#326 but stayed Todo. Without the repo check they would have been classified as overstuffed cycle work. Only caught because Forni said "I think it's wrapped" on GROW-292, prompting the spot check that surfaced the other two.
 
-**How to apply:** During scope, run `git -C <main-repo> log --since="<cycle-start>" --grep="<TEAM>-" -i --oneline`. Cross reference each ticket key against Linear states. For shipped-but-Todo, surface as a batch: "verified shipped in PR #N — mark Done?"
+**How to apply:** During scope, run `git -C <main-repo> log origin/main --since="<cycle-start>" --grep="<TEAM>-" -i --oneline` (adjust `origin/main` to the team's default branch; run `git -C <main-repo> fetch origin` first so the ref is current). Cross reference each ticket key against Linear states. For shipped-but-Todo, surface as a batch: "verified shipped in PR #N — mark Done?" Querying `origin/main` rather than `HEAD` avoids false positives from unmerged commits on a local feature branch.
 
 ### Re-query the Cycle at the End of Partitioning to Catch Newly Added Tickets.
 


### PR DESCRIPTION
## Summary

Four learned rules from the 2026-06-01 GROW Cycle 5 groom session. All four surfaced as real corrections during the run, not theoretical.

- **Default scope to assignee == requesting user.** Initial dump partitioned all 68 cycle tickets when only 42 were Forni's. The skill should filter to the requesting user by default, surface the per-assignee distribution, and let the user opt into broader scope.
- **Linear `priority: 0` is "No priority," not Urgent.** The integer rendered as "P0" anchored a wrong Urgent framing on two tickets before being caught. Always render `priorityLabel`.
- **Verify "shipped but Todo" via the team's main repo.** Three tickets (GROW-280, 289, 292) shipped in PRs but stayed Todo. Repo log grep would have caught this automatically.
- **Re-query the cycle at end of partitioning.** GROW-296 landed mid-session and was only surfaced in a closing verification pass.

Plugin bumped from 2.2.7 to 2.2.8 (patch).

## Test plan

- [ ] CodeRabbit review pass
- [ ] Next groom run validates the new rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)