### PR TITLE
Store atelic API token in Keychain, self-heal setup.sh

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -28,7 +28,7 @@ fi
 
 # Atelic API token lives in the macOS Keychain (not a plaintext dotfile).
 # Export it for setup.sh's atelic MCP registration. Reads silently; no-op if absent.
-if [[ -z "${ATELIC_API_TOKEN:-}" ]]; then
+if [[ -z "${ATELIC_API_TOKEN:-}" ]] && command -v security &>/dev/null; then
   ATELIC_API_TOKEN="$(security find-generic-password -s atelic-api-token -w 2>/dev/null)"
   [[ -n "$ATELIC_API_TOKEN" ]] && export ATELIC_API_TOKEN || unset ATELIC_API_TOKEN
 fi

--- a/.zshrc
+++ b/.zshrc
@@ -26,6 +26,13 @@ fi
 # Always source global .env.local for tokens and secrets
 [[ -f ~/.env.local ]] && source ~/.env.local
 
+# Atelic API token lives in the macOS Keychain (not a plaintext dotfile).
+# Export it for setup.sh's atelic MCP registration. Reads silently; no-op if absent.
+if [[ -z "${ATELIC_API_TOKEN:-}" ]]; then
+  ATELIC_API_TOKEN="$(security find-generic-password -s atelic-api-token -w 2>/dev/null)"
+  [[ -n "$ATELIC_API_TOKEN" ]] && export ATELIC_API_TOKEN || unset ATELIC_API_TOKEN
+fi
+
 directories=("/usr/local/opt/postgresql@15/bin", "$HOME/bin")
 for directory in "${directories[@]}"; do
   if [[ -s "${directory}" ]] && [[ ":$PATH:" != *":${directory}:"* ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -578,6 +578,15 @@ install_mcp_servers() {
   # Code expands at runtime from the env var the bin/claude wrapper injects from
   # the login Keychain. The canonical token lives in BitWarden; setup_auth seeds
   # the Keychain entry on a fresh machine. So no literal token is ever baked in.
+
+  # Self-heal: when the env var is empty (headless runs do not source ~/.zshrc),
+  # fall back to the token stashed in the macOS Keychain so a fresh machine can
+  # re-register atelic without a manual export. The empty-token guard below still
+  # protects us if neither source has it.
+  if [[ -z "${ATELIC_API_TOKEN:-}" ]] && command -v security &>/dev/null; then
+    ATELIC_API_TOKEN="$(security find-generic-password -s atelic-api-token -w 2>/dev/null || true)"
+  fi
+
   local desired=(
     "playwright|stdio|npx -y @playwright/mcp@latest"
     "atelic|http|https://api.atelic.me/mcp|Authorization: Bearer ${ATELIC_API_TOKEN:-}"

--- a/setup.sh
+++ b/setup.sh
@@ -584,7 +584,7 @@ install_mcp_servers() {
   # re-register atelic without a manual export. The empty-token guard below still
   # protects us if neither source has it.
   if [[ -z "${ATELIC_API_TOKEN:-}" ]] && command -v security &>/dev/null; then
-    ATELIC_API_TOKEN="$(security find-generic-password -s atelic-api-token -w 2>/dev/null || true)"
+    ATELIC_API_TOKEN="$(security find-generic-password -s atelic-api-token -w)" || ATELIC_API_TOKEN=""
   fi
 
   local desired=(


### PR DESCRIPTION
## What

Move `ATELIC_API_TOKEN` off the env-only path and into the macOS login Keychain, then teach both the shell and `setup.sh` to read it from there.

Atelic was already registered and connected via a baked-in MCP header, but the token lived nowhere reusable: `setup.sh` skipped re-registration on every run (`Skipping atelic: ATELIC_API_TOKEN not set`) and a fresh machine couldn't self-heal.

## Changes

- **`.zshrc`**: reads the token from Keychain (`security find-generic-password -s atelic-api-token`) and exports `ATELIC_API_TOKEN` for interactive shells. No secret in the tracked file.
- **`setup.sh` (`install_mcp_servers`)**: falls back to the Keychain when the env var is empty, so headless runs (which don't source `~/.zshrc`) and fresh-machine setups can re-register atelic without a manual export. The existing empty-token guard still protects the truly-absent case.

## Why Keychain

Honors the `Admin/tools/` selection heuristic: "Auth via Keychain or short lived OAuth. No long lived plaintext secrets in dotfiles." The existing `~/.env.local` plaintext pattern was deliberately declined for this token.

## Verification

- Keychain round-trips the token (43 chars).
- Fresh interactive `zsh` exports `ATELIC_API_TOKEN`.
- `setup.sh` no longer prints the skip warning (`Already registered: atelic`).
- Atelic MCP returns live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)