### PR TITLE
Enable vercel plugin in Claude Code setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -147,7 +147,8 @@
     "skill-creator@claude-plugins-official": true,
     "assist@local-skills": true,
     "linear-lifecycle@skillset": true,
-    "sdlc@skillset": true
+    "sdlc@skillset": true,
+    "vercel@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "claude-code-workflows": {


### PR DESCRIPTION
## What

Adds `vercel@claude-plugins-official` to `enabledPlugins` in `.claude/settings.json` so `setup.sh` installs the Vercel Claude Code plugin on a fresh machine.

## Why

While deploying the WAMM static site to Vercel, found that the plugin had been installed manually but wasn't captured in homebase. The two other Vercel pieces were already tracked:

- `vercel` npm global — already in `setup.sh` globals
- `claude-plugins-official` marketplace — already in `marketplace-sources.txt`

This enable entry was the only gap. No plugin version bump needed (`.claude/settings.json` lives outside any `plugins/` directory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)