### PR TITLE
Bias Agent Roster Toward Proactive Auto Routing

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -35,7 +35,7 @@ Open questions carried over time, revisited not resolved (full text in `~/Eudaim
 
 ## Agent Fan Out Defaults
 
-Delegate matching work to the user level agent roster in `~/.claude/agents/` proactively, without waiting for explicit invocation. When a task in front of you matches an agent's description, dispatch to it rather than doing the work inline: multi subsystem recon fans out to explore instances in parallel, claims and fresh changes get a skeptic pass, test and build runs go to runner, mechanical multi file sweeps go to migrator instances with non overlapping file ownership, and web research goes to researcher. Cap concurrent migrator writers at three; read only agents can fan wider. Agents return summaries with pointers, never transcripts. This does not override the rule against unprompted exploration; it governs how requested work gets executed, not whether to start work.
+Delegate matching work to the user level agent roster in `~/.claude/agents/` proactively, without waiting for explicit invocation. When a task matches an agent's description, dispatch to it rather than doing the work inline. Multi subsystem recon fans out to explore instances in parallel. Claims and fresh changes get a skeptic pass. Test and build runs go to runner. Mechanical multi file sweeps go to migrator instances with non overlapping file ownership. Web research goes to researcher. Cap concurrent migrator writers at three; read only agents can fan wider. Agents return summaries with pointers, never transcripts. This does not override the rule against unprompted exploration; it governs how requested work gets executed, not whether to start work.
 
 ## Bash Commands
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -35,7 +35,7 @@ Open questions carried over time, revisited not resolved (full text in `~/Eudaim
 
 ## Agent Fan Out Defaults
 
-Delegate matching work to the user level agent roster in `~/.claude/agents/` proactively, without waiting for explicit invocation. When a task in front of you matches an agent's description, dispatch to it rather than doing the work inline: multi subsystem recon fans out to explore agents in parallel, claims and fresh changes get a skeptic pass, test and build runs go to runner, mechanical multi file sweeps go to migrator instances with non overlapping file ownership, and web research goes to researcher. Cap concurrent writers at two or three migrators; read only agents can fan wider. Agents return summaries with pointers, never transcripts. This does not override the rule against unprompted exploration; it governs how requested work gets executed, not whether to start work.
+Delegate matching work to the user level agent roster in `~/.claude/agents/` proactively, without waiting for explicit invocation. When a task in front of you matches an agent's description, dispatch to it rather than doing the work inline: multi subsystem recon fans out to explore instances in parallel, claims and fresh changes get a skeptic pass, test and build runs go to runner, mechanical multi file sweeps go to migrator instances with non overlapping file ownership, and web research goes to researcher. Cap concurrent migrator writers at three; read only agents can fan wider. Agents return summaries with pointers, never transcripts. This does not override the rule against unprompted exploration; it governs how requested work gets executed, not whether to start work.
 
 ## Bash Commands
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -33,6 +33,10 @@ Open questions carried over time, revisited not resolved (full text in `~/Eudaim
 - Do not overstate or exaggerate the quality of results. If something looks like it works but has not been thoroughly validated, say so. Let the user judge quality.
 - **Verify transformed outputs before publishing them.** When the work involves a transform (cropping, rotating, OCR, merging, format conversion) and the destination is shared (Drive upload, email attachment, content replacement), spot check the result before pushing it out. Read the produced file or render a preview. A 5 second visual check catches mistakes that are awkward to undo once published.
 
+## Agent Fan Out Defaults
+
+Delegate matching work to the user level agent roster in `~/.claude/agents/` proactively, without waiting for explicit invocation. When a task in front of you matches an agent's description, dispatch to it rather than doing the work inline: multi subsystem recon fans out to explore agents in parallel, claims and fresh changes get a skeptic pass, test and build runs go to runner, mechanical multi file sweeps go to migrator instances with non overlapping file ownership, and web research goes to researcher. Cap concurrent writers at two or three migrators; read only agents can fan wider. Agents return summaries with pointers, never transcripts. This does not override the rule against unprompted exploration; it governs how requested work gets executed, not whether to start work.
+
 ## Bash Commands
 
 - **Never use `cd` in Bash tool calls.** Compound commands like `cd path && cmd` trigger permission prompts because they do not match single command allowlist entries such as `Bash(git:*)`. Use path aware flags instead:

--- a/.claude/agents/explore.md
+++ b/.claude/agents/explore.md
@@ -1,6 +1,6 @@
 ---
 name: explore
-description: Fast, cheap codebase reconnaissance. Use immediately when a question spans multiple files, directories, or subsystems and only conclusions are needed. Safe to fan out several instances concurrently, one per subsystem or search angle.
+description: Fast, cheap codebase reconnaissance. Use proactively and immediately when a question spans multiple files, directories, or subsystems and only conclusions are needed. Safe to fan out several instances concurrently, one per subsystem or search angle.
 tools: Read, Grep, Glob
 model: haiku
 effort: low

--- a/.claude/agents/migrator.md
+++ b/.claude/agents/migrator.md
@@ -1,6 +1,6 @@
 ---
 name: migrator
-description: Mechanical code sweeps executed in an isolated git worktree. Use for repetitive multi file transforms (renames, API migrations, convention updates) where each instance can own a distinct, non overlapping set of files. Launch at most two or three concurrently.
+description: Mechanical code sweeps executed in an isolated git worktree. Use proactively for repetitive multi file transforms (renames, API migrations, convention updates) where each instance can own a distinct, non overlapping set of files. Launch at most two or three concurrently.
 tools: Read, Edit, Write, Grep, Glob, Bash
 model: inherit
 isolation: worktree

--- a/.claude/agents/migrator.md
+++ b/.claude/agents/migrator.md
@@ -1,6 +1,6 @@
 ---
 name: migrator
-description: Mechanical code sweeps executed in an isolated git worktree. Use proactively for repetitive multi file transforms (renames, API migrations, convention updates) where each instance can own a distinct, non overlapping set of files. Launch at most two or three concurrently.
+description: Mechanical code sweeps executed in an isolated git worktree. Use proactively for repetitive multi file transforms (renames, API migrations, convention updates) where each instance can own a distinct, non overlapping set of files. Launch at most three concurrently.
 tools: Read, Edit, Write, Grep, Glob, Bash
 model: inherit
 isolation: worktree

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -1,6 +1,6 @@
 ---
 name: researcher
-description: Web research on a focused question. Use when a question needs current external sources rather than codebase knowledge. Safe to fan out several instances concurrently, one per research angle.
+description: Web research on a focused question. Use proactively when a question needs current external sources rather than codebase knowledge. Safe to fan out several instances concurrently, one per research angle.
 tools: WebSearch, WebFetch, Read
 model: inherit
 ---

--- a/.claude/agents/runner.md
+++ b/.claude/agents/runner.md
@@ -1,6 +1,6 @@
 ---
 name: runner
-description: Test and build output quarantine. Use immediately whenever tests, builds, or linters need to run and only the failures matter. Keeps thousands of lines of runner output out of the main conversation.
+description: Test and build output quarantine. Use proactively and immediately whenever tests, builds, or linters need to run and only the failures matter. Keeps thousands of lines of runner output out of the main conversation.
 tools: Bash, Read, Grep, Glob
 model: haiku
 ---

--- a/.claude/agents/skeptic.md
+++ b/.claude/agents/skeptic.md
@@ -1,6 +1,6 @@
 ---
 name: skeptic
-description: Adversarial verifier. Use immediately after code changes, or when a finding, bug report, or claim needs independent verification before it is trusted. Spawn two or three concurrently for high stakes claims; each tries to refute independently.
+description: Adversarial verifier. Use proactively and immediately after code changes, or when a finding, bug report, or claim needs independent verification before it is trusted. Spawn two or three concurrently for high stakes claims; each tries to refute independently.
 tools: Read, Grep, Glob, Bash
 model: inherit
 effort: high


### PR DESCRIPTION
## What

Follow up to #128. Makes the subagent roster dispatch automatically instead of relying on explicit invocation:

1. All five agent descriptions in `.claude/agents/` gain "use proactively" phrasing, the strongest documented cue for Claude's auto delegation heuristic.
2. GC (`.claude/CLAUDE.md`) gains an **Agent Fan Out Defaults** section: when a task matches an agent's description, sessions dispatch to it rather than working inline. Includes the two to three concurrent writer cap and the summaries not transcripts contract. Explicitly scoped to not override the existing rule against unprompted exploration.

## Why

Community reports flagged auto delegation as unreliable with description cues alone. Pairing per agent routing cues with a standing GC directive attacks the problem from both layers: the descriptions catch per task matches, the GC rule sets the default posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)