### PR TITLE
Remove dead Bash(rvm:*) permission

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -62,7 +62,6 @@
       "Bash(rsvg-convert:*)",
       "Bash(rsync:*)",
       "Bash(ruby:*)",
-      "Bash(rvm:*)",
       "Bash(sed:*)",
       "Bash(sips:*)",
       "Bash(sort:*)",


### PR DESCRIPTION
Final cleanup of the RVM → rbenv migration (#105): drop the now-useless `Bash(rvm:*)` allowlist entry from `.claude/settings.json`. RVM is gone and `Bash(rbenv:*)` is already allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)