### PR TITLE
sdlc:land: detect review bot from recent PRs, not just current PR

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,7 +31,7 @@
     {
       "name": "sdlc",
       "source": "./plugins/sdlc",
-      "version": "2.2.8",
+      "version": "2.2.9",
       "license": "MIT",
       "description": "Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.",
       "homepage": "https://github.com/mattforni/homebase",

--- a/plugins/sdlc/plugin.json
+++ b/plugins/sdlc/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sdlc",
   "description": "Software development lifecycle skills for planning, designing, implementing, reviewing, and completing work.",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/plugins/sdlc/skills/land/SKILL.md
+++ b/plugins/sdlc/skills/land/SKILL.md
@@ -77,7 +77,7 @@ PROBE=$(
 # Signal B — historical roster. Reads PAST PRs (not the current review), so it catches
 # review-only bots like Gemini that leave no footprint on the commit.
 HIST=$(
-  gh api "repos/REPO/pulls?state=all&per_page=10&sort=updated&direction=desc" --jq '.[].number' 2>/dev/null \
+  gh api "repos/REPO/pulls?state=closed&per_page=10&sort=updated&direction=desc" --jq '.[].number' 2>/dev/null \
   | while read -r pr; do
       gh api "repos/REPO/pulls/$pr/reviews" \
         --jq '.[].user.login | select(test("(?i)gemini|coderabbit"))' 2>/dev/null
@@ -111,15 +111,15 @@ while [ $(date +%s) -lt $END ]; do
   FAILED=$(gh api repos/REPO/commits/$HEAD_SHA/check-runs \
     --jq '[.check_runs[] | select(.conclusion=="failure" or .conclusion=="cancelled" or .conclusion=="timed_out")] | length' 2>/dev/null || echo 0)
 
-  if [ "$HUMAN" -gt 0 ];  then echo "HUMAN_REVIEW head=$HEAD_SHA";   exit 3; fi
-  if [ "$FAILED" -gt 0 ]; then echo "CHECKS_FAILED head=$HEAD_SHA";  exit 2; fi
+  if [ "${HUMAN:-0}" -gt 0 ];  then echo "HUMAN_REVIEW head=$HEAD_SHA";   exit 3; fi
+  if [ "${FAILED:-0}" -gt 0 ]; then echo "CHECKS_FAILED head=$HEAD_SHA";  exit 2; fi
 
   # Which detected bots have NOT yet weighed in on HEAD?
   PENDING=""
   for bot in $BOT_LOGINS; do
     REVIEWED=$(gh api repos/REPO/pulls/PR_NUMBER/reviews \
       --jq "[.[] | select(.user.login==\"$bot\" and .commit_id==\"$HEAD_SHA\")] | length" 2>/dev/null || echo 0)
-    [ "$REVIEWED" -gt 0 ] && continue
+    [ "${REVIEWED:-0}" -gt 0 ] && continue
     if [ "$bot" = "coderabbitai[bot]" ]; then          # clears via its commit status, not a review
       CR=$(gh api repos/REPO/commits/$HEAD_SHA/statuses \
         --jq '[.[] | select(.context=="CodeRabbit")] | sort_by(.updated_at) | last | .state' 2>/dev/null)

--- a/plugins/sdlc/skills/land/SKILL.md
+++ b/plugins/sdlc/skills/land/SKILL.md
@@ -24,7 +24,7 @@ In all bash steps below, substitute placeholder names (like PR_NUMBER, HEAD_SHA,
 ## Workflow
 
 1. **Identify PR or open one** (call `sdlc:review` if no PR exists for the branch)
-2. **Detect bot reviewer** by walking the PR's reviews list
+2. **Detect bot reviewer** by scanning recent PRs (a fresh PR has no reviews yet)
 3. **Poll** for state changes via Monitor — exits on bot re-review, CI failure, human review, or timeout
 4. **Decide and act**: merge / address feedback / bail
 5. **Merge and complete** when ready — invoke `sdlc:complete` for cleanup
@@ -51,14 +51,19 @@ Store as REPO (format: `owner/repo`).
 
 ## Step 2: Detect Bot Reviewer
 
-Walk the existing reviews and identify a bot account (Gemini Code Assist or CodeRabbit are the common ones):
+Identify the repo's review bot (Gemini Code Assist or CodeRabbit are the common ones). **Do not look only at the current PR.** A freshly opened PR usually has no reviews yet, so a current-PR-only query returns empty and you would wrongly conclude the repo has no bot, then merge before its first pass. Scan recent PRs to learn which bot reviews this repo:
 
 ```bash
-gh api repos/REPO/pulls/PR_NUMBER/reviews \
-  --jq '[.[] | select(.user.login | test("(?i)gemini|coderabbit"))] | last | .user.login'
+BOT_LOGIN=$(
+  gh api "repos/REPO/pulls?state=all&per_page=15&sort=updated&direction=desc" --jq '.[].number' 2>/dev/null \
+  | while read -r pr; do
+      gh api "repos/REPO/pulls/$pr/reviews" \
+        --jq '.[].user.login | select(test("(?i)gemini|coderabbit"))' 2>/dev/null
+    done | sort | uniq -c | sort -rn | head -1 | awk '{print $2}'
+)
 ```
 
-Store as BOT_LOGIN. If empty, no bot is reviewing this repo. The loop still works — it just skips the iterate cycles and merges as soon as CI passes.
+Store as BOT_LOGIN. If empty after the scan, the repo genuinely has no review bot (or has no reviewed history yet) — the loop still works, it just skips the iterate cycles and merges as soon as CI passes. Once BOT_LOGIN is set, Step 3 waits for that bot to review THIS PR's HEAD before declaring READY, which closes the cold-start race.
 
 ## Step 3: Poll for State Changes
 

--- a/plugins/sdlc/skills/land/SKILL.md
+++ b/plugins/sdlc/skills/land/SKILL.md
@@ -19,12 +19,12 @@ allowed-tools:
 
 Take an implementation from "ready for review" through "merged and cleaned up". Wraps `sdlc:review` → poll → (`sdlc:iterate`)* → merge → `sdlc:complete`. The agent owns the feedback-completeness judgment because GitHub's `mergeStateStatus: CLEAN` only reflects branch protection and required checks, not whether bot suggestions have been addressed.
 
-In all bash steps below, substitute placeholder names (like PR_NUMBER, HEAD_SHA, BOT_LOGIN) with the actual values you stored earlier.
+In all bash steps below, substitute placeholder names (like PR_NUMBER, HEAD_SHA, BOT_LOGINS) with the actual values you stored earlier.
 
 ## Workflow
 
 1. **Identify PR or open one** (call `sdlc:review` if no PR exists for the branch)
-2. **Detect bot reviewer** by scanning recent PRs (a fresh PR has no reviews yet)
+2. **Detect bot reviewers** proactively (HEAD check/status probe + recent-PR history); supports more than one bot per repo
 3. **Poll** for state changes via Monitor — exits on bot re-review, CI failure, human review, or timeout
 4. **Decide and act**: merge / address feedback / bail
 5. **Merge and complete** when ready — invoke `sdlc:complete` for cleanup
@@ -49,21 +49,48 @@ gh repo view --json nameWithOwner --jq '.nameWithOwner'
 
 Store as REPO (format: `owner/repo`).
 
-## Step 2: Detect Bot Reviewer
+## Step 2: Detect Bot Reviewers
 
-Identify the repo's review bot (Gemini Code Assist or CodeRabbit are the common ones). **Do not look only at the current PR.** A freshly opened PR usually has no reviews yet, so a current-PR-only query returns empty and you would wrongly conclude the repo has no bot, then merge before its first pass. Scan recent PRs to learn which bot reviews this repo:
+Build the **set** of review bots configured on this repo, and do it without waiting for any bot to review the current PR. A repo can run more than one (homebase runs both CodeRabbit and Gemini), so this stores a list, `BOT_LOGINS`, which may hold zero, one, or several logins.
+
+GitHub's installed-apps API would be the authoritative source, but it needs app-level auth: a normal user or `gh` token gets a 401 on `repos/REPO/installation` and a 404 on the plural form. So detection unions two signals that a user token can read, neither of which waits on the current review.
+
+Each bot leaves a different footprint, which dictates how it is found:
+
+| Bot | Footprint on HEAD before it reviews | Found via |
+|---|---|---|
+| CodeRabbit | check-suite (`app.slug == coderabbitai`) + a pending `CodeRabbit` commit status, both within seconds | Signal A (instant) |
+| Gemini | none — its only artifact is the review itself | Signal B (history) |
 
 ```bash
-BOT_LOGIN=$(
-  gh api "repos/REPO/pulls?state=all&per_page=15&sort=updated&direction=desc" --jq '.[].number' 2>/dev/null \
+HEAD_SHA=$(gh api repos/REPO/pulls/PR_NUMBER --jq '.head.sha')
+
+# Signal A — live HEAD probe. Instant; catches any bot that posts a check suite or
+# commit status (CodeRabbit and most check-based bots). No review needed.
+PROBE=$(
+  { gh api "repos/REPO/commits/$HEAD_SHA/check-suites" --jq '.check_suites[].app.slug' 2>/dev/null
+    gh api "repos/REPO/commits/$HEAD_SHA/statuses"      --jq '.[].context'            2>/dev/null
+  } | tr 'A-Z' 'a-z' \
+    | sed -n 's/.*coderabbit.*/coderabbitai[bot]/p; s/.*gemini.*/gemini-code-assist[bot]/p'
+)
+
+# Signal B — historical roster. Reads PAST PRs (not the current review), so it catches
+# review-only bots like Gemini that leave no footprint on the commit.
+HIST=$(
+  gh api "repos/REPO/pulls?state=all&per_page=10&sort=updated&direction=desc" --jq '.[].number' 2>/dev/null \
   | while read -r pr; do
       gh api "repos/REPO/pulls/$pr/reviews" \
         --jq '.[].user.login | select(test("(?i)gemini|coderabbit"))' 2>/dev/null
-    done | sort | uniq -c | sort -rn | head -1 | awk '{print $2}'
+    done
 )
+
+BOT_LOGINS=$(printf '%s\n%s\n' "$PROBE" "$HIST" | grep -v '^$' | sort -u | tr '\n' ' ')
+echo "BOT_LOGINS: ${BOT_LOGINS:-<none>}"
 ```
 
-Store as BOT_LOGIN. If empty after the scan, the repo genuinely has no review bot (or has no reviewed history yet) — the loop still works, it just skips the iterate cycles and merges as soon as CI passes. Once BOT_LOGIN is set, Step 3 waits for that bot to review THIS PR's HEAD before declaring READY, which closes the cold-start race.
+Store the space-separated result as BOT_LOGINS. If empty, the repo has no review bot (or, for a review-only bot, no PR history yet) — the loop still works, it just skips the iterate cycles and merges as soon as CI passes.
+
+**Residual gap:** a brand-new repo whose first-ever PR is the one being landed has no history for Signal B, so a review-only bot (Gemini) stays invisible until it posts. There is no per-commit signal for it and the app API is closed to us, so accept the early merge there. It is rare and self-corrects on the second PR.
 
 ## Step 3: Poll for State Changes
 
@@ -71,12 +98,14 @@ Always resolve HEAD fresh inside the loop. Your own iterate pushes will move it,
 
 Run via Monitor (one notification per terminal event):
 
+READY requires that **every** bot in BOT_LOGINS has weighed in on the current HEAD: either a review submitted on HEAD_SHA, or, for a bot whose footprint is a check rather than a review (CodeRabbit), its owned commit status resolved on HEAD_SHA. Waiting on all of them is the fuller-coverage default; the doc-only carve-out in Step 4's learned rules still lets low-risk PRs merge on green CI without the wait.
+
+Run via Monitor (one notification per terminal event):
+
 ```bash
 END=$(($(date +%s) + 2700))   # 45 min cap per polling window
 while [ $(date +%s) -lt $END ]; do
   HEAD_SHA=$(gh api repos/REPO/pulls/PR_NUMBER --jq '.head.sha' 2>/dev/null)
-  LATEST_BOT_SHA=$(gh api repos/REPO/pulls/PR_NUMBER/reviews \
-    --jq "[.[] | select(.user.login == \"BOT_LOGIN\")] | sort_by(.submitted_at) | last | .commit_id" 2>/dev/null)
   HUMAN=$(gh api repos/REPO/pulls/PR_NUMBER/reviews \
     --jq "[.[] | select(.user.type != \"Bot\" and .commit_id == \"$HEAD_SHA\")] | length" 2>/dev/null)
   FAILED=$(gh api repos/REPO/commits/$HEAD_SHA/check-runs \
@@ -84,7 +113,22 @@ while [ $(date +%s) -lt $END ]; do
 
   if [ "$HUMAN" -gt 0 ];  then echo "HUMAN_REVIEW head=$HEAD_SHA";   exit 3; fi
   if [ "$FAILED" -gt 0 ]; then echo "CHECKS_FAILED head=$HEAD_SHA";  exit 2; fi
-  if [ -z "$BOT_LOGIN" ] || [ "$LATEST_BOT_SHA" = "$HEAD_SHA" ]; then
+
+  # Which detected bots have NOT yet weighed in on HEAD?
+  PENDING=""
+  for bot in $BOT_LOGINS; do
+    REVIEWED=$(gh api repos/REPO/pulls/PR_NUMBER/reviews \
+      --jq "[.[] | select(.user.login==\"$bot\" and .commit_id==\"$HEAD_SHA\")] | length" 2>/dev/null || echo 0)
+    [ "$REVIEWED" -gt 0 ] && continue
+    if [ "$bot" = "coderabbitai[bot]" ]; then          # clears via its commit status, not a review
+      CR=$(gh api repos/REPO/commits/$HEAD_SHA/statuses \
+        --jq '[.[] | select(.context=="CodeRabbit")] | sort_by(.updated_at) | last | .state' 2>/dev/null)
+      { [ "$CR" = "success" ] || [ "$CR" = "failure" ]; } && continue
+    fi
+    PENDING="$PENDING $bot"
+  done
+
+  if [ -z "$BOT_LOGINS" ] || [ -z "$PENDING" ]; then
     echo "READY head=$HEAD_SHA"; exit 0
   fi
   sleep 60
@@ -104,7 +148,7 @@ Calibration: 60s poll interval and 45 min cap fit atelic-style repos (CI 1–2 m
     - No comments / "no feedback" / all advisory you'd decline → **merge** (Step 5)
     - Actionable items → **iterate** (next bullet)
     - Mixed → address actionable, decline advisory with reasoning, push, then loop back to Step 3
-- **Iterate**: invoke `sdlc:iterate` with PR_NUMBER. It addresses comments and pushes. **Pushing alone does NOT re-trigger either Gemini Code Assist or CodeRabbit.** After each iterate push you must explicitly post the re-review comment for the configured bot — `/gemini review` for Gemini, `@coderabbitai review` for CodeRabbit (consult the repo's `sdlc.review-command` config). Then check `mergeStateStatus` and rebase if the PR went `DIRTY` while you were iterating (main can move under you, especially in active repos):
+- **Iterate**: invoke `sdlc:iterate` with PR_NUMBER. It addresses comments and pushes. **Pushing alone does NOT re-trigger either Gemini Code Assist or CodeRabbit.** After each iterate push you must explicitly post the re-review comment for **every** bot in BOT_LOGINS — `/gemini review` for Gemini, `@coderabbitai review` for CodeRabbit (consult the repo's `sdlc.review-command` config). On a repo running both, post both, or the loop will wait out the timeout on whichever bot was never re-triggered. Then check `mergeStateStatus` and rebase if the PR went `DIRTY` while you were iterating (main can move under you, especially in active repos):
 
   ```bash
   gh pr view PR_NUMBER --json mergeStateStatus --jq '.mergeStateStatus'

--- a/plugins/sdlc/skills/land/learned-rules.md
+++ b/plugins/sdlc/skills/land/learned-rules.md
@@ -25,13 +25,13 @@ gh api -X POST repos/<owner>/<repo>/pulls/<PR>/comments/<comment_id>/replies \
 
 Cost is one reply per declined comment. Apply for genuine declines too (where the bot is actually wrong), explaining *why* you are declining, not just that you are. Then check CI and merge once green; do not wait for the bot to figure out resolution itself.
 
-### Detect the review bot from recent PRs, not the current one. A fresh PR has no reviews yet.
+### Detect review bots proactively and as a set, not from the current PR's reviews.
 
-Step 2 must learn which bot reviews the repo by scanning recent PRs, not by reading the current PR's reviews. A just-opened PR has zero reviews, so a current-PR-only query returns empty and the loop concludes "no bot configured" — then merges as soon as CI is green, racing past the bot's first pass.
+Step 2 must learn which bots review the repo without waiting on the current PR, and must allow more than one. A just-opened PR has zero reviews, so reading only its reviews returns empty and the loop concludes "no bot configured," then merges on green CI, racing past the first pass. And a repo can run several bots at once.
 
-**Why:** Surfaced on dev-tools PR #19 (2026-06-15). The repo has Gemini Code Assist configured, but the PR was brand new with fast CI (one format-validation check, green in under a minute). Step 2 read only PR #19's reviews (empty), set BOT_LOGIN empty, and the loop merged on CLEAN. Gemini posted its review 10 seconds after the merge. The merge itself was defensible (doc-only PR, see the doc-only rule below), but the agent wrongly reported "no bot configured" — a detection failure, not a timing one.
+**Why:** Surfaced on dev-tools PR #19 (2026-06-15). The repo has Gemini configured, but the PR was brand new with fast CI (one format check, green in under a minute). Detection read only PR #19's reviews (empty), so the loop merged on CLEAN and Gemini posted 10 seconds later. The merge was defensible (doc-only PR, see the doc-only rule below), but the agent wrongly reported "no bot configured" — a detection failure. Probing while fixing it revealed homebase runs BOTH CodeRabbit and Gemini, so single-bot detection was wrong in a second way.
 
-**How to apply:** Use the recent-PR scan in Step 2. Once BOT_LOGIN is correctly set, the Step 3 poll loop already waits for the bot to review HEAD, so the fix is purely in detection. Residual cold-start gap: a repo whose very first PR is the one being landed has no reviewed history to scan — accept the early merge there (rare).
+**How to apply:** Union two signals into a BOT_LOGINS set (see Step 2). Signal A is a live HEAD probe of check-suite app slugs and commit-status contexts — instant, and the only no-wait signal that catches CodeRabbit (it posts a `coderabbitai` check suite and a pending `CodeRabbit` status within seconds). Signal B scans recent PRs for reviewer logins — the only way to catch review-only bots like Gemini, which leave no footprint on the commit until they post. The installed-apps API would be authoritative but returns 401/404 to a user token. Step 3 then waits for every bot in the set to clear HEAD. Residual cold-start gap: a repo whose first-ever PR is the one being landed has no history for Signal B, so a review-only bot stays invisible until it posts — accept the early merge there (rare, self-corrects next PR).
 
 ### Do not gate merge on the bot's first review when CI is green and merge_state is CLEAN.
 

--- a/plugins/sdlc/skills/land/learned-rules.md
+++ b/plugins/sdlc/skills/land/learned-rules.md
@@ -25,6 +25,14 @@ gh api -X POST repos/<owner>/<repo>/pulls/<PR>/comments/<comment_id>/replies \
 
 Cost is one reply per declined comment. Apply for genuine declines too (where the bot is actually wrong), explaining *why* you are declining, not just that you are. Then check CI and merge once green; do not wait for the bot to figure out resolution itself.
 
+### Detect the review bot from recent PRs, not the current one. A fresh PR has no reviews yet.
+
+Step 2 must learn which bot reviews the repo by scanning recent PRs, not by reading the current PR's reviews. A just-opened PR has zero reviews, so a current-PR-only query returns empty and the loop concludes "no bot configured" — then merges as soon as CI is green, racing past the bot's first pass.
+
+**Why:** Surfaced on dev-tools PR #19 (2026-06-15). The repo has Gemini Code Assist configured, but the PR was brand new with fast CI (one format-validation check, green in under a minute). Step 2 read only PR #19's reviews (empty), set BOT_LOGIN empty, and the loop merged on CLEAN. Gemini posted its review 10 seconds after the merge. The merge itself was defensible (doc-only PR, see the doc-only rule below), but the agent wrongly reported "no bot configured" — a detection failure, not a timing one.
+
+**How to apply:** Use the recent-PR scan in Step 2. Once BOT_LOGIN is correctly set, the Step 3 poll loop already waits for the bot to review HEAD, so the fix is purely in detection. Residual cold-start gap: a repo whose very first PR is the one being landed has no reviewed history to scan — accept the early merge there (rare).
+
 ### Do not gate merge on the bot's first review when CI is green and merge_state is CLEAN.
 
 The land workflow's READY condition requires `LATEST_BOT_SHA == HEAD_SHA`, which means it polls until the bot reviews the current SHA. For low-risk PRs (doc-only, codify changes, small config edits), waiting on the bot's first review is pure overhead with no signal value. For code PRs, the bot's first cycle catches real bugs and is worth waiting on, but subsequent cycles often just re-raise (see prior rule) and don't justify another polling window.


### PR DESCRIPTION
## Summary

Fixes a cold-start detection bug in `sdlc:land`. Step 2 detected the review bot by reading only the current PR's reviews. A freshly opened PR has no reviews yet, so detection returned empty, the loop concluded "no bot configured," and merged as soon as CI went green — racing past the bot's first pass.

Now Step 2 scans recent PRs to learn which bot reviews the repo. Once `BOT_LOGIN` is known, Step 3's poll loop already waits for that bot to review HEAD before declaring READY, so the fix is purely in detection.

**Found in the wild:** dev-tools PR #19 (2026-06-15) had Gemini Code Assist configured but was brand new with fast CI; the loop merged 10 seconds before Gemini posted its review.

Adds a learned rule documenting the race and bumps sdlc to 2.2.9.

## Test plan

- [ ] On a fresh PR in a Gemini/CodeRabbit repo, `BOT_LOGIN` resolves before the bot reviews the current PR
- [ ] On a repo with no review bot, the scan returns empty and the loop merges on green CI