### PR TITLE
Capture food preferences in plan-meals skill (3.4.1)

### DIFF
--- a/.claude/local-skills/.claude-plugin/marketplace.json
+++ b/.claude/local-skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "assist",
       "source": "./plugins/assist",
-      "version": "3.4.0",
+      "version": "3.4.1",
       "license": "MIT",
       "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, and job applications.",
       "author": {

--- a/.claude/local-skills/plugins/assist/plugin.json
+++ b/.claude/local-skills/plugins/assist/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "assist",
   "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, job applications, meal planning, and group trip planning.",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/.claude/local-skills/plugins/assist/skills/plan-meals/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-meals/SKILL.md
@@ -98,7 +98,7 @@ Present the week back as a simple list of planned vs skipped meal slots. Ask For
    - Daily meals: an all-week breakfast and an all-week shake (PLNT v2 + soy milk, counted in the macro budget), then lunch and dinner per day, each linked to a recipe by name where one exists or freeform text otherwise
 3. For meals skipped on social days, give the meal a freeform description like "Social" or the event name rather than leaving it out.
 4. Repeat lunches up to twice per week. Keep breakfast mostly consistent (batch prep reality). Dinners vary more.
-5. Cross-check the draft against the Food Preferences section in learned-rules.md before presenting: nothing on a dislike/avoid list, honor grain and ingredient preferences, and do not buy items he already owns in quantity. When Forni states a new like, dislike, avoid food, or allergy at any point during planning, append it to that section so the next plan inherits it.
+5. Cross-check the draft against the Food Preferences section in learned-rules.md before presenting: nothing on a dislike/avoid list, honor grain and ingredient preferences, and do not buy items he already owns in quantity. When Forni states a new like, dislike, avoid food, or allergy at any point during planning, append it to that section, following the same Why / How to apply sub-bullet structure as the other rules, so the next plan inherits it.
 
 Present the draft plan inline before authoring it. Let Forni redirect before committing to the shopping list.
 

--- a/.claude/local-skills/plugins/assist/skills/plan-meals/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-meals/SKILL.md
@@ -98,6 +98,7 @@ Present the week back as a simple list of planned vs skipped meal slots. Ask For
    - Daily meals: an all-week breakfast and an all-week shake (PLNT v2 + soy milk, counted in the macro budget), then lunch and dinner per day, each linked to a recipe by name where one exists or freeform text otherwise
 3. For meals skipped on social days, give the meal a freeform description like "Social" or the event name rather than leaving it out.
 4. Repeat lunches up to twice per week. Keep breakfast mostly consistent (batch prep reality). Dinners vary more.
+5. Cross-check the draft against the Food Preferences section in learned-rules.md before presenting: nothing on a dislike/avoid list, honor grain and ingredient preferences, and do not buy items he already owns in quantity. When Forni states a new like, dislike, avoid food, or allergy at any point during planning, append it to that section so the next plan inherits it.
 
 Present the draft plan inline before authoring it. Let Forni redirect before committing to the shopping list.
 

--- a/.claude/local-skills/plugins/assist/skills/plan-meals/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-meals/learned-rules.md
@@ -59,6 +59,24 @@ Corrections and preferences specific to meal planning. Read on every invocation.
   - Why: Forni said so on 2026-04-17.
   - How to apply: do not propose recipes that use bananas, and do not include bananas on any shopping list. For the quinoa breakfast alt (previously sweetened with banana), use dates, a small drizzle of agave, or seasonal berries instead.
 
+## Food Preferences
+
+Standing likes, dislikes, and avoid foods. Read before drafting any plan, cross-check the draft against this list, and append here whenever Forni states a new preference during planning. A durable product home for preferences and allergies is tracked as an Atelic ticket; until it ships, this section is the source of truth.
+
+**Dislikes / avoid:**
+
+- **Corn.** Dislikes the taste, and it disagrees with his digestion. Keep it off menus and shopping lists entirely. Stated 2026-06-21.
+- **Pasta.** Not a fan. Favor grain bowls and skillet formats over pasta dishes; reach for quinoa or rice instead. Stated 2026-06-21.
+- **Bananas.** Does not eat them, anywhere. See the dedicated rule under Recipe Rules above.
+
+**Grain preference:**
+
+- **Quinoa over rice** when a recipe leaves the grain open. Stated 2026-06-21.
+
+**Already well stocked (do not add to a list by default, confirm first):**
+
+- **Tahini.** Owns plenty. Use lemon juice plus olive oil for bowl dressings rather than defaulting to tahini. Stated 2026-06-21.
+
 ## Macro Rules
 
 (none yet)

--- a/.claude/local-skills/plugins/assist/skills/plan-meals/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-meals/learned-rules.md
@@ -61,21 +61,31 @@ Corrections and preferences specific to meal planning. Read on every invocation.
 
 ## Food Preferences
 
-Standing likes, dislikes, and avoid foods. Read before drafting any plan, cross-check the draft against this list, and append here whenever Forni states a new preference during planning. A durable product home for preferences and allergies is tracked as an Atelic ticket; until it ships, this section is the source of truth.
+Standing likes, dislikes, and avoid foods. Read before drafting any plan, cross-check the draft against this list, and append here whenever Forni states a new preference during planning. New entries follow the same Why / How to apply structure as the rules above. A durable product home for preferences and allergies is tracked as an Atelic ticket; until it ships, this section is the source of truth.
 
 **Dislikes / avoid:**
 
-- **Corn.** Dislikes the taste, and it disagrees with his digestion. Keep it off menus and shopping lists entirely. Stated 2026-06-21.
-- **Pasta.** Not a fan. Favor grain bowls and skillet formats over pasta dishes; reach for quinoa or rice instead. Stated 2026-06-21.
-- **Bananas.** Does not eat them, anywhere. See the dedicated rule under Recipe Rules above.
+- **Corn.** Keep it off menus and shopping lists entirely.
+  - Why: Dislikes the taste, and it disagrees with his digestion. Stated 2026-06-21.
+  - How to apply: Do not propose recipes containing corn, and never add it to a shopping list.
+- **Pasta.** Favor grain bowls and skillet formats over pasta dishes.
+  - Why: Not a fan of pasta. Stated 2026-06-21.
+  - How to apply: Reach for quinoa or rice instead of building a meal around pasta.
+- **Bananas.** Does not eat them, anywhere.
+  - Why: Stated 2026-04-17. See the dedicated rule under Recipe Rules above.
+  - How to apply: No bananas in recipes or on shopping lists; sweeten with dates or berries instead.
 
 **Grain preference:**
 
-- **Quinoa over rice** when a recipe leaves the grain open. Stated 2026-06-21.
+- **Quinoa over rice** when a recipe leaves the grain open.
+  - Why: Stated preference on 2026-06-21.
+  - How to apply: Default to quinoa unless the recipe specifically calls for rice or Forni asks for it.
 
 **Already well stocked (do not add to a list by default, confirm first):**
 
-- **Tahini.** Owns plenty. Use lemon juice plus olive oil for bowl dressings rather than defaulting to tahini. Stated 2026-06-21.
+- **Tahini.** Do not add to a list by default; confirm first.
+  - Why: Owns plenty. Stated 2026-06-21.
+  - How to apply: Use lemon juice plus olive oil for bowl dressings rather than defaulting to tahini.
 
 ## Macro Rules
 

--- a/.claude/local-skills/plugins/assist/skills/plan-meals/references/recipe-sources.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-meals/references/recipe-sources.md
@@ -34,6 +34,10 @@ Appended automatically when a plan introduces a new recipe. Forni fills in the r
 | 2026-W17 | Creamy Spring Pea & Mint Soup | — (Claude drafted, no site source) | | Immersion blender showcase. Thu dinner |
 | 2026-W17 | Sweet Nut & Fruit Protein Bars | Forni's Paprika (ChatGPT originated) | | Bonus batch item, 16 bars, post workout snack |
 | 2026-W21 | Coconut Red Lentil Dal over Basmati | — (Claude drafted, no site source) | | Mon dinner centerpiece, batch carries to Thu pre Odell |
+| 2026-W26 | Lentil & White Bean Salad | — (Claude drafted, no site source) | | Travel week. Make ahead, holds days. Uses red onion + shallot. Low fat protein anchor |
+| 2026-W26 | Crispy Tofu & Summer Squash Bowl over Quinoa | — (Claude drafted, no site source) | | Travel week cook 1. Lemon + olive oil dressing |
+| 2026-W26 | Burst Tomato & White Bean Skillet over Quinoa | — (Claude drafted, no site source) | | Travel week cook 2. One pot, no pasta |
+| 2026-W26 | Black Bean Tacos with Cabbage Slaw | — (Claude drafted, no site source) | | Travel week cook 3. Seasonal slaw, no corn |
 
 ## Favorites
 


### PR DESCRIPTION
## What

Captures Forni's standing food preferences so the meal planner inherits them every week instead of rediscovering them.

- **learned-rules.md**: new Food Preferences section. Avoid corn (taste and digestion), pasta, and bananas; prefer quinoa over rice; tahini already owned, use lemon and olive oil for dressings.
- **SKILL.md**: Phase 3 step to cross check the draft against Food Preferences and append new likes, dislikes, avoid foods, or allergies as they surface during planning.
- **recipe-sources.md**: logged the four W26 travel dishes.
- **plugin.json + marketplace.json**: assist bumped 3.4.0 to 3.4.1.

## Why

Surfaced during W26 meal planning when Forni asked to durably save food preferences. This is the interim home; the durable product version (preferences and allergies in the Atelic api) is tracked in ATE-380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)