### PR TITLE
assist: coach agent, taper reference, full week planning rules

### DIFF
--- a/.claude/agents/coach.md
+++ b/.claude/agents/coach.md
@@ -19,7 +19,7 @@ You are Forni's endurance coach: evidence based, direct, warm. The block posture
 - **Vert is co equal with mileage.** Every read evaluates both.
 - **Any calf, heel, or foot signal drops the next week to the current week's numbers.** No exceptions.
 - **Easy days must be easy.** Relative effort and HR versus the Z2 ceiling are the check, not pace.
-- **Budget math is the deliverable.** When asked about a week, always compute: ceiling, minus committed runs, equals remaining, and say where the remainder fits. Numbers in tables, imperial units, 24 hour times.
+- **Budget math is the deliverable.** When asked about a week, always compute both budgets: weekly MAX miles and MAX vert, minus committed runs, equals remaining, and say where the remainder lands. Present the full cross training slate alongside the runs. Numbers in tables, imperial units, 24 hour times.
 
 ## Output
 

--- a/.claude/agents/coach.md
+++ b/.claude/agents/coach.md
@@ -1,0 +1,26 @@
+---
+name: coach
+description: Endurance training coach. Use proactively for training plan questions, weekly load and taper analysis, retro reads, route vetting, race prep, and post run analysis. Reads the canonical plan (~/Eudaimonia/Constitution/Fitness/2026-training-plan.md), the assist plan-training skill and its references, and Strava via MCP. Returns analysis and recommendations with explicit numbers; never modifies the calendar or the plan files directly.
+tools: Read, Grep, Glob, Bash, WebSearch, WebFetch, ToolSearch
+---
+
+You are Forni's endurance coach: evidence based, direct, warm. The block posture is **joyful completion, not time**. You analyze; the main session decides and writes.
+
+## Where Truth Lives
+
+- **The plan**: `~/Eudaimonia/Constitution/Fitness/2026-training-plan.md`. Block table (weekly MAX mi, long mi, vert ft, phase), weekly retrospectives, guardrails. Back half numbers are **ceilings, not floors**.
+- **Conventions**: `~/Eudaimonia/Constitution/Fitness/CLAUDE.md` and `~/Eudaimonia/schedule.md` (weekly skeleton).
+- **Skill knowledge**: `~/.claude/local-skills/plugins/assist/skills/plan-training/` — SKILL.md (workflow), learned-rules.md (live calibration), `reference/` (research: tapering, and future fueling/altitude notes). Read the references before re researching a settled question; extend them when you learn something new worth keeping.
+- **What happened**: Strava, via MCP tools (load with ToolSearch, e.g. `mcp__claude_ai_Strava__list_activities`). The calendar is intent, never evidence of completion. Strava returns metric; report imperial (miles = m / 1609.344, feet = m * 3.28084).
+
+## Coaching Principles
+
+- **Ramp and clustering injure, not peak volume.** Flag weekly mileage ramps over ~15% and two big days (over 8 mi or over 1,000 ft) within 48 hours. Both injury episodes in this block's history came from those signatures.
+- **Vert is co equal with mileage.** Every read evaluates both.
+- **Any calf, heel, or foot signal drops the next week to the current week's numbers.** No exceptions.
+- **Easy days must be easy.** Relative effort and HR versus the Z2 ceiling are the check, not pace.
+- **Budget math is the deliverable.** When asked about a week, always compute: ceiling, minus committed runs, equals remaining, and say where the remainder fits. Numbers in tables, imperial units, 24 hour times.
+
+## Output
+
+Tight tables plus a short read. State what the data says, then a recommendation with the reasoning in one or two sentences. No hedging, no effusive praise. When a question is genuinely settled by the references, cite the file instead of re deriving.

--- a/.claude/local-skills/.claude-plugin/marketplace.json
+++ b/.claude/local-skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "assist",
       "source": "./plugins/assist",
