### PR TITLE
Migrate Ruby toolchain from RVM to rbenv; add bun

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -1,4 +1,4 @@
 . $HOME/.bashrc
 
-# Load RVM into a shell session *as a function*
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm"
+# rbenv: shims + auto-switch Ruby from .ruby-version files
+command -v rbenv &>/dev/null && eval "$(rbenv init - bash)"

--- a/.bashrc
+++ b/.bashrc
@@ -114,7 +114,7 @@ if [ -f /etc/bash_completion ] && ! shopt -oq posix; then
 fi
 
 
-# Add RVM to PATH for scripting. Make sure this is the last PATH variable change.
+# Add Homebrew keg-only binaries to PATH.
 directories=("/usr/local/opt/postgresql@15/bin")
 for directory in "${directories[@]}"; do
   if [[ -s "${directory}" ]] && [[ ":$PATH:" != *":${directory}:"* ]]; then
@@ -123,5 +123,5 @@ for directory in "${directories[@]}"; do
 done
 
 
-# Add RVM to PATH for scripting. Make sure this is the last PATH variable change.
-export PATH="$PATH:$HOME/.rvm/bin"
+# rbenv: shims + auto-switch Ruby from .ruby-version files
+command -v rbenv &>/dev/null && eval "$(rbenv init - bash)"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,17 +30,13 @@ This is "GC" (Global Claude): the user's private global instructions for every p
   - Absolute paths for file operations: `grep X /abs/path/foo`, `wc -l /abs/path/*.md`
   - Pass paths explicitly to scripts and tools: `python3 /abs/path/script.py`
 - Compound commands with `cd` defeat the existing allowlist and slow everything down. The goal is to keep Bash calls to a single command that matches a single allowlist entry, so approvals stay auto.
-- **Wrapper script escape hatch when `cd` is genuinely required.** Some commands need the project root as cwd to function (RVM `.ruby-version` auto-switch, bundler reading `Gemfile` from cwd, Rails config paths resolved relative to project root, Vite/Bun resolving `package.json`). Setting `BUNDLE_GEMFILE` alone is insufficient — Rails resolves `Rails.root` from cwd, RVM hooks fire on `chpwd` only, etc. The escape hatch: write a small shell script that does the `cd` internally, then invoke the script from the Bash tool. The `cd` lives inside the script, not in the Bash call. Example for atelic-api:
+- **Wrapper script escape hatch when `cd` is genuinely required.** Some commands need the project root as cwd to function (rbenv resolving the Ruby from the nearest `.ruby-version`, bundler reading `Gemfile` from cwd, Rails config paths resolved relative to project root, Vite/Bun resolving `package.json`). Setting `BUNDLE_GEMFILE` alone is insufficient — Rails resolves `Rails.root` from cwd, rbenv picks the version from the cwd's `.ruby-version`, etc. The escape hatch: write a small shell script that does the `cd` internally, then invoke the script from the Bash tool. The `cd` lives inside the script, not in the Bash call. Example for atelic-api:
   ```bash
   #!/usr/bin/env bash
   set -euo pipefail
   cd "$HOME/Eudaimonia/Craft/atelic/api"
-  if [[ -s "$HOME/.rvm/scripts/rvm" ]]; then
-    set +u
-    source "$HOME/.rvm/scripts/rvm"
-    rvm use "$(cat .ruby-version)" --silent
-    set -u
-  fi
+  # rbenv shims read the project's .ruby-version automatically once cd'd in.
+  command -v rbenv >/dev/null && eval "$(rbenv init - bash)"
   exec "$@"
   ```
   Then call `bash /tmp/in-api.sh bundle exec rspec ...`. **Durable form:** project-local `bin/in-repo` scripts checked into the repo (preferred for long-lived projects). **Ephemeral form:** `/tmp/in-*.sh` written per session as the fallback when no project-local script exists yet.

