### PR TITLE
Drop unused cargo aliases; alias cr to coderabbit

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -20,10 +20,8 @@ alias sls="screen -ls"
 alias sra="screen -d -RR"
 alias sw="screen -wipe"
 
-# Cargo Aliases
-alias cb="cargo build"
-alias cr="cargo run"
-alias ct="cargo test -- --nocapture"
+# CodeRabbit
+alias cr="coderabbit"
 
 # Docker Aliases
 alias docker-clean='docker rm $(docker ps -a -q -f status=exited)'


### PR DESCRIPTION
## Summary
- Remove the unused cargo aliases (`cb`, `cr`, `ct`) left over from Rust work.
- Repurpose `cr` as a shortcut for the `coderabbit` CLI.

## Test plan
- [ ] `source ~/.aliases` then `type cr` reports `coderabbit`