### PR TITLE
assist 3.4.4: Reconcile the Pantry First in plan-meals

### DIFF
--- a/.claude/local-skills/.claude-plugin/marketplace.json
+++ b/.claude/local-skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "assist",
       "source": "./plugins/assist",
-      "version": "3.4.3",
+      "version": "3.4.4",
       "license": "MIT",
       "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, and job applications.",
       "author": {

--- a/.claude/local-skills/plugins/assist/plugin.json
+++ b/.claude/local-skills/plugins/assist/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "assist",
   "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, job applications, meal planning, and group trip planning.",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/.claude/local-skills/plugins/assist/skills/plan-meals/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-meals/SKILL.md
@@ -81,12 +81,14 @@ Meal plans live in Atelic, not in markdown. Author them through the MCP tools (s
 
 Present the week back as a simple list of planned vs skipped meal slots. Ask Forni if anything is missing before continuing.
 
-### Phase 2: Inventory Check
+### Phase 2: Reconcile the Pantry First
+
+**The pantry data drifts and must be reconciled against reality before drafting. Do not trust stock levels at face value, especially after a travel week.** Planning against a stale pantry means building meals around produce that is no longer there and buying duplicates of what is already on hand. This reconcile is the first real move of every weekly plan.
 
 1. Pull the full pantry with `mcp__atelic__list_pantry` (see Pantry Access above)
-2. The restock signal (staple + `needs_restock`) and any items with "low" in `notes` are the first candidates to ask about. Favor items that get used heavily week to week (tofu, soy milk, kimchi, hummus, greens, lentils, rice, oats)
-3. Ask Forni in one batch (use AskUserQuestion) for what's on hand. Group the questions by category (produce, refrigerated, dry goods, condiments) to keep it scannable. Keep it targeted; do not ask about every staple
-4. Update the api db with his answers before generating the plan, using `mcp__atelic__update_pantry_item` (or `mcp__atelic__add_pantry_item` for something new). The pantry gets more accurate over time, which matters more here than the small overhead of the write
+2. **Reconcile the perishables first.** Produce, dairy, and fresh proteins are where the data rots. Present what is currently shown in stock (group hardy vs delicate so it is fast to answer) and have Forni confirm what actually survived; knock everything else to level 0. After a travel week, assume most fresh stock is gone unless he says otherwise. For a full reconcile, present the list and let him name the survivors rather than asking thirty one-at-a-time questions (that scales badly on a phone); reserve the one-at-a-time pattern (see Pantry Rules in learned-rules.md) for the smaller set of genuinely ambiguous staples.
+3. Write the reconciliation back immediately with `mcp__atelic__update_pantry_item` (level up survivors, 0 for gone), `mcp__atelic__add_pantry_item` for new items, and `mcp__atelic__remove_pantry_item` for ones no longer tracked, so the rest of the flow reads accurate data. When zeroing, route each out item to its store (or remove it); a storeless `needs_restock` item pollutes every store's shopping view (see Pantry Rules).
+4. Then surface restock candidates (staple + `needs_restock`, anything "low" in `notes`) for items used heavily week to week (tofu, soy milk, kimchi, hummus, greens, lentils, rice, oats) and confirm before adding to the shopping list
 
 ### Phase 3: Draft the Plan
 

--- a/.claude/local-skills/plugins/assist/skills/plan-meals/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-meals/learned-rules.md
@@ -107,6 +107,18 @@ Standing likes, dislikes, and avoid foods. Read before drafting any plan, cross-
 
 ## Pantry Rules
 
+- **Reconcile the pantry against reality FIRST, before drafting the plan.** Treat the stored stock levels as a stale draft, not truth, especially after a travel week. Knock down what is gone and confirm survivors before planning anything.
+  - Why: On 2026-06-27 the pantry claimed a full summer produce drawer (4 tomato entries, 3 bell peppers, broccoli, kale, etc.) after a week in a rental kitchen. Planning against it would have built meals around food that did not exist and bought duplicates. Forni called for reconciliation to be step one of every weekly plan.
+  - How to apply: this is Phase 2 of the flow. Present perishables grouped hardy vs delicate, let Forni name the survivors, zero the rest, write it back, then plan against the corrected pantry.
+
+- **A full reconcile is a "name the survivors" pass, not thirty one-at-a-time questions.** The one-at-a-time rule below is for the smaller set of genuinely ambiguous staples, not for a whole-fridge audit.
+  - Why: After travel, most fresh stock is gone, so it is faster for Forni to list the few survivors than to tap through every item. He is often mobile (e.g. shopping) when this happens and dislikes tedious phone input.
+  - How to apply: present the in-stock perishables grouped hardy vs delicate and ask him to name what is still good; zero everything he does not name.
+
+- **Zeroing a non-staple still flags it `needs_restock`, and storeless items show under every store filter.** A bulk reconcile that zeros lots of produce floods every store's shopping view unless each out item carries a store.
+  - Why: On 2026-06-27, zeroing about 30 produce items buried the Costco shopping view under out-of-stock produce, because storeless `needs_restock` rows match all store filters.
+  - How to apply: when zeroing during a reconcile, route each out item to the store it is bought at (or `remove_pantry_item` if it is untracked / no longer wanted) so each store's list stays the clean "what to grab here" surface.
+
 - **Pantry inventory questions go one at a time, not in a batch.** Use AskUserQuestion with structured options rather than asking for a batched reply in chat.
   - Why: Forni corrected this on 2026-04-17. A long checklist in chat feels tedious; one question at a time keeps the rhythm conversational.
-  - How to apply: loop through pantry items individually. Each question should offer the common answers (Yes on hand, No need to buy, Have some but low, Skip) plus a free text option for quantity or notes.
+  - How to apply: loop through pantry items individually. Each question should offer the common answers (Yes on hand, No need to buy, Have some but low, Skip) plus a free text option for quantity or notes. (Exception: a full post-travel reconcile uses the "name the survivors" pass above, not this.)


### PR DESCRIPTION
## What

Makes pantry reconciliation the explicit first step of the weekly meal flow, so plans stop getting built around stale inventory.

Surfaced live on 2026-06-27: after a travel week the pantry claimed a full summer produce drawer that no longer existed. Planning against it would have built meals around ghost produce and bought duplicates.

## Changes (assist 3.4.4)

- **SKILL.md**: Phase 2 renamed from "Inventory Check" to **"Reconcile the Pantry First."** Now the explicit first move, with after travel guidance ("assume most fresh stock is gone") and store routing guidance when zeroing.
- **learned-rules.md**: three new Pantry Rules:
  1. Reconcile against reality before drafting.
  2. A full reconcile is a "name the survivors" pass, not thirty one at a time questions (Forni is often mobile when this happens).
  3. Zeroing a non staple still flags `needs_restock`, and storeless items pollute every store filter, so route out items to a store or remove them.
- **Version**: bumped 3.4.3 to 3.4.4 in plugin.json and marketplace.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)