### PR TITLE
Fix failing mise headless runs (marketplace-sync denials + socket drops)

### DIFF
--- a/.claude/local-skills/.claude-plugin/marketplace.json
+++ b/.claude/local-skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "assist",
       "source": "./plugins/assist",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "MIT",
       "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, and job applications.",
       "author": {

--- a/.claude/local-skills/plugins/assist/plugin.json
+++ b/.claude/local-skills/plugins/assist/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "assist",
   "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, job applications, and meal planning.",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/.claude/local-skills/plugins/assist/skills/mise/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/mise/SKILL.md
@@ -2,10 +2,11 @@
 name: assist:mise
 description: Morning prep sync for Forni's workstation. Pulls latest in ~/Eudaimonia and ~/Eudaimonia/Craft/Development/personal/homebase, then runs homebase's setup.sh to deploy dotfiles and refresh brew, npm globals, IDE extensions, and Claude plugins. Use this skill whenever Forni says "mise", "mise en place", "prep the station", "morning sync", "get the station ready", or otherwise wants his dev environment neat and tidy before the day's work. Also trigger for "/assist:mise". Named after mise en place: everything in its place before service.
 allowed-tools:
-  - Bash(git *)
-  - Bash(test *)
-  - Bash(date *)
-  - Bash(./setup.sh)
+  - Bash(git:*)
+  - Bash(test:*)
+  - Bash(date:*)
+  - Bash(./setup.sh:*)
+  - Bash(./bin/sync-marketplaces:*)
   - Read
   - Skill
 ---
@@ -60,39 +61,19 @@ Same conflict handling: stop on conflict, do not proceed to setup.sh.
 
 setup.sh installs Claude plugins from cached marketplace clones at `~/.claude/plugins/marketplaces/`, not from source repos directly. If any clone lags behind its remote, setup.sh installs stale plugin contents and recently merged skills do not appear after Claude Code restarts. Claude Code does not auto refresh these clones; mise owns keeping them current.
 
-For each subdirectory of `~/.claude/plugins/marketplaces/`, check whether it is a git repo and pull it. Skip directories that are not git repos (e.g., `claude-plugins-official` is a flat manifest, not a clone).
-
-Detect git repo status:
+This sync is purely mechanical, so it lives in a committed script rather than in this prose. Run it from the homebase path:
 
 ```bash
-git -C "$MARKETPLACE" rev-parse --git-dir
+./bin/sync-marketplaces
 ```
 
-Discover the default branch per repo. Most use `main` but some (older external mirrors) use `master`:
+The script iterates every clone, skips non git directories (`claude-plugins-official` is a flat manifest) and scratch `temp_*` clones, detects each clone's default branch, fast forwards it, and hard resets to the remote when a clone has drifted. It always exits 0 so one broken clone never blocks the rest, and it prints one status line per clone plus a final aggregate.
 
-```bash
-git -C "$MARKETPLACE" symbolic-ref --short refs/remotes/origin/HEAD
-```
+Parse its output for the summary. Each line is one of `PULLED`, `CURRENT`, `RESET`, `FAIL`, or `SKIP`. Fold the counts into the aggregate marketplace line, and call out by name any clone that reported `RESET` (drift recovered) or `FAIL` (could not sync) on its own line so a recovery or breakage stays unmissable. Clean `CURRENT`/`PULLED` clones roll into the aggregate without individual lines.
 
-The output is `origin/<branch>`. Strip the `origin/` prefix to get `$DEFAULT_BRANCH`. If `origin/HEAD` is not set, probe the remote refs in order: try `refs/remotes/origin/main` first, then `refs/remotes/origin/master`. Use the first one that exists. If neither exists, record failure for that marketplace and continue to the next — defaulting blindly to `main` would silently leave a `master` based clone stale.
+A `RESET` is safe and expected on occasion: these clones are caches, and anything unique to them is by definition ephemeral state or accidental drift, never real user work. A `FAIL` means setup.sh may install stale content for that one clone, but the rest install current.
 
-Try fast forward first:
-
-```bash
-git -C "$MARKETPLACE" pull --ff-only origin "$DEFAULT_BRANCH"
-```
-
-These clones are read only mirrors. They should never carry local commits or untracked work. If `pull --ff-only` refuses (clone has drifted, history rewritten on remote, no merge base, or local commits exist), auto recover:
-
-```bash
-git -C "$MARKETPLACE" fetch origin "$DEFAULT_BRANCH"
-git -C "$MARKETPLACE" reset --hard "origin/$DEFAULT_BRANCH"
-git -C "$MARKETPLACE" clean -fd
-```
-
-Log the recovery loudly in the mise summary (call out which marketplace and that a reset happened) so Forni notices when a clone needed rescuing rather than a clean ff. Auto recovery is safe because these clones are caches — anything unique to them is by definition either ephemeral state or accidental drift, never real user work.
-
-If recovery itself fails (network, auth, missing remote), record the failure for that marketplace and continue to the next one. One broken marketplace should not block setup.sh from refreshing the others. Surface the per marketplace failures in the summary; setup.sh may still install stale content for the affected clones but the rest will install current.
+Why this was extracted into a script: the headless run (`bin/run-mise`) pre-allows a tight tool list, and compound shell loops authored at runtime cannot match a single-prefix allowlist entry like `Bash(git:*)`. The old prose loops were denied on every headless run, which also widened the window for a transient API/socket drop. One allowlisted script call fixes both.
 
 ### Step 4: Run setup.sh
 

--- a/.claude/references/headless-claude.md
+++ b/.claude/references/headless-claude.md
@@ -112,6 +112,17 @@ Note: even with `--dangerously-skip-permissions`, writes to `.claude/`, `.git/`,
 `.vscode/`, `.idea/`, `.husky/` still prompt. For a true no prompt run in those
 paths, use `--allowedTools` with explicit patterns instead.
 
+**Compound shell commands cannot be allowlisted.** A `Bash(git:*)` entry matches
+only a single bare `git ...` invocation. A multi-statement command (a `for`
+loop, piped commands, `cmd1 && cmd2`, anything with shell control flow) matches
+no single-prefix entry and is denied every run, even when each inner command
+would be allowed on its own. When a skill needs mechanical multi-step shell in a
+headless run, extract it into a committed script and allowlist that one path
+(e.g. `Bash(./bin/sync-marketplaces:*)`). Bonus: far fewer model turns spent
+authoring loops, which shrinks the window for a transient API/socket drop. The
+mise marketplace-sync step thrashed on denied loops for a week before this fix
+(PR #109, 2026-06-09).
+
 ## Success detection
 
 Exit code alone is not enough. `claude -p "/unknown:skill"` returns 0 with
@@ -134,6 +145,13 @@ Where `<expected>` is the distinctive success string the skill emits.
   the flow.
 - **`id -u` via subshell in bash `local`**: `local var="$(id -u)"` masks the
   return value (ShellCheck SC2155). Split declare and assign.
+- **Transient API/socket drops on long runs**: `claude -p` can die mid-stream
+  with `API Error: The socket connection was closed unexpectedly` and exit
+  non-zero, especially on long sessions. Wrap the invocation in a `timeout` with
+  a single retry on a transient signature (`socket connection was closed|API
+  Error|overloaded|Connection error`); a clean skill-level abort (e.g. a merge
+  conflict) should not match and should report immediately. Idempotent routines
+  are safe to retry. Reference impl: `bin/run-mise` (PR #109, 2026-06-09).
 
 ## Email reporting via Resend
 

--- a/bin/run-mise
+++ b/bin/run-mise
@@ -31,11 +31,24 @@ KEYCHAIN_SERVICE="claude-code-oauth"
 ALLOWED_TOOLS=(
   "Bash(git:*)"
   "Bash(./setup.sh:*)"
+  "Bash(./bin/sync-marketplaces:*)"
   "Bash(date:*)"
   "Read"
   "Skill"
   "SlashCommand"
 )
+
+# Guard the headless claude invocation against transient API/socket drops and
+# hangs. Each attempt runs under a timeout; on a timeout or a transient API
+# error we retry once. Mise is idempotent, so a retry just re-syncs (mostly
+# no-ops) and completes. A clean skill-level abort (e.g. a merge conflict the
+# skill deliberately reports) does not match the transient signature, so it is
+# reported immediately without a wasteful retry.
+ATTEMPT_TIMEOUT="15m"
+MAX_ATTEMPTS=2
+RETRY_BACKOFF_SECONDS=15
+# Output substrings that mark a transient failure worth one retry.
+TRANSIENT_SIGNATURE='socket connection was closed|API Error|overloaded|Connection error|terminated'
 
 mkdir -p "$(dirname "$LOG")"
 
@@ -117,7 +130,7 @@ fi
     exit 1
   fi
 
-  for tool in claude jq curl security; do
+  for tool in claude jq curl security timeout; do
     if ! command -v "$tool" &>/dev/null; then
       fatal_report "$tool not on PATH ($PATH)"
       exit 1
@@ -130,10 +143,40 @@ fi
     echo "auth: no token found in keychain or file; relying on claude default"
   fi
 
-  result=$(claude -p "/assist:mise" \
-    --allowedTools "${ALLOWED_TOOLS[@]}" \
-    --output-format json)
-  rc=$?
+  stderr_file="$(dirname "$LOG")/mise-claude-stderr.txt"
+  attempt=1
+  while :; do
+    echo "=== $(date -Iseconds) claude attempt $attempt/$MAX_ATTEMPTS (timeout $ATTEMPT_TIMEOUT) ==="
+    # Keep stdout (the JSON) in $result for the downstream jq parse; tee stderr
+    # to a file so the transient check below can inspect it without polluting
+    # the JSON.
+    result=$(timeout "$ATTEMPT_TIMEOUT" claude -p "/assist:mise" \
+      --allowedTools "${ALLOWED_TOOLS[@]}" \
+      --output-format json 2>"$stderr_file")
+    rc=$?
+
+    [[ $rc -eq 0 ]] && break
+
+    # rc 124 = timeout killed the attempt. Otherwise inspect both streams for a
+    # transient API/socket signature (the error can surface in the JSON result
+    # or on stderr). Anything else is a real failure: report it without retrying.
+    transient=false
+    if [[ $rc -eq 124 ]]; then
+      transient=true
+      echo "claude attempt $attempt timed out after $ATTEMPT_TIMEOUT"
+    elif { printf '%s' "$result"; cat "$stderr_file" 2>/dev/null; } | grep -qiE "$TRANSIENT_SIGNATURE"; then
+      transient=true
+      echo "claude attempt $attempt hit a transient API error (exit $rc)"
+    fi
+
+    if [[ "$transient" == true && $attempt -lt $MAX_ATTEMPTS ]]; then
+      echo "retrying in ${RETRY_BACKOFF_SECONDS}s"
+      attempt=$((attempt + 1))
+      sleep "$RETRY_BACKOFF_SECONDS"
+      continue
+    fi
+    break
+  done
 
   echo "$result"
   echo "=== $(date -Iseconds) run-mise end (exit $rc) ==="

--- a/bin/sync-marketplaces
+++ b/bin/sync-marketplaces
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Refresh the cached Claude plugin marketplace clones under
+# ~/.claude/plugins/marketplaces/ so setup.sh installs current plugin
+# contents rather than stale skills.
+#
+# This carries the marketplace-sync logic that used to live as prose in the
+# assist:mise skill (Step 3). It was extracted into a script for two reasons:
+#   1. Headless mise (bin/run-mise) pre-allows a tight tool list. Compound
+#      shell loops authored at runtime cannot match a single-prefix allowlist
+#      entry like Bash(git:*), so the old prose loops were denied every run.
+#      One committed script is a single allowlistable command.
+#   2. Asking the model to author git loops burned turns and widened the
+#      window for a transient API/socket drop. This is purely mechanical work.
+#
+# These clones are read-only mirrors. They should never carry local commits or
+# untracked work, so on drift we hard-reset to the remote default branch.
+# Anything unique to a clone is by definition ephemeral state or accidental
+# drift, never real user work.
+#
+# Always exits 0: one broken clone must not block setup.sh from refreshing the
+# rest. Per-clone failures are reported on stderr and rolled into the summary.
+set -uo pipefail
+
+MARKETPLACES_DIR="${CLAUDE_MARKETPLACES_DIR:-$HOME/.claude/plugins/marketplaces}"
+
+pulled=0
+current=0
+reset=0
+failed=0
+
+# default_branch <repo> — echo the clone's default branch name, or empty if
+# it cannot be determined. Prefer origin/HEAD; fall back to probing main then
+# master. Never guess blindly: a master-based clone defaulted to main would be
+# silently left stale.
+default_branch() {
+  local repo="$1" head br
+  head="$(git -C "$repo" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)"
+  br="${head#origin/}"
+  if [[ -n "$br" ]]; then
+    echo "$br"
+    return 0
+  fi
+  if git -C "$repo" show-ref --verify --quiet refs/remotes/origin/main; then
+    echo "main"
+  elif git -C "$repo" show-ref --verify --quiet refs/remotes/origin/master; then
+    echo "master"
+  fi
+}
+
+if [[ ! -d "$MARKETPLACES_DIR" ]]; then
+  echo "SKIP-ALL no marketplaces dir at $MARKETPLACES_DIR"
+  echo "Marketplaces: 0 total (none found)"
+  exit 0
+fi
+
+for repo in "$MARKETPLACES_DIR"/*/; do
+  [[ -d "$repo" ]] || continue
+  repo="${repo%/}"
+  name="$(basename "$repo")"
+
+  # Scratch clones Claude Code leaves behind; not real marketplaces.
+  case "$name" in
+    temp_*)
+      echo "SKIP $name (scratch clone)"
+      continue
+      ;;
+  esac
+
+  # Skip non-git directories (e.g. claude-plugins-official is a flat manifest).
+  if ! git -C "$repo" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "SKIP $name (not a git repo)"
+    continue
+  fi
+
+  br="$(default_branch "$repo")"
+  if [[ -z "$br" ]]; then
+    echo "FAIL $name (no default branch)" >&2
+    failed=$((failed + 1))
+    continue
+  fi
+
+  # Fast forward first.
+  if git -C "$repo" pull --ff-only origin "$br" >/tmp/sync-marketplaces.txt 2>&1; then
+    if grep -q "Already up to date" /tmp/sync-marketplaces.txt; then
+      echo "CURRENT $name ($br)"
+      current=$((current + 1))
+    else
+      echo "PULLED $name ($br)"
+      pulled=$((pulled + 1))
+    fi
+    continue
+  fi
+
+  # ff-only refused: clone drifted, history rewritten upstream, or local
+  # commits exist. Recover by hard-resetting to the remote.
+  reason="$(tail -1 /tmp/sync-marketplaces.txt)"
+  if git -C "$repo" fetch origin "$br" >/dev/null 2>&1 \
+    && git -C "$repo" reset --hard "origin/$br" >/dev/null 2>&1 \
+    && git -C "$repo" clean -fd >/dev/null 2>&1; then
+    echo "RESET $name ($br) :: drift recovered (${reason})"
+    reset=$((reset + 1))
+  else
+    echo "FAIL $name ($br) :: recovery failed (${reason})" >&2
+    failed=$((failed + 1))
+  fi
+done
+
+total=$((pulled + current + reset + failed))
+echo "Marketplaces: ${total} total, ${pulled} pulled, ${current} current, ${reset} reset, ${failed} failed"
+
+exit 0

--- a/bin/sync-marketplaces
+++ b/bin/sync-marketplaces
@@ -28,6 +28,12 @@ current=0
 reset=0
 failed=0
 
+# Per-invocation temp file for capturing git output. mktemp avoids the symlink
+# races and cross-invocation collisions of a predictable /tmp path; the trap
+# cleans it up on any exit.
+tmp_out="$(mktemp)" || exit 1
+trap 'rm -f "$tmp_out"' EXIT
+
 # default_branch <repo> — echo the clone's default branch name, or empty if
 # it cannot be determined. Prefer origin/HEAD; fall back to probing main then
 # master. Never guess blindly: a master-based clone defaulted to main would be
@@ -80,8 +86,8 @@ for repo in "$MARKETPLACES_DIR"/*/; do
   fi
 
   # Fast forward first.
-  if git -C "$repo" pull --ff-only origin "$br" >/tmp/sync-marketplaces.txt 2>&1; then
-    if grep -q "Already up to date" /tmp/sync-marketplaces.txt; then
+  if git -C "$repo" pull --ff-only origin "$br" >"$tmp_out" 2>&1; then
+    if grep -q "Already up to date" "$tmp_out"; then
       echo "CURRENT $name ($br)"
       current=$((current + 1))
     else
@@ -93,7 +99,7 @@ for repo in "$MARKETPLACES_DIR"/*/; do
 
   # ff-only refused: clone drifted, history rewritten upstream, or local
   # commits exist. Recover by hard-resetting to the remote.
-  reason="$(tail -1 /tmp/sync-marketplaces.txt)"
+  reason="$(tail -1 "$tmp_out")"
   if git -C "$repo" fetch origin "$br" >/dev/null 2>&1 \
     && git -C "$repo" reset --hard "origin/$br" >/dev/null 2>&1 \
     && git -C "$repo" clean -fd >/dev/null 2>&1; then

--- a/setup.sh
+++ b/setup.sh
@@ -470,6 +470,13 @@ install_claude_plugins() {
     claude plugin marketplace add "$local_skills_dir"
   fi
 
+  # Refresh marketplace metadata from sources so plugin version bumps become
+  # visible to the update step below. `marketplace add` short-circuits when a
+  # marketplace is already on disk and does not refresh, so without this a
+  # bumped version would never be seen. Git sources do a network fetch here.
+  info "Refreshing marketplaces..."
+  claude plugin marketplace update >/dev/null 2>&1 || warn "Marketplace refresh hit an error"
+
   # Extract installed plugin names from formatted `claude plugin list` output.
   # Lines look like: "  ❯ feature-dev@claude-code-plugins"
   local installed_plugins
@@ -499,7 +506,20 @@ for k, v in d.get('enabledPlugins', {}).items():
     [[ -z "$plugin" ]] && continue
 
     if [[ -n "${installed_set[$plugin]+x}" ]] && [[ "$FORCE" != true ]]; then
-      info "Already installed: $plugin"
+      # Already installed: proactively update so version bumps actually deploy.
+      # setup.sh used to short-circuit here, so a bumped plugin never upgraded
+      # until a manual `claude plugin update`. update is a near no-op when the
+      # plugin is already current. Changes apply on the next claude launch.
+      local update_output
+      if update_output=$(claude plugin update "$plugin" 2>&1); then
+        if echo "$update_output" | grep -q "updated from"; then
+          info "Updated: $plugin"
+        else
+          info "Already current: $plugin"
+        fi
+      else
+        warn "Failed to update $plugin: $update_output"
+      fi
     else
       info "Installing: $plugin"
       claude plugin install "$plugin" || warn "Failed to install $plugin"


### PR DESCRIPTION
## Context

The weekday morning `mise` automation (`bin/run-mise`, launched by `com.mattforni.mise`) calls `claude -p "/assist:mise"` headlessly and emails a `[Mise]` report. It has been flaky all week, capped by the 2026-06-09 report ending with `API Error: The socket connection was closed unexpectedly`, exit 1, and four Bash permission denials.

The denials were the root cause. The mise skill's Step 3 instructed Claude to *author* compound shell loops at runtime (`for d in .../*/; do git -C "$d" pull ...; done`). Compound commands cannot match the headless allowlist entry `Bash(git:*)`, which only matches a single `git ...` invocation, so every marketplace-sync attempt was denied. Claude retried variants, the session ballooned in turns, and long denial-thrashing runs widened the window for a transient Anthropic streaming drop. The same cause explains the `skill did not complete` failures on 06-03 through 06-05 (the run never reached its `Mise complete` sentinel).

## Changes

- **New `bin/sync-marketplaces`**: deterministic, allowlistable script carrying the marketplace clone-sync logic that used to live as prose in the skill. Skips non-git dirs and scratch `temp_*` clones, detects each clone's default branch, fast forwards, and hard-resets on drift. Always exits 0; prints per-clone status plus an aggregate.
- **`mise` SKILL.md Step 3**: replaced the prose loops with a single `./bin/sync-marketplaces` call, with instructions to fold its output into the summary. Frontmatter `allowed-tools` aligned to colon syntax and the script added.
- **`bin/run-mise`**: allowlisted the script; wrapped the `claude -p` call in a ~15m timeout with a single retry on a transient API/socket signature (a clean skill-level abort like a merge conflict is reported immediately, not retried). Added `timeout` to the preflight tool check.
- **Version bump**: assist plugin `2.1.4` → `2.1.5` in both `plugin.json` and the local-skills `marketplace.json`.

## Verification

Live headless dry-run via `~/bin/run-mise` after deploy: completed with `"permission_denials":[]`, `is_error:false`, 13 turns, the new wrapper engaged (`claude attempt 1/2 (timeout 15m)`), `bin/sync-marketplaces` ran clean (6 clones current), the `Mise complete ✓` sentinel was reached, and the success email sent. `bin/sync-marketplaces` was also run standalone (skips the manifest and scratch dir, exits 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
