### PR TITLE
Add assist:plan-trip skill (group trip planning)

### DIFF
--- a/.claude/local-skills/.claude-plugin/marketplace.json
+++ b/.claude/local-skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "assist",
       "source": "./plugins/assist",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, and job applications.",
       "author": {
@@ -32,6 +32,7 @@
         "./skills/bd-email",
         "./skills/job-apply",
         "./skills/plan-meals",
+        "./skills/plan-trip",
         "./skills/mise",
         "./skills/permissions",
         "./skills/present",

--- a/.claude/local-skills/plugins/assist/plugin.json
+++ b/.claude/local-skills/plugins/assist/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "assist",
-  "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, job applications, and meal planning.",
-  "version": "3.3.0",
+  "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, job applications, meal planning, and group trip planning.",
+  "version": "3.4.0",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/.claude/local-skills/plugins/assist/skills/plan-trip/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-trip/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: assist:plan-trip
+description: Group trip and getaway planning. Scope the trip, pull live lodging availability, present options with per head cost, verify before booking, research the constraint that actually drives the trip (weather windows, permit and reservation release dates, access rules), hand off the booking, then capture a trip doc and schedule the time sensitive follow ups. Use this skill whenever Forni mentions planning a trip, a getaway, a group house, a cabin or Airbnb or VRBO for a crew, a basecamp for a race or hike or backpacking objective, finding lodging for friends, splitting a house, acclimation lodging, or asks "where should we stay", "find us a place", or "book the house" for an upcoming adventure. Also trigger for "/assist:plan-trip", "plan the Aspen trip", "find a house for the boys", or "we need a place for the loop weekend". Trip records live under `~/Eudaimonia/Craft/Adventure/`; this skill is the workflow counterpart to the Adventure planning conventions documented there.
+argument-hint: "[scope | search | present | verify | book | doc]"
+allowed-tools:
+  - Bash
+  - mcp__playwright__*
+  - mcp__claude_ai_Todoist__*
+  - WebSearch
+  - WebFetch
+  - Read
+  - Edit
+  - Write
+  - AskUserQuestion
+---
+
+# Plan Trip Assist
+
+Help Forni plan a group trip end to end: from a vague "we need a place" to a booked house, a captured trip doc, and the follow ups scheduled. The skill is a pipeline, but it is enterable at any phase. If the house is already booked and Forni just wants the doc, jump to Capture. If options are already on the table and he is deciding, jump to Verify.
+
+The whole point is to be a real planning partner, not a search box. The lodging is rarely the hard part. The hard part is the constraint nobody thought to check until it bit: the permit that releases on a fixed date, the afternoon storms that dictate a dawn start, the cancellation policy that is not what everyone assumed. Surfacing those is where this skill earns its keep.
+
+## Before Every Invocation
+
+1. Read [learned-rules.md](learned-rules.md) in this directory. It holds the calibrated gotchas from real trips, and it is the part most likely to save a misstep.
+2. Read `~/Eudaimonia/Craft/Adventure/CLAUDE.md`, especially the **Checking real availability for specific dates** section. The live availability mechanics (VRBO dated search, the Guesty calendar API, Airbnb dated search via Playwright) live there. This skill references them rather than restating them, so the two stay in sync.
+3. Skim the existing trip docs under `~/Eudaimonia/Craft/Adventure/` for the house style. `2026 Four Pass Loop/README.md` and `2026 Summer Camp/README.md` are the two worked examples this skill is built from.
+
+## Source of Truth
+
+Trip records live under `~/Eudaimonia/Craft/Adventure/<YEAR Trip Name>/README.md`, registered in `Adventure/CLAUDE.md` as an active trip. The README is the spec and the running log. Booking engines (Airbnb, VRBO, the property's own site) are truth for live availability and price. The crew is truth for who is actually in.
+
+## The Pipeline
+
+### Phase 1: Scope
+
+Nail the parameters before searching. Get these wrong and every option you present is noise. Ask **one question at a time** via `AskUserQuestion`, because each answer reshapes the next question, and because Forni thinks better when not handed a wall of prompts.
+
+The four that matter:
+
+- **Roster and headcount.** Who is actually coming, and does anyone bring a partner, kids, or a dog. This sets the bed count and the floor on bedrooms. "Probably 3ish rooms" is a real answer; pin the range, not a false precision.
+- **Budget and its basis.** Ask whether to think in nightly total or **per head**, because for a group splitting a house, per head is usually the number that matters and the one the crew will react to. Do not assume a nightly ceiling; let him frame it.
+- **Dates, locked versus floating.** Trips often have one hard anchor and one soft edge ("Sunday arrival is locked, the end date floats"). Find out which is which. The floating edge is a cost lever you can pull later.
+- **Location must haves and constraints.** The real driver is often not the town. "Doesn't have to be Aspen, we want to get Collins elevation" reframes the whole search toward sleeping altitude, not proximity. Draw out the underlying need.
+
+### Phase 2: Search
+
+Pull **live, dated availability** for the exact window using the methods in `Adventure/CLAUDE.md`. Do not present a property until you have confirmed it is actually open for those nights; a generic listings page is not availability.
+
+- Search across a few candidate areas when the constraint allows it, not just the obvious town. The acclimation trip's best value sat in Snowmass, not Aspen, and a higher altitude fallback (Leadville) existed an hour away. Casting one town wider than expected is usually worth it.
+- Scour both VRBO and Airbnb when Forni asks to "see options". They surface different inventory. Note that Airbnb card prices are the nightly sum **before** cleaning and service fees, while VRBO totals are usually all in. Flag the mismatch so the comparison is honest.
+- Filter to genuine bedroom count. Search filters lie; read each card.
+
+### Phase 3: Present
+
+Lay options out as a **tiered table** grouped by the tradeoff that matters (altitude vs proximity vs cost, or value vs premium), with **per head cost** on every row. Collapse the recommendation into the preferred row rather than writing a separate "I recommend" section. Give a short, opinionated read underneath: which one and why, and the one honest cost of that pick.
+
+Keep it scannable. Forni reacts to a table faster than to prose. Link every property inline.
+
+### Phase 4: Verify Before Committing
+
+Before any money moves, verify the three things that are most often wrong:
+
+- **The listing is real and matches.** Right town, right bedroom count, real reviews. A suspiciously cheap result deserves a 5 second look at the actual page before you put it forward.
+- **The true all in price.** The "all fees included" subtotal on the search card is often **not** the final number. Lodging and occupancy tax frequently get added at the last checkout screen, and that gap is real (on the Four Pass Loop condo it was the difference between $2,267 and $2,563). State the all in, and note the tax caveat.
+- **The cancellation policy.** Never assume "24 hours to refund" is universal; it depends on the listing (Flexible, Moderate, Firm, Strict). Read the actual policy. At several weeks out you are usually fine, but the safety net has to be confirmed, not guessed, before Forni commits.
+
+### Phase 5: Research the Driving Constraint
+
+This is the phase that separates a search from real planning. Almost every trip has one constraint that is not the lodging and that quietly dictates everything else. Find it and research it properly with `WebSearch` and `WebFetch`:
+
+- **Weather windows.** Late summer in the Colorado high country means daily afternoon storms, which forces a dawn start on any exposed objective. The plan bends around the weather, not the other way around.
+- **Permit and reservation release dates.** Trailhead parking, wilderness permits, and campground spots often release on a fixed date and sell out fast. These are time sensitive in a way lodging is not. Find the exact release date and time, and treat it as an action with a deadline.
+- **Access rules.** Timed entry, shuttle requirements, road closures, vehicle restrictions. The thing that turns a clean plan into a scramble at 04:00.
+
+When you surface one of these, say plainly that it matters more than the house, and let it reshape the recommendation. On the Four Pass Loop, the June 18 parking drop and the monsoon dawn start mattered more than which condo.
+
+### Phase 6: Booking Handoff
+
+**Never run Forni's card through an automated browser session.** Even with his go ahead to book, the final Reserve and payment click is his. This is a hard boundary, not a courtesy. Set him up so it is one click: the direct listing link with dates and guests prefilled, the all in number, and the confirmed cancellation policy so he knows the safety net before he commits. Then hand off.
+
+If he wants the crew told, draft the message in the right register (a casual group text reads nothing like an email; see GC for tone). Offer to copy it to his clipboard with `pbcopy`.
+
+### Phase 7: Capture
+
+Finish the artifact before you call it done.
+
+1. **Create the trip README** at `~/Eudaimonia/Craft/Adventure/<YEAR Trip Name>/README.md` using the structure below.
+2. **Register it** in `Adventure/CLAUDE.md` under Current Trips with a Key Files row, so future sessions pick it up.
+3. **Schedule the time sensitive follow ups** in Todoist. Reservation drops and refund deadlines are the classic ones. Put the exact datetime on the task, and add a timezone caveat when the source did not state one (recreation.gov releases are local to the site, so Mountain is the safe read for Colorado). Details go in a task comment per the Todoist conventions.
+
+Trip README structure (adapt section names to the trip; this is the worked shape, not a rigid template):
+
+```markdown
+# <YEAR Trip Name>
+
+<One paragraph: what the trip is, the objective, the shape.>
+
+## Status
+<What is locked, what is booked, what is still open. The first thing a future session reads.>
+
+## Crew
+<Table: person, status, notes. Who is in, who is maybe, who is out and why.>
+
+## Dates
+<What is hard locked vs floating. The lodging window. The objective day.>
+
+## Lodging
+<Booked place: link, where and why, the place, dates, all in cost and per head, cancellation policy.>
+
+## The Plan (or The Attempt)
+<The objective and how it gets done. The driving constraint and the strategy around it.>
+
+## Logistics / Access
+<Permits, reservations, timed entry, the release dates, the open knots.>
+
+## Options Considered
+<Tiered table of what was evaluated and why the pick won. Saves re deriving it.>
+
+## Open Items
+<Checklist. What is done, what is still live.>
+```
+
+## Booking Boundary, Restated
+
+The one rule worth repeating because it is the one with real downside: tee up the booking, hand off the final click. You set the table; Forni eats.
+
+## Learned Rules
+
+See [learned-rules.md](learned-rules.md) for the live, mutable gotchas harvested from real trips. Stable workflow lives in this file; calibrated lessons and corrections go there.

--- a/.claude/local-skills/plugins/assist/skills/plan-trip/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-trip/SKILL.md
@@ -79,7 +79,7 @@ When you surface one of these, say plainly that it matters more than the house, 
 
 **Never run Forni's card through an automated browser session.** Even with his go ahead to book, the final Reserve and payment click is his. This is a hard boundary, not a courtesy. Set him up so it is one click: the direct listing link with dates and guests prefilled, the all in number, and the confirmed cancellation policy so he knows the safety net before he commits. Then hand off.
 
-If he wants the crew told, draft the message in the right register (a casual group text reads nothing like an email; see GC for tone). Offer to copy it to his clipboard with `pbcopy`.
+If he wants the crew told, draft the message in the right register: a casual group text reads nothing like an email. The register rule and the comms tone notes live in [learned-rules.md](learned-rules.md). Offer to copy it to his clipboard with `pbcopy`.
 
 ### Phase 7: Capture
 

--- a/.claude/local-skills/plugins/assist/skills/plan-trip/evals/evals.json
+++ b/.claude/local-skills/plugins/assist/skills/plan-trip/evals/evals.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "assist:plan-trip",
+  "evals": [
+    {
+      "id": 0,
+      "name": "permit-objective-house-hunt",
+      "prompt": "A few of us are trying to day-hike Half Dome the weekend of 2026-09-19. Four guys, want to split a house with maybe 3 bedrooms near Yosemite, doesn't have to be in the park itself. We'd drive in Friday and the Sunday is the soft edge. Can you find us some options?",
+      "expected_output": "Scopes via one-at-a-time questions or reasonable defaults; pulls dated availability across a couple of gateway towns; presents a tiered table with per-head cost; verifies all-in price and cancellation policy; and critically, surfaces the Half Dome cables permit lottery as the driving constraint (release/preseason lottery timing) rather than treating it as just a house hunt. Hands off booking rather than booking. Offers a trip doc.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "name": "getaway-no-objective",
+      "prompt": "Planning a guys' weekend in Bend, Oregon for 6 of us, 2026-10-09 to 2026-10-11. Want a big house with a hot tub and space to hang. What are our options?",
+      "expected_output": "Scopes headcount/budget basis/dates; pulls live dated availability for the window; presents a grouped, tiered options table with per-head cost and the recommendation collapsed into the preferred row; verifies all-in vs subtotal and cancellation policy on the top pick; respects the booking boundary; offers to capture a trip doc. No invented permit constraint where none exists.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "mid-pipeline-capture-and-followup",
+      "prompt": "We just booked an Airbnb in Leadville for the crew, 2026-07-10 to 2026-07-13, for a Mount Massive and Mount Elbert weekend. Can you write up the trip doc and make sure I don't forget to sort out anything time-sensitive?",
+      "expected_output": "Enters the pipeline mid-stream at Capture: creates a trip README with the right structure (Status, Crew, Dates, Lodging, Plan, Logistics, Options, Open Items), registers it in Adventure/CLAUDE.md, and schedules the time-sensitive follow-ups in Todoist (e.g., overnight parking/permit considerations, anything date-gated) with a timezone caveat. Does not redo a search that's already settled.",
+      "files": []
+    }
+  ]
+}

--- a/.claude/local-skills/plugins/assist/skills/plan-trip/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-trip/learned-rules.md
@@ -1,0 +1,45 @@
+# Plan Trip: Learned Rules
+
+Live, mutable rules harvested from real trips. The stable workflow lives in `SKILL.md`; calibrated lessons and corrections accumulate here. Add to this file when a trip surfaces a new gotcha, and prune when one stops being true.
+
+Seeded from two runs: **2026 Summer Camp** (Buena Vista lodge, headcount 15) and **2026 Four Pass Loop** (Snowmass acclimation condo, the boys).
+
+## Scoping
+
+- **Think per head, not per night, for group trips.** When a crew splits a house, the per head number is the one they react to and the one that makes a $3,699 house feel cheap. Ask which basis Forni wants, but default to surfacing per head on every option. *Why: the same house reads as expensive nightly and a steal per head; the framing changes the decision.*
+
+- **Find the locked anchor and the floating edge.** Trips usually have one hard date and one soft one ("Sunday arrival is locked, the end date floats"). The floating edge is a cost lever: dropping a night is the cheapest way to lower the total. Pin which is which during scoping. *Why: a floating checkout turned a 7 night quote into a 5 night one and cut the per head cost meaningfully.*
+
+- **Draw out the real location constraint.** The town is often a red herring. "Doesn't have to be Aspen, we want to get Collins elevation" reframes the search from proximity to sleeping altitude and opens better options. Ask what the trip is actually optimizing for. *Why: the best value sat in Snowmass, and a max altitude fallback sat an hour away in Leadville, neither of which a literal "Aspen" search prioritizes.*
+
+## Searching
+
+- **Confirm dated availability before presenting anything.** A listings page is not availability. Use the VRBO dated search and the Guesty calendar API and Airbnb dated search from `Adventure/CLAUDE.md`. *Why: presenting a place that is booked for the dates wastes everyone's time and erodes trust in the option set.*
+
+- **Airbnb card prices are pre fee; VRBO totals are usually all in.** When comparing across the two, say so, or the comparison is dishonest. Airbnb adds cleaning and service (figure another 12 to 18%) and the lodging tax at the final screen. *Why: an Airbnb card and a VRBO card showing the "same" price are not the same price.*
+
+- **Cast one town wider than asked.** Search a couple of candidate areas, not just the obvious one. *Why: the acclimation trip's value pick and its altitude fallback both sat outside the named town.*
+
+## Verifying
+
+- **The "all fees included" subtotal is often not the final number.** Lodging and occupancy tax frequently get added at the last checkout screen. State the true all in and flag the tax caveat. *Why: on the Four Pass Loop condo the search card said $2,267 all in, the actual checkout was $2,563. That gap is real money and it is the number the crew should hear.*
+
+- **Never assume the cancellation policy.** "24 hours to refund" is not universal; it depends on the listing tier (Flexible, Moderate, Firm, Strict). Read the actual policy text before Forni commits. At several weeks out he is usually fine, but confirm the safety net rather than guessing it. *Why: the refund window is what makes "book now, decide by EOD" safe, and it is only safe if it is actually there.*
+
+- **A suspiciously cheap result earns a 5 second look at the real page.** Verify town, bedroom count, and reviews before putting it forward. *Why: the cheapest Snowmass 3BR looked too good; a quick check confirmed it was legitimate, and that check is what made it safe to recommend.*
+
+## The Driving Constraint
+
+- **Research the non lodging constraint; it usually matters more than the house.** Weather windows, permit and reservation release dates, access and timed entry rules. Find it, research it with web search, and let it reshape the recommendation. *Why: on the Four Pass Loop, the monsoon dawn start and the June 18 parking drop drove the plan far more than which condo won.*
+
+- **Reservation and permit release dates are time sensitive actions, not notes.** When a trailhead parking or wilderness permit or campground spot releases on a fixed date and sells out fast, put it in Todoist with the exact datetime and a P1, and add a timezone caveat when the source did not state one. Recreation.gov releases are local to the site, so Mountain is the safe read for Colorado. *Why: a permit that opens at 08:00 and sells out by 08:05 is a calendar event, and missing it can sink the objective even with the house booked.*
+
+## Booking and Handoff
+
+- **Tee up the booking; hand off the final click.** Never run Forni's card through an automated browser session, even with his go ahead. Set him up with the prefilled link, the all in number, and the confirmed cancellation policy, then let him press Reserve. *Why: this is a hard boundary on spending his money; the convenience of auto booking is not worth the risk of an unwanted charge.*
+
+- **Match the comms register to the channel.** A casual group text to the boys reads nothing like an email. Tight, warm, no sign off, the per head number up front, the deadline plain. Offer to copy it to the clipboard. *Why: the crew message is the last action and should reflect the final state cleanly; the wrong register lands wrong.*
+
+## Capture
+
+- **Finish the doc before calling it done.** Create the trip README, register it in `Adventure/CLAUDE.md`, schedule the follow ups. *Why: the planning value evaporates if it lives only in a chat that scrolls away; the README is the source of truth the next session reads.*


### PR DESCRIPTION
## What

Adds **`assist:plan-trip`**, a new skill that codifies the group trip planning workflow, and bumps the `assist` plugin from 3.3.0 to 3.4.0.

## Why

We just planned the Four Pass Loop acclimation trip by hand (booked a Snowmass house, researched the Maroon Bells permit drop, drafted the crew text, captured a trip doc). That was the second real run of the same workflow after 2026 Summer Camp. Two hand runs is a strong base to codify from, so this captures it into a skill that slots into the existing `plan-*` family.

## The skill

A 7-phase pipeline, enterable at any phase:

1. **Scope** params one question at a time (roster, budget basis, locked vs floating dates, real location constraint)
2. **Search** live dated availability across candidate areas (references the existing methods in `Adventure/CLAUDE.md` rather than duplicating)
3. **Present** a per-head tiered options table with the recommendation collapsed in
4. **Verify** the true all-in price and cancellation policy before money moves
5. **Research the driving constraint** (weather windows, permit and reservation release dates, access rules), the part that usually matters more than the house
6. **Booking handoff** (never run the card autonomously, tee up the one-click)
7. **Capture** a trip doc, register it in `Adventure/CLAUDE.md`, schedule the time-sensitive follow ups

Plus `learned-rules.md` with the harvested gotchas (per-head framing, locked-vs-floating dates, the all-in-exceeds-subtotal lesson, never-assume-cancellation, the booking boundary).

## Validation

Ran the skill-creator eval harness across three test cases (Half Dome permit hunt, Bend getaway, Leadville mid-pipeline capture). With-skill scored **100%** vs **61.7%** baseline. The gains concentrate in the booking boundary, the trip-doc structure, the all-in/cancellation verification, and the Adventure registration. Honest caveat: n=1 per cell, and the famous Half Dome permit was catchable without the skill, so the constraint-research phase is somewhat unproven on obscure constraints.

## Files

- `plugins/assist/skills/plan-trip/SKILL.md` (new)
- `plugins/assist/skills/plan-trip/learned-rules.md` (new)
- `plugins/assist/skills/plan-trip/evals/evals.json` (new, test record)
- `plugins/assist/plugin.json` (3.3.0 to 3.4.0)
- `.claude-plugin/marketplace.json` (3.3.0 to 3.4.0, plan-trip added to skills list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