-      "version": "4.1.4",
+      "version": "4.1.5",
       "license": "MIT",
       "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, and job applications.",
       "author": {

--- a/.claude/local-skills/.claude-plugin/marketplace.json
+++ b/.claude/local-skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "assist",
       "source": "./plugins/assist",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "license": "MIT",
       "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, and job applications.",
       "author": {

--- a/.claude/local-skills/.claude-plugin/marketplace.json
+++ b/.claude/local-skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "assist",
       "source": "./plugins/assist",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "MIT",
       "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, and job applications.",
       "author": {

--- a/.claude/local-skills/.claude-plugin/marketplace.json
+++ b/.claude/local-skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "assist",
       "source": "./plugins/assist",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, and job applications.",
       "author": {

--- a/.claude/local-skills/.claude-plugin/marketplace.json
+++ b/.claude/local-skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "assist",
       "source": "./plugins/assist",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "license": "MIT",
       "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, and job applications.",
       "author": {

--- a/.claude/local-skills/plugins/assist/plugin.json
+++ b/.claude/local-skills/plugins/assist/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "assist",
   "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, job applications, meal planning, group trip planning, and YNAB spend categorization.",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/.claude/local-skills/plugins/assist/plugin.json
+++ b/.claude/local-skills/plugins/assist/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "assist",
   "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, job applications, meal planning, group trip planning, and YNAB spend categorization.",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/.claude/local-skills/plugins/assist/plugin.json
+++ b/.claude/local-skills/plugins/assist/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "assist",
   "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, job applications, meal planning, group trip planning, and YNAB spend categorization.",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/.claude/local-skills/plugins/assist/plugin.json
+++ b/.claude/local-skills/plugins/assist/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "assist",
   "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, job applications, meal planning, group trip planning, and YNAB spend categorization.",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/.claude/local-skills/plugins/assist/plugin.json
+++ b/.claude/local-skills/plugins/assist/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "assist",
   "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, job applications, meal planning, group trip planning, and YNAB spend categorization.",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/.claude/local-skills/plugins/assist/skills/plan-meals/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-meals/SKILL.md
@@ -65,7 +65,7 @@ Meal plans live in Atelic, not in markdown. Author them through the MCP tools (s
 - **Batch prep friendly.** One prep session on Sunday or Monday carries most of the week. A mid week refresh handles the rest. Favor ingredients that survive the fridge for several days.
 - **Macro anchored.** The daily target is 2,112 cal / 118g P / 257g C / 68g F. The shake handles ~32g of protein and ~225 cal. The remaining three meals should roughly split the rest as laid out in README.
 - **Realistic for the week.** Social events, travel, and team lunches eat meals. Do not prep for meals that will not happen.
-- **Repeatable, not boring.** Repeating a lunch twice in a week is fine (batch prep reality). Three or four times in a row is a trap; rotate a second lunch option in.
+- **A couple of meal kinds, eaten repeatedly.** The whole point of prepping is a few meals eaten several times; one batch can rightly carry four days. Variety comes week to week, not within the week.
 - **Recipe backed, not hand waved.** Every real cooked meal links to a Recipe with actual ingredients, amounts, and directions, so Forni can open it and cook it and the macros are computed rather than guessed. If a recipe does not exist yet, create it (Phase 5). Reserve freeform text and estimated macros for genuinely uncooked slots (Social, Out, Leftovers).
 
 ## The Plan Flow
@@ -103,7 +103,13 @@ Present the week back as a simple list of planned vs skipped meal slots. Ask For
 
 ### Phase 4: Present the Full Plan in Plan Mode
 
-**No plan artifact writes to Atelic before this gate.** (The Phase 2 pantry reconcile is the deliberate exception: it records reality, not plan decisions.) Enter plan mode and write the complete plan as readable prose: the menu table, the batch prep checklist with amounts, every Atelic write to be made (recipes to create or reuse, authoring the plan, shopping list changes item by item), and the shopping day. Exit plan mode for approval and execute only on the green light. An AskUserQuestion answer about one slot is not plan approval; the approved plan document is.
+**No plan artifact writes to Atelic before this gate.** (The Phase 2 pantry reconcile is the deliberate exception: it records reality, not plan decisions.) Enter plan mode and write the complete plan in the three section format. The plan's one job is decision elimination: the tired mid week moment ("Wednesday 17:30, what happens next") must get its answer in one glance, already cooked.
+
+1. **The Meals.** Every meal and snack named, with Cal / P / C / F per serving. Clean numbers, no tildes or hedge marks (he knows they are estimates). A couple of meal kinds per week, period; snacks are one or two standing items, never per day engineering.
+2. **The Plan.** Every slot of every day explicit (breakfast, lunch, snacks, dinner; no "mornings are all the same" shorthand), each day totaled as actual / target for all four macros. Dinners out get an asterisk on the day and the event with a single footnote under the table; those days' totals count home food only.
+3. **The Prep.** Numbered cook sessions with exact amounts, times, and temperatures. Fresh proteins and grains cook no more than 2 days ahead, so the back half of the week gets a midweek refresh session. Prep beyond the current week belongs to next week's planning session.
+
+After the three sections: every Atelic write to be made (recipes to create or reuse, authoring the plan, shopping list changes item by item) and the shopping day when there is one. Exit plan mode for approval and execute only on the green light. An AskUserQuestion answer about one slot is not plan approval; the approved plan document is.
 
 ### Phase 5: Execute the Writes
 

--- a/.claude/local-skills/plugins/assist/skills/plan-meals/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-meals/learned-rules.md
@@ -130,3 +130,14 @@ Standing likes, dislikes, and avoid foods. Read before drafting any plan, cross-
 - **Pantry inventory questions go one at a time, not in a batch.** Use AskUserQuestion with structured options rather than asking for a batched reply in chat.
   - Why: Forni corrected this on 2026-04-17. A long checklist in chat feels tedious; one question at a time keeps the rhythm conversational.
   - How to apply: loop through pantry items individually. Each question should offer the common answers (Yes on hand, No need to buy, Have some but low, Skip) plus a free text option for quantity or notes. (Exception: a full post-travel reconcile uses the "name the survivors" pass above, not this.)
+
+## Plan Presentation (Codified 2026-07-19, Week 30 Session)
+
+- **The plan's one job is decision elimination.** The mid week moment ("Wednesday 17:30, tired, what happens next") must get its answer in one glance, already cooked. Every format choice serves that; macros exist so Forni never has to think about them mid week, not so he reads them daily.
+- **Present every plan in three sections: The Meals, The Plan, The Prep.** The Meals names each meal with full macros (Cal / P / C / F), snacks included, the trust layer read once at approval. The Plan shows every slot of every day explicitly (breakfast, lunch, snacks, dinner; no "mornings are all the same" shorthand) with per day totals shown as actual / target for all four macros. The Prep is numbered sessions with exact amounts and times.
+- **A couple of meal kinds per week, period.** The whole point of prepping is a few meals eaten several times. Do not engineer per day snack variety or one off meals to tune macros; a protein bar and one snack pairing is plenty. Forni, 2026-07-19: "The whole point of meal prepping is to make a couple kinds of meals... make this very fucking simple."
+- **No tildes or hedge marks on estimates in the presented plan.** He knows they are approximate. Clean numbers only.
+- **Dinner out days: asterisk the day and the event, one footnote under the table.** Do not scatter asterisks across every cell; totals count home food only.
+- **Breakfasts are protein and carb forward, never fat heavy.** The 21g fat yogurt bowl was rejected 2026-07-19; more yogurt, fruit forward, granola as a sprinkle.
+- **Fresh proteins and grains cook no more than ~2 days ahead.** Back half meals get a midweek refresh session (bake tofu and cook grains Wednesday for Friday, never Sunday for Friday).
+- **Prep beyond the current week belongs to next week's planning session.** Do not put next Sunday's cooking in this week's plan.

--- a/.claude/local-skills/plugins/assist/skills/plan-meals/references/recipe-sources.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-meals/references/recipe-sources.md
@@ -34,6 +34,8 @@ Appended automatically when a plan introduces a new recipe. Forni fills in the r
 | 2026-W17 | Creamy Spring Pea & Mint Soup | — (Claude drafted, no site source) | | Immersion blender showcase. Thu dinner |
 | 2026-W17 | Sweet Nut & Fruit Protein Bars | Forni's Paprika (ChatGPT originated) | | Bonus batch item, 16 bars, post workout snack |
 | 2026-W21 | Coconut Red Lentil Dal over Basmati | — (Claude drafted, no site source) | | Mon dinner centerpiece, batch carries to Thu pre Odell |
+| 2026-W30 | Lentil Couscous TVP Stuffed Peppers | Claude drafted | | TVP boost on the W29 peppers; batch carries Mon to Thu |
+| 2026-W30 | Protein Forward Yogurt Bowl | Claude drafted | | Breakfast rebuilt protein and carb forward, granola demoted to sprinkle |
 | 2026-W26 | Lentil & White Bean Salad | — (Claude drafted, no site source) | | Travel week. Make ahead, holds days. Uses red onion + shallot. Low fat protein anchor |
 | 2026-W26 | Crispy Tofu & Summer Squash Bowl over Quinoa | — (Claude drafted, no site source) | | Travel week cook 1. Lemon + olive oil dressing |
 | 2026-W26 | Burst Tomato & White Bean Skillet over Quinoa | — (Claude drafted, no site source) | | Travel week cook 2. One pot, no pasta |

--- a/.claude/local-skills/plugins/assist/skills/plan-training/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-training/learned-rules.md
@@ -97,3 +97,15 @@ Training specific rules tied to current life shape. Read on every invocation. St
   | Missouri / Belford / Oxford | 15.1 / 7,217 | Distance perfect, vert way over — only for a true peak week with no cap. |
 
   Codified 2026-06-27 after a five-round route hunt during Wk 9 planning. The shortlist is a starting menu, not a constraint; extend it as new objectives get run.
+
+## Transitions
+
+- **Transitions are ALWAYS 30 minutes. Never 15.** Do not shrink a transition series to fit a tight block; move the adjacent block instead (end Deep Work earlier, shift the lift). Forni, 2026-07-19: "always 30 minutes for transitions always, always, always." The plan-week shrink to fit behavior applies only when a one off meeting eats into a transition's slot that week; the standing series size is never 15.
+
+## Full Week Planning
+
+- **Plan the whole training week with explicit budget math, and say where everything fits.** The week pass is not just the Friday long. State the weekly MAX miles and vert, subtract the committed runs (Tue DRC 3.1, Thu SPRC 5.2), state the remainder and where it lands, and flag when the sum would breach the ceiling with the tradeoff spelled out plainly. Present the full cross training slate alongside the runs (lifts with upper/lower intent, swims, yoga, climb, PT), confirming each anchor exists on the calendar. Surfaced 2026-07-19: "I don't even know how many miles I'm supposed to run this week... The plan should actually plan the training and it should plan our cross-training."
+
+## Reference Library
+
+- **Settled research lives in `reference/` beside this skill; consult it before re researching.** `reference/tapering.md` (2026-07-19) covers taper duration, the last big effort window, the repeated bout effect, race week, and altitude. Extend the library rather than re deriving answers. The `coach` agent (`~/.claude/agents/coach.md`) reads the same plan and references; delegate load analysis, retro reads, and route vetting to it.

--- a/.claude/local-skills/plugins/assist/skills/plan-training/learned-rules.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-training/learned-rules.md
@@ -109,3 +109,7 @@ Training specific rules tied to current life shape. Read on every invocation. St
 ## Reference Library
 
 - **Settled research lives in `reference/` beside this skill; consult it before re researching.** `reference/tapering.md` (2026-07-19) covers taper duration, the last big effort window, the repeated bout effect, race week, and altitude. Extend the library rather than re deriving answers. The `coach` agent (`~/.claude/agents/coach.md`) reads the same plan and references; delegate load analysis, retro reads, and route vetting to it.
+
+## Weekly Summary
+
+- **Every training pass ends with the one look weekly summary before anything else gets discussed:** total miles, total vert, the type of week in one sentence, then the day by day table. Surfaced 2026-07-19: after a full planning pass Forni still had to ask "how many miles am I supposed to run this week?" The summary is the deliverable; the mechanics are supporting detail. Write the same summary into the week banner body.

--- a/.claude/local-skills/plugins/assist/skills/plan-training/reference/tapering.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-training/reference/tapering.md
@@ -12,7 +12,7 @@ Settled knowledge; consult before re researching taper questions. Applies to mar
 ## The Last Big Effort
 
 - Coaching consensus: final long or big effort **10 to 14 days out**; a moderate long run is acceptable **7 to 10 days out**.
-- **Repeated bout effect**: one hard downhill bout reduces subsequent eccentric damage 50 to 80% for 2 to 6 weeks and can attenuate fatigue in a later run (Sci Reports 2020, MDPI 2024). A big descent day two weeks out is protective, not just tolerable.
+- **Repeated bout effect**: one hard downhill bout reduces subsequent eccentric damage 50 to 80% for 2 to 6 weeks and attenuated fatigue in a later run in lab settings (Sci Reports 2020, MDPI 2024). A big descent day two weeks out is likely protective, not just tolerable.
 - A moderate social trail day with real vert seven days out is tolerable and arguably useful IF: genuinely conversational, descents not raced, weekly volume near half of normal, and it is the last meaningful vert. **The tell: quads still sore 3 to 4 days after means it was run too hard, not scheduled too close.**
 
 ## Race Week
@@ -22,7 +22,7 @@ Settled knowledge; consult before re researching taper questions. Applies to mar
 
 ## Altitude (Denver Resident, 10,000+ ft Race)
 
-- Denver living plus recent 14er exposure gives meaningful partial acclimatization; full red cell adaptation takes weeks. Practical levers: arrive a day or more early and sleep high, deliberately easy first hours, roughly double fluids with elevated calories (metabolic cost and dehydration both rise at elevation).
+- Denver living plus recent 14er exposure gives meaningful partial acclimatization; full red cell adaptation takes weeks. Practical levers: arrive a day or more early and sleep high, deliberately easy first hours, elevated calories, and more fluids sized to sweat rate and conditions rather than a fixed multiplier (fluid needs rise at elevation, but forced overdrinking risks hyponatremia; drink to thirst plus a modest planned baseline).
 
 ## Sources
 

--- a/.claude/local-skills/plugins/assist/skills/plan-training/reference/tapering.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-training/reference/tapering.md
@@ -1,0 +1,35 @@
+# Tapering (Researched 2026-07-19, for Four Pass Loop Wk 12 to 13)
+
+Settled knowledge; consult before re researching taper questions. Applies to marathon to 50k mountain efforts with a joyful completion goal.
+
+## Duration and Structure
+
+- **8 to 14 days is the meta analytic sweet spot.** Bosquet 2007 found peak gains at a 2 week taper; Wang 2023 (PLOS One) confirms 8 to 14 days for endurance athletes.
+- **Volume cuts 41 to 60%** (fast decay), while **intensity and run frequency are maintained**. Cut the volume of intensity, not the type (Koop/CTS). Keep terrain and vert specificity; avoid novel activities.
+- Light sharpening late in the taper (short strides) is endorsed (Uphill Athlete).
+- A taper "shouldn't look drastically different from a normal deloading week" (Koop); longer events warrant somewhat shorter tapers.
+
+## The Last Big Effort
+
+- Coaching consensus: final long or big effort **10 to 14 days out**; a moderate long run is acceptable **7 to 10 days out**.
+- **Repeated bout effect**: one hard downhill bout reduces subsequent eccentric damage 50 to 80% for 2 to 6 weeks and can attenuate fatigue in a later run (Sci Reports 2020, MDPI 2024). A big descent day two weeks out is protective, not just tolerable.
+- A moderate social trail day with real vert seven days out is tolerable and arguably useful IF: genuinely conversational, descents not raced, weekly volume near half of normal, and it is the last meaningful vert. **The tell: quads still sore 3 to 4 days after means it was run too hard, not scheduled too close.**
+
+## Race Week
+
+- Short, easy, mostly flat, plus strides if anything.
+- DOMS resolves in 5 to 7 days; nothing in race week should create new eccentric load.
+
+## Altitude (Denver Resident, 10,000+ ft Race)
+
+- Denver living plus recent 14er exposure gives meaningful partial acclimatization; full red cell adaptation takes weeks. Practical levers: arrive a day or more early and sleep high, deliberately easy first hours, roughly double fluids with elevated calories (metabolic cost and dehydration both rise at elevation).
+
+## Sources
+
+- [Bosquet 2007 meta analysis (PubMed)](https://pubmed.ncbi.nlm.nih.gov/17762369/)
+- [Wang 2023 meta analysis (PMC)](https://pmc.ncbi.nlm.nih.gov/articles/PMC10171681/)
+- [CTS/Koop on ultra tapering](https://trainright.com/tapering-ultrarunning-prevent-taper-tantrum/)
+- [Uphill Athlete taper guide](https://uphillathlete.com/trail-running/tapering-for-race-event-what-to-do/)
+- [Trail Runner race week guide](https://www.trailrunnermag.com/training/trail-tips-training/a-day-by-day-training-guide-for-race-weeks-and-tapers/)
+- [Downhill repeated bout effect (Sci Reports 2020)](https://www.nature.com/articles/s41598-020-76008-2), [MDPI 2024](https://www.mdpi.com/2075-4663/12/6/169)
+- [Colorado Runner on altitude fueling](https://www.coloradorunnermag.com/2026/06/29/running-at-altitude-what-colorado-runners-need-to-know-about-fueling-and-recovery-at-elevation/)

--- a/.claude/local-skills/plugins/assist/skills/plan-week/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-week/SKILL.md
@@ -39,7 +39,7 @@ When there is a conflict between the template and the calendar, the calendar is 
 
 These constraints exist for real physiological and practical reasons. They are not suggestions.
 
-**Transitions**: Every movement between locations gets a 30 minute buffer. This is not travel time alone; it includes the mental shift between contexts. Do not schedule events back to back without a transition unless they are at the same location. Transitions are placeholders — when a scheduled meeting claims part of a transition's time slot, shrink the transition to fit the remaining gap rather than flagging it as a conflict.
+**Transitions**: Every movement between locations gets a 30 minute buffer. This is not travel time alone; it includes the mental shift between contexts. Do not schedule events back to back without a transition unless they are at the same location. Transitions are placeholders: when a one off meeting claims part of a transition's time slot that week, shrink that week's instance to fit the remaining gap rather than flagging it as a conflict. This applies only to the single affected instance; the standing transition series is always 30 minutes and is never resized (see `assist:plan-training` learned rules).
 
 **Work hours**: No W2 as of 2026-06-29 and the weekly skeleton is being rebuilt. Treat `~/Eudaimonia/schedule.md` as the source of truth for anchors and do not assume office days.
 

--- a/.claude/local-skills/plugins/assist/skills/plan-week/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/plan-week/SKILL.md
@@ -236,7 +236,7 @@ The named label table (names, hexes, label IDs) and the transition / travel / ti
 
 - **Emoji prefix**: All personal events use an emoji prefix (e.g., "🏋️ Strength", "✍️ Writing")
 - **Labels, not colors**: every created event carries the `eventLabelId` matching its meaning (🍏 Constitution, 🧠 Contemplation, 🤝 Community, 🛠️ Craft, and the rest of the table)
-- **Heads Down (deep work)**: Use "🙈 Heads Down" with the 🙈 Heads Down label. Protected focus blocks, created as one offs when a particular day needs a protected window. No transitions needed (block stays at current location).
+- **Deep work**: 🔨 Deep Work blocks carry the 🛠️ Craft label (the Heads Down label retired 2026-07-19; deep work is Craft, not its own category). Protected focus, no transitions needed (block stays at current location).
 - **Week banner**: the all day event spanning Monday through Sunday that carries the week's theme, created by Set Intention with the 🧭 Theme label, transparency `"free"`. Title is emoji + theme only; training detail lives in the body, written there by `assist:plan-training`.
 
 Include the location when the event is at a specific place.
@@ -287,7 +287,7 @@ Use the `gws` CLI tool (via Bash) for Gmail operations during planning. Common u
 - Add an appropriate emoji prefix to tasks that lack one. Shorten task names to fit well on a calendar.
 - When slotting a task, always set: date/time via reschedule-tasks, then duration + Scheduled label via update-tasks.
 - Todoist deadlineDate is Premium only. Note deadlines in the task description instead.
-- Transition and travel conventions are in `~/Eudaimonia/Admin/tools/google-calendar.md`. Transition is *holding space* (context shift, destination in description). Travel is *explicit* (drive / transit, destination in title). They carry separate labels (↔️ Transition, 🚙 Travel).
+- Transition and travel conventions are in `~/Eudaimonia/Admin/tools/google-calendar.md`. Transition is *holding space* (context shift, destination in description). Travel is *explicit* (drive / transit, destination in title). Both carry the single 🚙 Travel label (Basil); the distinction lives in the title. Transitions are always 30 minutes, never 15.
 - When a Todoist bookmark is really an open question rather than an action (description phrased as a question, "Investigate" prefix, no clear next step), capture it as a koan under `~/Eudaimonia/Life-Design/Koans/<topic>.md` and delete the Todoist task. Don't punt to next Monday — questions don't get less true with time.
 - Worktree mechanics for planning live in Before Every Invocation and the worktree rule below. Cut and enter the `wk-<ISO week>` worktree before any Eudaimonia or homebase edits, never mid session.
 - Do not skip Plan Training (invoke `assist:plan-training` in week mode), even when training decisions feel already made inline during Sweep Calendar. The training skill carries its own gate, the previous week's retro, which has no other place to live. Surfaced 2026-05-25 when I rationalized skipping it because strength moves had been discussed during conflict resolution; Forni caught it. The retro turned up real signal (PAH as transit, PT miss, weigh-in trend) that would otherwise have stayed invisible until next Monday.


### PR DESCRIPTION
## Summary

- New `coach` agent (`.claude/agents/coach.md`): endurance training coach reading the canonical plan, the plan-training skill references, and Strava via MCP. Analysis only; never modifies calendar or plan files.
- New `plan-training/reference/tapering.md`: settled taper research with citations (taper duration meta analyses, last big effort window, repeated bout effect, race week, altitude). Consulted before re researching.
- plan-training learned rules: transitions are always 30 minutes (never 15), full week planning with explicit budget math and the cross training slate, reference library pointer.
- assist 4.1.0 to 4.1.1 (plugin.json + marketplace.json in sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)