### PR TITLE
plan-training: add Load Safety Check to the retro

### DIFF
--- a/.claude/local-skills/.claude-plugin/marketplace.json
+++ b/.claude/local-skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "assist",
       "source": "./plugins/assist",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, and job applications.",
       "author": {

--- a/.claude/local-skills/plugins/assist/plugin.json
+++ b/.claude/local-skills/plugins/assist/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "assist",
   "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, job applications, and meal planning.",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/.claude/local-skills/plugins/assist/skills/plan-training/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-training/SKILL.md
@@ -70,7 +70,7 @@ Run the full retro workflow on the just-closed ISO week (see Mode: retro below).
 - An adherence read on what hit, what slipped
 - A plan adjustment check: do the current week's targets still hold, or do they step down?
 
-When the retro reveals drift (long run missed, weekly mileage 30%+ under plan, two consecutive weeks of misses, or weight off trajectory), pause before scheduling. Propose adjustments to the current week's targets and get user confirmation before continuing to Phase 2.
+When the retro reveals drift (long run missed, weekly mileage 30%+ under plan, two consecutive weeks of misses, or weight off trajectory) or the load safety check fires a flag (ceiling breach, weekly ramp over ~15%, or two big days clustered within 48 hours), pause before scheduling. Propose adjustments to the current week's targets and get user confirmation before continuing to Phase 2.
 
 If a `### Wk N` subsection already exists in the plan for the just-closed week, skip Phase 1 and continue to Phase 2.
 
@@ -174,7 +174,20 @@ Compare each against the plan row. Express delta as percentage and direction.
 
 **Vert is co-equal with mileage.** The plan tracks both; the retro evaluates against both. Hitting mileage and missing vert (e.g., long run on flat terrain instead of trail) is a partial hit, not a hit.
 
-### Phase 5: Interrogate Significant Deltas
+**From Wk 7 onward the plan numbers are ceilings, not floors** (see the Maximums recalibration note in `2026-training-plan.md`). A positive delta against a back-half row is a breach to flag in Phase 5, not an overachievement to celebrate.
+
+### Phase 5: Load Safety Check
+
+Run this every retro, right after the numbers and before interrogating deltas. The historical injury driver was not peak volume but ramp speed and the clustering of long and vertical days: the 2026-04 spike of 31 mi with three trail efforts in five days, and the 2026-06 stack of a high-effort Friday long onto a 14er the next morning. The under-performance triggers miss this entirely, so check the over-side explicitly. Four checks against the week's actuals:
+
+1. **Ceiling breach.** Compare actual weekly miles, weekly vert, and longest single day against the week's MAX in the plan row. Any value over its ceiling is a breach. State the amount over.
+2. **Ramp.** Compare this week's actual mileage to the prior week's actual (read the previous `### Wk N` retro's Numbers row). An increase over roughly 15% is a flag, stated as a percentage. Ramp off a low base (returning from a layoff) is the highest risk; call it out even when the absolute mileage looks modest.
+3. **Clustering.** Scan the week's Strava activities for two big days within 48 hours of each other, where a big day is any effort over 8 mi or over 1,000 ft. The specific pattern to catch is a Saturday 14er or trail day stacked on the back of the Friday long. One flag per cluster.
+4. **Recovery read (heart rate).** Pull `mcp__claude_ai_Strava__get_activity_performance` for the week's easy and recovery-labeled runs, and `get_athlete_zones` for the Z2 ceiling. Two signals: (a) easy days that are not actually easy, with average HR drifting above the Z2 ceiling; (b) HR at a comparable easy pace climbing across the week, which reads as accumulating fatigue. Note either; absence of both is worth one line of reassurance.
+
+If any flag fires, carry it into Phase 6 and Phase 8: a load safety flag is as much a reason to step the next week down as an under-performance miss is. Record the outcome in the retro's Load Check section. When all four are clean, say so in one line and move on.
+
+### Phase 6: Interrogate Significant Deltas
 
 When the numbers show significant divergence from plan — mileage 30%+ under, long run missed entirely, two consecutive weeks of misses, or weight off trajectory — interrogate the cause before writing the retro. Numbers alone are not the read; they are the symptom. The cause shapes the adjustment.
 
@@ -189,7 +202,7 @@ Ask one focused question for category, then leave room for the user to fill in d
 
 Skip this phase only when the retro lands at or above plan with no meaningful gap.
 
-### Phase 6: Write the Retro Subsection
+### Phase 7: Write the Retro Subsection
 
 Append a new subsection at the bottom of the **Weekly Retrospectives** section in `2026-training-plan.md`. Use this skeleton (note the heading levels: `###` for the week, `####` for the inner sections so the table of contents stays clean):
 
@@ -213,6 +226,10 @@ Append a new subsection at the bottom of the **Weekly Retrospectives** section i
 | Vert ft | ... | ... | ... |
 | Weight | ... | ... | ... |
 
+#### Load Check
+
+<One line each: ceiling (within, or breached by X), ramp (+X% vs last week), clustering (none, or Sat 14er on Fri long), recovery (easy days easy, no HR drift). State clean explicitly when clean.>
+
 #### The Read
 
 <2 to 4 short paragraphs on what hit, what slipped, what's open. Be specific and direct. Avoid effusive praise or hedging.>
@@ -228,9 +245,9 @@ Append a new subsection at the bottom of the **Weekly Retrospectives** section i
 
 Before writing, present the draft inline and ask the user one question via `AskUserQuestion`: anything to add or correct? Save after they confirm or redirect. Use `Edit` to insert the new subsection at the end of the Weekly Retrospectives section, immediately before the `## References` heading.
 
-### Phase 7: Plan Adjustment Check
+### Phase 8: Plan Adjustment Check
 
-Compare the just-written retro to the **current** week's plan row. When the retro shows under-coverage — long run missed, weekly mileage 30%+ under, two weeks in a row of misses, or weight off trajectory — the current week's targets likely need to step down rather than press forward.
+Compare the just-written retro to the **current** week's plan row. When the retro shows under-coverage — long run missed, weekly mileage 30%+ under, two weeks in a row of misses, or weight off trajectory — the current week's targets likely need to step down rather than press forward. The same step-down applies when Phase 5 fired a load safety flag (ceiling breach, ramp over ~15%, or clustered big days): lower the ceiling and space the big days before continuing the build. Per the standing guardrail, any calf, heel, or foot signal drops the next week to the current week's numbers, no exceptions.
 
 Propose adjustment options to the user via `AskUserQuestion`. Typical levers:
 
@@ -242,7 +259,7 @@ After the user decides, update the row in `2026-training-plan.md` to reflect the
 
 Skip this phase only when the retro shows the week landed at or above plan.
 
-### Phase 8: Surface Trends
+### Phase 9: Surface Trends
 
 After saving, briefly scan the prior 1 to 2 retro subsections already in the plan file (if they exist). Surface any pattern: repeated misses, drifting metrics, growing or shrinking adherence. Keep this short — one or two sentences. Do not invent patterns when there is not enough data.
 

--- a/.claude/local-skills/plugins/assist/skills/plan-training/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-training/learned-rules.md
@@ -49,13 +49,19 @@ Training specific rules tied to current life shape. Read on every invocation. St
 
   **Why:** Pressing forward on a plan that already slipped multiplies the gap. Adjusting in response to reality keeps adherence honest. Codified 2026-05-18.
 
-  **How to apply:** Phase 7 of retro mode does this explicitly. If the retro shows missed long run, mileage 30%+ under, or back to back misses, surface adjustment options before continuing to schedule.
+  **How to apply:** Phase 8 of retro mode does this explicitly. If the retro shows missed long run, mileage 30%+ under, or back to back misses, surface adjustment options before continuing to schedule.
 
 - **Interrogate significant deltas, don't just record them.** When retro numbers diverge sharply from plan, the read is incomplete without knowing the cause. Ask the user via `AskUserQuestion` about category (injury / schedule / motivation / conditions), then prompt for detail in chat. The cause drives the adjustment more than the numbers do. When the cause is medical, ask for any provider notes or AI consults the user wants captured in the retro.
 
   **Why:** Wk 2 (ISO 2026-W20) came in -51% on mileage and -89% on vert. Numbers alone read as "fell off." Actual cause was a left heel injury (suspected plantar fasciitis). Without interrogating, the adjustment would have been wrong — push harder Wk 3 rather than step back and prioritize healing. Codified 2026-05-18.
 
-  **How to apply:** Phase 5 of retro mode. Always run it when the gap is 30%+ on any tracked metric or when a marquee session (long run, Thu SPRC) is fully missed.
+  **How to apply:** Phase 6 of retro mode. Always run it when the gap is 30%+ on any tracked metric or when a marquee session (long run, Thu SPRC) is fully missed.
+
+- **Load safety is the over-side of the retro: ramp and clustering injure, not peak volume.** Every retro runs Phase 5 (Load Safety Check) before interrogating deltas: ceiling breach, weekly ramp over ~15%, two big days clustered within 48 hours, and an HR recovery read. A flag steps the next week down exactly like an under-coverage miss does.
+
+  **Why:** A January-to-June 2026 Strava look-back showed both injury episodes shared one signature, and it was not high mileage. The Apr 13-19 week hit 31 mi with three trail efforts in five days; the June rebuild stacked a 124-relative-effort Friday long onto the Holy Cross 14er the next morning. HR data cleared intensity discipline (easy days were genuinely easy, the 14er was paced in Z1), so the cause was structural: ramp speed and clustered big days. Codified 2026-06-16.
+
+  **How to apply:** Run Phase 5 every retro. Compare actuals against the week's MAX, since back-half plan rows are ceilings, not floors. Flag a Saturday 14er sitting on the back of a Friday long. Pull `get_activity_performance` on easy days to confirm they stayed in Z2. Any flag, or any calf, heel, or foot signal, drops the next week to the current week's numbers.
 
 - **Vert is co-equal with mileage.** The training plan tracks both Long mi and Vert ft per week. A retro that only evaluates mileage misses half the point. Always pull elevation gain from Strava activity details and total against the plan's Vert ft target.
 - **Lifts at Movement RiNo do not show in Strava.** When a lift is missing from Strava, the status is **open**, not missed. Confirm with the user before logging it as a miss in the retro. Same applies to climbing at Movement.


### PR DESCRIPTION
## What

Adds a load safety lens to the `assist:plan-training` retro so it catches the **over**-side, not just under-performance. Born from a January to June 2026 Strava look-back that found both 2026 injury episodes shared one signature, and it was not peak mileage: ramp speed and clustered big days.

## Changes

- **New Phase 5: Load Safety Check** (runs every retro, before interrogating deltas):
  1. Ceiling breach vs the week's MAX
  2. Weekly ramp over ~15% vs prior week actual
  3. Two big days (over 8 mi or 1,000 ft) clustered within 48 hours, especially a Saturday 14er on the back of the Friday long
  4. Heart rate recovery read (easy days staying in Z2, no cross-week drift)
- Reframes back-half plan rows as **ceilings, not floors**; a positive delta is now a breach to flag.
- Wires load flags into the schedule-pause (Mode: week Phase 1) and plan-adjustment (Phase 8) gates.
- Renumbers retro phases 5 to 8 into 6 to 9; adds a Load Check line to the retro skeleton.
- Codifies the ramp-and-clustering lesson in learned-rules.
- Bumps `assist` 3.2.0 to 3.3.0.

## Version note (resolved)

Rebased onto current main after #115 (the plan-meals rename) shipped 3.2.0. This PR now takes **3.3.0**, and the rebase retains #115's plan-meals changes. Diff against main is the four files above only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)