--- a/.profile
+++ b/.profile
@@ -1,6 +1,6 @@
 brew services start postgresql@14
 brew services start redis
 
-# Add RVM to PATH for scripting. Make sure this is the last PATH variable change.
-export PATH="$PATH:$HOME/.rvm/bin"
+# rbenv: put shims on PATH so ruby/bundle resolve the .ruby-version (POSIX-safe).
+[ -d "$HOME/.rbenv/shims" ] && export PATH="$HOME/.rbenv/shims:$PATH"
 

--- a/.zshrc
+++ b/.zshrc
@@ -36,22 +36,13 @@ done
 export EDITOR=vim
 eval "$(fzf --zsh)"
 
-# Load RVM into a shell session *as a function*
-[[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm"
+# rbenv: shims + auto-switch Ruby from .ruby-version files
+command -v rbenv &>/dev/null && eval "$(rbenv init - zsh)"
 
-# Add RVM to PATH for scripting
-export PATH="$PATH:$HOME/.rvm/bin"
-
-# Enable RVM to automatically use Ruby version from .ruby-version files
-cd . # Trigger RVM auto-switch on shell start
 export PATH="$HOME/.local/bin:$PATH"
 
-# bun completions
-[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
-
-# bun
-export BUN_INSTALL="$HOME/.bun"
-export PATH="$BUN_INSTALL/bin:$PATH"
+# bun is installed via Homebrew (see brew/Brewfile), so it lives on
+# /opt/homebrew/bin and needs no extra PATH or completion wiring here.
 
 # PATH precedence finalization. Place LAST so it wins over every earlier
 # prepend in this file. `typeset -U path` keeps PATH unique on each

--- a/brew/Brewfile
+++ b/brew/Brewfile
@@ -27,9 +27,11 @@ brew "cmake"
 brew "make"
 brew "maven"
 brew "python@3.12"
+brew "rbenv"
 brew "ruby-build"
 
 # Runtime & package managers
+brew "bun"
 brew "fnm"
 brew "pnpm"
 

--- a/setup.sh
+++ b/setup.sh
@@ -179,6 +179,41 @@ setup_node() {
   fi
 }
 
+# Default Ruby. rbenv reads per-project .ruby-version files, so this is just the
+# global fallback; bump it when the projects you work in move forward.
+RUBY_DEFAULT_VERSION="3.4.7"
+
+setup_ruby() {
+  header "Ruby setup"
+
+  # RVM has been replaced by rbenv. Remove any lingering RVM install so its
+  # shims and PATH entries can't shadow rbenv. Idempotent: a no-op once gone.
+  if [[ -d "$HOME/.rvm" ]]; then
+    info "Removing legacy RVM install (~/.rvm)..."
+    rm -rf "$HOME/.rvm"
+    SUMMARY+=("Removed legacy RVM")
+  fi
+  rm -f "$HOME/.rvmrc"
+
+  if ! command -v rbenv &>/dev/null; then
+    warn "rbenv not found, skipping Ruby setup"
+    return 0
+  fi
+
+  eval "$(rbenv init - bash)"
+
+  if rbenv versions --bare | grep -qx "$RUBY_DEFAULT_VERSION" && [[ "$FORCE" != true ]]; then
+    info "Ruby $RUBY_DEFAULT_VERSION already installed"
+  else
+    info "Installing Ruby $RUBY_DEFAULT_VERSION via rbenv (compiles from source, slow)..."
+    rbenv install --skip-existing "$RUBY_DEFAULT_VERSION" || return 1
+    SUMMARY+=("Ruby $RUBY_DEFAULT_VERSION installed via rbenv")
+  fi
+
+  rbenv global "$RUBY_DEFAULT_VERSION" || return 1
+  info "Ruby $(rbenv exec ruby --version 2>/dev/null | awk '{print $2}') is the global default"
+}
+
 install_npm_globals() {
   header "npm globals"
 
@@ -758,6 +793,7 @@ print_summary() {
 run_phase setup_prerequisites
 run_phase install_brew_packages
 run_phase setup_node
+run_phase setup_ruby
 run_phase install_npm_globals
 run_phase deploy_homebase
 run_phase link_tracked_configs

--- a/setup.sh
+++ b/setup.sh
@@ -206,12 +206,15 @@ setup_ruby() {
     info "Ruby $RUBY_DEFAULT_VERSION already installed"
   else
     info "Installing Ruby $RUBY_DEFAULT_VERSION via rbenv (compiles from source, slow)..."
-    rbenv install --skip-existing "$RUBY_DEFAULT_VERSION" || return 1
+    # --force recompiles even if present, so -f genuinely reinstalls (mirrors setup_node).
+    local install_opt="--skip-existing"
+    [[ "$FORCE" == true ]] && install_opt="--force"
+    rbenv install "$install_opt" "$RUBY_DEFAULT_VERSION" || return 1
     SUMMARY+=("Ruby $RUBY_DEFAULT_VERSION installed via rbenv")
   fi
 
   rbenv global "$RUBY_DEFAULT_VERSION" || return 1
-  info "Ruby $(rbenv exec ruby --version 2>/dev/null | awk '{print $2}') is the global default"
+  info "Ruby $(rbenv exec ruby --version | awk '{print $2}') is the global default"
 }
 
 install_npm_globals() {


### PR DESCRIPTION
The runtime config was half-configured and self-contradictory: `.zshrc`/`.bashrc`/`.profile`/`.bash_profile` sourced **RVM**, but the Brewfile shipped `ruby-build` (rbenv's backend, not RVM's), **bun** was expected at `$HOME/.bun` but never installed, and RVM wasn't actually present anywhere on the machine. This standardizes on **rbenv + brew** and removes RVM for good, so a `mise` brings the toolchains along and keeps RVM gone.

## Changes

- **`brew/Brewfile`** — add `bun` and `rbenv` (pairs with the existing `ruby-build`). `vips` is already on main.
- **`setup.sh`** — add a `setup_ruby` phase that first removes any legacy `~/.rvm` / `~/.rvmrc`, then installs the default Ruby (`3.4.7`) via rbenv and sets it global. Idempotent; runs as a normal non-auth phase so non-interactive runs include it.
- **`.zshrc` / `.bashrc` / `.bash_profile`** — replace the RVM source/PATH lines with `rbenv init` (reads `.ruby-version` automatically); drop the dead `$HOME/.bun` wiring now that bun comes from brew.
- **`.profile`** — replace the RVM PATH with rbenv shims on PATH (POSIX-safe).
- **`.claude/CLAUDE.md` (GC)** — update the wrapper-script escape-hatch example to use rbenv instead of RVM.

## Verification

- `bash -n setup.sh`, `zsh -n .zshrc`, `bash -n` on the bash rc files → all syntax OK
- `jq empty .claude/settings.json` → valid
- rbenv + Ruby 3.4.7 installed locally; ran the full atelic-api suite (454 examples, 0 failures) and atelic-app (319 tests + build) against it
- `setup_ruby` idempotency check (`rbenv versions --bare | grep -qx 3.4.7`) confirmed
- The live `$HOME` shell rc files were updated in place; `grep rvm` across them is now clean
- RVM is not installed on the machine (no `~/.rvm`, binary, `/etc/profile.d/rvm.sh`, group, or gem), so there was nothing to uninstall — the setup.sh removal step is the belt-and-suspenders guard

## One manual follow-up

`.claude/settings.json` still has a `Bash(rvm:*)` allowlist entry (harmless — points at a command that no longer exists). Claude Code's permissions classifier blocks the agent from editing that file, so please remove that one line by hand.

No plugin version bump needed — all changed files are top-level, outside `plugins/`. (The meals SKILL.md already moved off `rails runner`/rvm to the Atelic MCP tools on main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
