### PR TITLE
feat(assist): add handle-budget YNAB categorization skill

### DIFF
--- a/.claude/local-skills/.claude-plugin/marketplace.json
+++ b/.claude/local-skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "assist",
       "source": "./plugins/assist",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "MIT",
       "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, and job applications.",
       "author": {

--- a/.claude/local-skills/plugins/assist/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/learned-rules.md
@@ -88,3 +88,30 @@ Routing conventions (established 2026-06-01):
   **How to apply:** New phase goes at its integer position. Every phase after it shifts up by one. Update body cross references (e.g., "continue to Phase 5") and any references in learned-rules.md or other skills that point at numbered phases. Worth a final grep for `Phase [0-9]\.[0-9]` to catch stragglers.
 
 ## Created Filters
+
+## Spend Categorization
+
+Rules for `assist:handle-budget`. The payee map is [reference/payee-map.md](reference/payee-map.md); these corrections override it.
+
+Mechanics (hard-won, do not rediscover):
+
+- Write through the YNAB REST API directly (`curl` plus Keychain `YNAB_ACCESS_TOKEN`), never the `ynab` MCP. The MCP read output hides the transaction and category IDs needed to write.
+- Imported transactions land **unapproved**, and categorizing does NOT approve them. Approve as the final step (`approved: true`) or the changes never flow into budget views. This is the usual cause of "my changes aren't showing up."
+- YNAB clients use delta sync. After API writes, an open app or web session needs a hard refresh to display them.
+- Payee names carry HTML entities (`&amp;`). Decode before matching.
+- Budget IDs: Personal `a55b71e6-76e4-46d9-a5c6-336b36ddd14c`, RYLLC `e0d471f0-bf90-452c-8232-b1153b7411be`.
+
+Conventions:
+
+- Trips are itemized into real categories with a memo `<emoji> <Trip Name>` (e.g. `🏔️ Crested Butte`, `⛷️ Vail`), NOT a YNAB flag. Quarantines vacation from the everyday baseline while keeping a per-trip total. Non-discretionary trip-time charges (vehicle repair) stay untagged.
+- Admin is not a generic catch-all. Estate and legal bills go to `📑 Admin / ⚖️ Legal`. Home-purchase costs (down payment, lender fees, inspection) go to `📑 Admin / 🏡 3033 Blake St Home Purchase`.
+- A couples outing or show with Jasmine can be `🍿 Entertainment` or `❤️ Dating`; ask. Forni chose Entertainment for The Empire Strips Back.
+
+Payee corrections (session 2026-06-29):
+
+- `7-Eleven` -> `🚬 Nicotine` (confirmed, buys nicotine there).
+- `Bunny and Clyde's` -> `☕️ Caffeine` (Salida coffee).
+- `Body Jewelry`, `Easy Steez Vintage` -> `🧥 Clothing`.
+- `Gem Figueroa` (friend, Venmo) -> context dependent; was `🍿 Entertainment` (a movie).
+- `Badfish SUP` -> `🎒 Gear`. `Rhino Air`, `Discount Tire`, `Costco Gas` -> `🚙 Transportation`.
+- `Amazon` history is split (~52%); always confirm, never auto.

--- a/.claude/local-skills/plugins/assist/plugin.json
+++ b/.claude/local-skills/plugins/assist/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "assist",
-  "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, job applications, meal planning, and group trip planning.",
-  "version": "3.5.0",
+  "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, job applications, meal planning, group trip planning, and YNAB spend categorization.",
+  "version": "3.6.0",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/.claude/local-skills/plugins/assist/reference/payee-map.md
+++ b/.claude/local-skills/plugins/assist/reference/payee-map.md
@@ -1,0 +1,63 @@
+# Payee Map (Spend Categorization Rules Engine)
+
+Read on every `assist:handle-budget` run. Generated from YNAB transaction history (payee -> dominant category), refreshed by re-mining. Corrections live in [learned-rules.md](../learned-rules.md) under `## Spend Categorization` and OVERRIDE this file.
+
+How to use it:
+
+- **Skip** (never categorize, they are account moves): any payee whose name matches `Transfer`, `CRCARDPMT`, `AUTOPAY`, `External Transfer`, `P2P`, `RECURRING FROM CHK`, `Online Scheduled Payment`, `PAYMENT FROM CHK`, `Confirmation`, `Descriptive Withdrawal/Deposit`. Leave uncategorized.
+- **Inflows** (income, route to `Inflow: Ready to Assign`, not a spend category): see the Inflows list below.
+- **Auto-categorize**: payees below with a clear historical category. Apply silently.
+- **Always confirm**: payees whose history is split. Ask before applying; do not auto-default.
+- **New payees** (not listed): ask the user one-by-one, then append the decision to learned-rules.md so it sticks.
+
+Trip handling: itemize each trip charge into its real category (coffee to Caffeine, meals to Dining Out) AND set the transaction memo to `<emoji> <Trip Name>` (e.g. `🏔️ Crested Butte`, `⛷️ Vail`). Forni's own convention, NOT a YNAB flag. This keeps everyday categories clean while letting a trip be totaled by its memo.
+
+Note: `Matthew Bigelow` historically maps to Rent. After the 3033 Blake purchase (June 2026) that recurring housing line becomes a mortgage payment, not rent.
+
+## Auto-Categorize (clear history, apply silently)
+
+- **🛒 Groceries**: Sprouts (22), Safeway (19), King Soopers (13), Costco (7), Whole Foods (5), Natural Grocers (5), Trader Joe's (4), Lider Express (2), Merpago Proidencia (2), Target (2), Raquelitas Tortillas (2), Brothers Market (2), Raquelita's Tortillas (2), City Market (2), FamilyMart (2), Albertsons (2), Spinellis (2), Mountain Earth Grocery (2)
+- **🍟 Fast Food**: Domino's (56), Illegal Pete's (23), Sliceworks (7), McDonald's (4), DoorDash (3)
+- **🌏 Adventure**: Foreign Transaction Fee (20), Airbnb (10), United Airlines (10), Denver Parking (5), Inn the Clouds (3), Booking.com (3), Jetstar (3), Southwest Airlines (2), The Bidwell (2), Kuroneko Yamato (2), Hokkaido Resort Liner (2), Highway Bus (2), Kajiwara Kitchen Supply (2), Cajun Encounters (2)
+- **🍾 Sobriety**: York Street Club (32), High Noon (20), Dakota Schwarz (2)
+- **☕️ Caffeine**: Improper City (11), Blue Sparrow Coffee (5), Santiago Coffee (3), Starbucks (2), Copper Door Coffee (2), Before & After (2), Hearth (2), Crema Coffee House (2), Lazybird Coffee (2), Invigatorium (2), Huckleberry Roasters (2), Wash Perk (2), Bunny and Clyde's (2), Camp 4 Coffee (2)
+- **🤲 Giving**: Project Angel Heart (12), Colorado Mountain Club (9), Charity: Water (9), CHARITY:WATER (3), We Dont Waste (3)
+- **🍿 Entertainment**: Amazon Prime (8), Prime Video (7), Nick Titus "📺" (5), Spotify (4), Netflix (4), Hulu (2), Buffalo Exchange (2), AXS (2), Townie Books & Rumors (2)
+- **🚙 Transportation**: Maverik (7), Suica (7), Sinclair (6), ExxonMobil (3), TRANSPORTES DEL ESTUARIO (2), Circle K (2), Public Works (2), JR East (2), Keisei Skyliner (2)
+- **🍽️ Dining Out**: Himchuli Indian (3), The Corner Beet (3), Shibuya Tokyu Foodshow (3), Donde Rodrigo y Jose Luis (2), Willie's (2), Great Divide Brewery (2), New Moonlight Pizza (2)
+- **🎒 Gear**: REI (10), Smith Optics (3)
+- **⚡️ Utilities**: Xcel Energy (13)
+- **🏡 Home Improvement**: Ace Hardware (6), Mill Industries (3), The Home Depot (2), Carbon Knife Co (2)
+- **🧖‍♂️ Personal Care**: Cult of Mane Salon (6), CVS Pharmacy (3), Pratt Physical Therapy (3)
+- **🏥 Benefits**: Elevate Health Plans (7), River North Dentistry (3), Epic Hospital & Clinic (2)
+- **🏡 Rent**: Matthew Bigelow (11)
+- **🧥 Clothing**: Keep it Local (3), Arc Thrift Stores (2), Goodwill (2)
+- **🛋️ Therapy**: Elizabeth Sump (5)
+- **🚬 Nicotine**: Phillips 66 (3), Nesbit's Magazine St Mkt (2)
+- **🧖 Naosu Sauna**: Naosu Sauna (4)
+- **🚙 Car Insurance**: GEICO (3)
+- **🧗 Movement**: Movement RiNo (3)
+- **👨‍🦱 Nutrafol**: Nutrafol (3)
+- **🎁 Gifts**: Rapha Racing (2)
+- **💳 Chase United Fee**: Annual Membership Fee (2)
+- **❤️ Dating**: Nocturne (2)
+- **🧽 Cleaning**: Blue Spruce Service (2)
+
+## Always Confirm (history is split, ask first)
+
+- **7-Eleven** (39 txns, 74% 🚬 Nicotine) - confirm; buys across categories.
+- **Amazon** (36 txns, 52% 🏡 Home Improvement) - confirm; buys across categories.
+- **Arc Thrift** (9 txns, 66% 🏡 Home Improvement) - confirm; buys across categories.
+- **Conoco** (4 txns, 50% 🚙 Transportation) - confirm; buys across categories.
+- **Shell** (4 txns, 75% 🚙 Transportation) - confirm; buys across categories.
+- **QuikTrip** (4 txns, 75% 🚙 Transportation) - confirm; buys across categories.
+- **USPS** (3 txns, 66% 🧥 Clothing) - confirm; buys across categories.
+- **Joan of Clean** (3 txns, 66% 🧽 Cleaning) - confirm; buys across categories.
+- **Azam Mughal** (3 txns, 66% 🌏 Adventure) - confirm; buys across categories.
+- **Joe's Liquors** (3 txns, 66% ☕️ Caffeine) - confirm; buys across categories.
+- **Monthly Maintenance Fee** (2 txns, 50% 💳 BOFA Alaska Fee) - confirm; buys across categories.
+- **Guiry's** (2 txns, 50% 🏡 Home Improvement) - confirm; buys across categories.
+
+## Inflows (route to Inflow: Ready to Assign, not spend)
+
+Credit Dividend (12), RYLLC Income (8), Venmo (7), Fidelity (7), Zero Homes (7), Chase (5), Stacks Supplement (4), First Tech Federal Credit Union (4), Bank of America (2)

--- a/.claude/local-skills/plugins/assist/skills/handle-budget/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/handle-budget/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: assist:handle-budget
+description: Categorize and approve YNAB transactions, building a payee rules engine that gets smarter each run. Use whenever Forni mentions YNAB, categorizing spend, cleaning up the budget, approving transactions, the unapproved queue, payee cleanup, or wants a clean read on where money is going. Also trigger for "/assist:handle-budget", "tidy the budget", or "categorize my spending".
+allowed-tools:
+  - Bash
+  - Read
+  - Edit
+  - Write
+  - AskUserQuestion
+---
+
+# Handle Budget
+
+Pull uncategorized YNAB transactions, file them into the right category, tag trips, and approve. The rules engine is [reference/payee-map.md](../../reference/payee-map.md) (payee to category, mined from history) plus the `## Spend Categorization` section of [learned-rules.md](../../learned-rules.md) (corrections that override the map). Every new decision feeds back into learned-rules so the next run asks less.
+
+## Before Every Invocation
+
+1. Read [reference/payee-map.md](../../reference/payee-map.md) and the `## Spend Categorization` section of [learned-rules.md](../../learned-rules.md). Learned rules override the map.
+2. Confirm API access (token in Keychain):
+
+   ```bash
+   tok=$(security find-generic-password -a "$USER" -s YNAB_ACCESS_TOKEN -w)
+   ```
+
+3. Budget IDs: Personal `a55b71e6-76e4-46d9-a5c6-336b36ddd14c`, RYLLC `e0d471f0-bf90-452c-8232-b1153b7411be`. Default to Personal unless asked.
+
+## Why the API, Not the MCP
+
+Write through the YNAB REST API directly (`curl` plus `jq`, or a small Python script). The `ynab` MCP is fine for browsing but its text output **hides the transaction and category IDs** needed to write, so it cannot drive categorization. The API exposes `id`, `category_id`, `transfer_account_id`, and `approved` cleanly.
+
+Category IDs: resolve by name at runtime so a renamed category never breaks the skill:
+
+```bash
+curl -s -H "Authorization: Bearer $tok" "https://api.ynab.com/v1/budgets/$b/categories" \
+ | jq -r '.data.category_groups[].categories[] | "\(.name) => \(.id)"'
+```
+
+## Phase 1: Pull the Queue
+
+Get everything needing attention. Two relevant filters: `type=uncategorized` and `type=unapproved`.
+
+```bash
+curl -s -H "Authorization: Bearer $tok" \
+ "https://api.ynab.com/v1/budgets/$b/transactions?since_date=YYYY-MM-DD&type=uncategorized"
+```
+
+Decode HTML entities in payee names (`&amp;` to `&`) before matching.
+
+## Phase 2: Partition
+
+For each transaction:
+
+- **Skip** if `transfer_account_id` is set, or the payee matches a transfer/payment pattern (`Transfer`, `CRCARDPMT`, `AUTOPAY`, `External Transfer`, `P2P`, `RECURRING FROM CHK`, `Online Scheduled Payment`, `PAYMENT FROM CHK`, `Confirmation`, `Descriptive Withdrawal/Deposit`). These are account moves, not spend. Leave uncategorized. They can still be approved.
+- **Inflow** if the payee is in the Inflows list. Route to `Inflow: Ready to Assign`.
+- **Auto** if the payee is in the Auto-Categorize map. Apply silently.
+- **Confirm** if the payee is in the Always-Confirm list (split history). Ask before applying.
+- **New** otherwise. Ask one-by-one via AskUserQuestion, showing date, amount, payee, and a proposed category with rationale.
+
+Trips: when several charges cluster around a trip (lodging plus out-of-town food and coffee), itemize each into its real category AND set its memo to `<emoji> <Trip Name>` (Forni's convention, e.g. `🏔️ Crested Butte`). Confirm the emoji and trip name with the user once per trip. Do NOT use a YNAB flag for this. Vehicle repair and other non-discretionary charges that happen during a trip stay untagged.
+
+## Phase 3: Apply
+
+Batch the updates into one PATCH (auto-converts dollars to milliunits server-side):
+
+```bash
+curl -s -X PATCH -H "Authorization: Bearer $tok" -H "Content-Type: application/json" \
+ "https://api.ynab.com/v1/budgets/$b/transactions" \
+ -d '{"transactions":[{"id":"...","category_id":"...","memo":"🏔️ Crested Butte","approved":true}]}'
+```
+
+Always print the full plan (date, amount, payee, target category, memo) before writing, then confirm the server response count.
+
+## Phase 4: Approve
+
+Imported transactions land **unapproved**, and categorizing does NOT approve them. Until approved, the changes do not flow into the budget/category views, which reads as "my changes aren't showing up." Approve as the final step:
+
+```bash
+# all unapproved -> approved
+ids=$(curl -s -H "Authorization: Bearer $tok" "https://api.ynab.com/v1/budgets/$b/transactions?type=unapproved" \
+  | jq -c '[.data.transactions[] | {id:.id, approved:true}]')
+curl -s -X PATCH -H "Authorization: Bearer $tok" -H "Content-Type: application/json" \
+  "https://api.ynab.com/v1/budgets/$b/transactions" -d "{\"transactions\":$ids}"
+```
+
+Then remind the user to hard-refresh the YNAB app or web tab, since an already-open client uses delta sync and will not show the writes until it re-syncs.
+
+## Phase 5: Learn
+
+When the user corrects a proposed category, or decides a brand-new payee, append the rule to the `## Spend Categorization` section of [learned-rules.md](../../learned-rules.md) so it sticks. One line: `Payee -> Category (note)`.
+
+## Phase 6: Report
+
+Print: counts by action (auto, confirmed, asked, skipped, approved), any trips totaled by memo, anything left flagged for follow-up (e.g. a suspected fraudulent charge), and new learned rules added.
+
+## Refreshing the Map (periodic)
+
+The Auto-Categorize and Always-Confirm lists are mined from history: group every categorized, non-transfer transaction by payee, take the dominant category, list payees with >=2 transactions (auto at >=80% dominance, confirm at 50 to 80%). Re-mine occasionally to absorb newly-recurring payees. The generator lives in the skill's history; re-run it to regenerate `reference/payee-map.md`.
+
+## Notes
+
+- **Payee sprawl**: each Venmo note spawns a new payee, so the budget carries 1,000+ payees. Collapsing them is a separate hygiene pass (rename/merge via the API, or YNAB's native Renaming Rules). Native Renaming Rules and per-payee auto-categorize are app-only and not in the API.
+- **Housing line**: `Matthew Bigelow` was Rent; after the June 2026 home purchase the recurring housing line is a mortgage.


### PR DESCRIPTION
## What

Adds `assist:handle-budget`, a YNAB transaction categorization and approval skill for the assist plugin (bumped to 3.6.0).

## How it works

- **`reference/payee-map.md`**: rules engine mined from real transaction history. 112 payees auto-categorize, 12 flagged for confirmation (split history, e.g. Amazon), 9 income payees routed to inflow. Plus transfer-skip patterns and the trip-memo convention.
- **`SKILL.md`**: pull the queue, skip transfers, auto-apply known payees, ask only on new ones, batch-write, then approve.
- **`learned-rules.md`**: a Spend Categorization section holding the hard-won mechanics and every payee correction from the first hand pass.

## Why the API, not the MCP

The `ynab` MCP hides the transaction and category IDs needed to write, so the skill writes through the YNAB REST API directly (curl + Keychain token).

## Provenance

Authored from a real manual categorization pass over 48 backlog transactions (manual first, then codify). The skill orchestration itself has not yet run end to end; its first true test is the next time the queue fills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)