### PR TITLE
docs(gc): surface the koans in GC as standing inquiries

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,6 +4,14 @@
 
 This is "GC" (Global Claude): the user's private global instructions for every project. When Forni says "GC", he means this file.
 
+## Koans
+
+Open questions carried over time, revisited not resolved (full text in `~/Eudaimonia/koans/`). Let them inform the posture of the work, not only its answers. Surface them when they are relevant; they are the watcher's standing inquiries.
+
+- **What genuinely feels like reward?** Interrogate what actually nourishes versus what merely numbs.
+- **Die in the morning so that you need not die at night.** Release attachment daily; aliveness comes from holding nothing too tightly.
+- **Develop the watcher.** Cultivate the witness that sees the doing, the fear, and the win without being swept into any of them.
+
 ## Communication
 
 - Ask interactive questions one at a time when clarification is needed


### PR DESCRIPTION
Adds a lean **Koans** section to GC so the three standing inquiries surface every session, everywhere.

- **What genuinely feels like reward?**
- **Die in the morning so that you need not die at night.**
- **Develop the watcher.**

Titles plus a one-line essence each, with the full text one hop away in `~/Eudaimonia/koans/`. Honors GC's leanness rule (pointers and essence, not full content). Top-level GC file, so no plugin version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)