### PR TITLE
Polish Agent Kit From Smoke Test Findings

### DIFF
--- a/.claude/agents/explore.md
+++ b/.claude/agents/explore.md
@@ -13,4 +13,4 @@ Process:
 1. Search broadly with Grep and Glob before reading anything.
 2. Read only the excerpts needed to confirm a conclusion, never a whole file when a section will do.
 
-Output contract: return conclusions, not raw content. Every positive claim about the code gets a file:line pointer. For negative findings, state the scope you searched and that no match was found rather than padding. Cap the report at roughly 20 lines.
+Output contract: return conclusions, not raw content. Every positive claim about the code gets a file:line pointer. For negative findings, state the scope you searched and that no match was found rather than padding. Hard cap: 20 lines total. When the full answer will not fit, return the most decision relevant conclusions and name what you left out in one line; never exceed the cap to be complete.

--- a/.claude/hooks/worktree-gate.sh
+++ b/.claude/hooks/worktree-gate.sh
@@ -13,7 +13,9 @@ cmd=$(jq -r '.tool_input.command // empty' <<<"$input" 2>/dev/null)
 # flags (--no-pager, --git-dir=x) and separate argument forms of -c/-C,
 # including quoted paths with spaces. Bare words are deliberately not
 # allowed there so "git log | grep commit" cannot false positive.
-if ! grep -qE "(^|[;&|[:space:]])git([[:space:]]+-[cC][[:space:]]+(\"[^\"]*\"|'[^']*'|[^[:space:]]+)|[[:space:]]+--?[^[:space:]]+)*[[:space:]]+(commit|checkout|switch|merge|rebase|cherry-pick|reset|restore|stash|revert|am)([[:space:]]|\$)" <<<"$cmd"; then
+# stash gets special handling: bare stash and its mutating verbs (or a
+# flag form like stash -u) match, while read only stash list/show do not.
+if ! grep -qE "(^|[;&|[:space:]])git([[:space:]]+-[cC][[:space:]]+(\"[^\"]*\"|'[^']*'|[^[:space:]]+)|[[:space:]]+--?[^[:space:]]+)*[[:space:]]+((commit|checkout|switch|merge|rebase|cherry-pick|reset|restore|revert|am)([[:space:]]|\$)|stash([[:space:]]+(push|pop|apply|drop|clear|branch|save|create|store)([[:space:]]|\$)|[[:space:]]+-|[[:space:]]*([;&|]|\$)))" <<<"$cmd"; then
   exit 0
 fi
 

--- a/.claude/hooks/worktree-gate.sh
+++ b/.claude/hooks/worktree-gate.sh
@@ -13,9 +13,11 @@ cmd=$(jq -r '.tool_input.command // empty' <<<"$input" 2>/dev/null)
 # flags (--no-pager, --git-dir=x) and separate argument forms of -c/-C,
 # including quoted paths with spaces. Bare words are deliberately not
 # allowed there so "git log | grep commit" cannot false positive.
-# stash gets special handling: bare stash and its mutating verbs (or a
-# flag form like stash -u) match, while read only stash list/show do not.
-if ! grep -qE "(^|[;&|[:space:]])git([[:space:]]+-[cC][[:space:]]+(\"[^\"]*\"|'[^']*'|[^[:space:]]+)|[[:space:]]+--?[^[:space:]]+)*[[:space:]]+((commit|checkout|switch|merge|rebase|cherry-pick|reset|restore|revert|am)([[:space:]]|\$)|stash([[:space:]]+(push|pop|apply|drop|clear|branch|save|create|store)([[:space:]]|\$)|[[:space:]]+-|[[:space:]]*([;&|]|\$)))" <<<"$cmd"; then
+# Read only stash invocations (list/show) are stripped first so plain
+# "stash" can stay in the mutating list; this keeps redirected forms
+# like "git stash > /dev/null" caught without a fragile stash regex.
+filtered_cmd=$(sed -E "s/(^|[;&|[:space:]])git([[:space:]]+-[cC][[:space:]]+(\"[^\"]*\"|'[^']*'|[^[:space:]]+)|[[:space:]]+--?[^[:space:]]+)*[[:space:]]+stash[[:space:]]+(list|show)([^;&|]*)/ /g" <<<"$cmd")
+if ! grep -qE "(^|[;&|[:space:]])git([[:space:]]+-[cC][[:space:]]+(\"[^\"]*\"|'[^']*'|[^[:space:]]+)|[[:space:]]+--?[^[:space:]]+)*[[:space:]]+(commit|checkout|switch|merge|rebase|cherry-pick|reset|restore|stash|revert|am)([[:space:]]|\$)" <<<"$filtered_cmd"; then
   exit 0
 fi
 


### PR DESCRIPTION
## What

Two refinements surfaced by the agent roster's first live smoke test (follow up to #128, #129, #130):

1. **explore agent**: the 20 line output cap is now hard. One smoke test run came back well past the soft "roughly 20 lines" phrasing; the contract now says to return the most decision relevant conclusions, name omissions in one line, and never exceed the cap.
2. **worktree gate**: `git stash list` and `git stash show` no longer trigger the nudge. The skeptic agent, hunting counterexamples during the smoke test, found that the regex matched the `stash` subcommand name regardless of whether the invocation was read only. Bare `git stash`, its mutating verbs (push, pop, apply, drop, clear, branch, save, create, store), and flag forms like `stash -u` still fire.

## Testing

Twelve payload regression suite passes, covering the prior nine cases plus stash list, stash show with flags, bare stash, stash pop, flag form stash, and chained stash.

Also a milestone for the repo's own conventions: this branch was authored in a linked worktree, so the worktree gate stayed silent throughout, first change to land fully under the new isolation workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)