### PR TITLE
wrap: destroy leftover merged worktrees (assist 7.0.1)

### DIFF
--- a/.claude/local-skills/.claude-plugin/marketplace.json
+++ b/.claude/local-skills/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "assist",
       "source": "./plugins/assist",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "license": "MIT",
       "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, and job applications.",
       "author": {

--- a/.claude/local-skills/plugins/assist/plugin.json
+++ b/.claude/local-skills/plugins/assist/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "assist",
   "description": "Personal productivity skills: email triage, weekly planning, knowledge capture, BD outreach, job applications, meal planning, group trip planning, and YNAB spend categorization.",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "author": {
     "name": "Matthew Fornaciari",
     "url": "https://github.com/mattforni"

--- a/.claude/local-skills/plugins/assist/skills/wrap/SKILL.md
+++ b/.claude/local-skills/plugins/assist/skills/wrap/SKILL.md
@@ -65,6 +65,7 @@ Categorize per repo:
 - **Open PR awaiting the user.** Blocks exit (see Step 9). Surface review comments and chain to `/sdlc:iterate`.
 - **Open PR awaiting reviewer.** Blocks exit (see Step 9). Watch for review to land, then chain to `/sdlc:iterate` or `/sdlc:complete` as appropriate.
 - **Merged PR with the branch still local.** Chain to `/sdlc:complete` via the Skill tool.
+- **Leftover worktree from a merged branch.** Destroy it: `git worktree remove <path>` then `git branch -D <branch>`. Do this for every session worktree whose PR has merged. The one exception is the current session's own working directory and any `locked` worktree; leave those, they get cleaned when the session ends.
 
 When the session already ran `/sdlc:complete`, this step is usually fast and returns clean for the main repo.
 


### PR DESCRIPTION
Adds a Step 2 categorization for leftover worktrees from merged branches: destroy them, excepting the session's own cwd and locked worktrees. assist 7.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)